### PR TITLE
fix(goreleaser): add `file_name_template` for consistent package naming

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -52,6 +52,7 @@ archives:
 
 nfpms:
   - package_name: tc
+    file_name_template: '{{ .PackageName }}_{{ .Os }}_{{ .Arch }}'
     vendor: JetBrains s.r.o.
     homepage: https://github.com/JetBrains/teamcity-cli
     maintainer: JetBrains <teamcity-support@jetbrains.com>

--- a/README.md
+++ b/README.md
@@ -135,19 +135,19 @@ curl -fsSL https://jb.gg/tc/install | bash
 
 **Debian/Ubuntu:**
 ```bash
-curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/download/v0.4.0/tc_0.4.0_linux_amd64.deb
-sudo dpkg -i tc_0.4.0_linux_amd64.deb
+curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/latest/download/tc_linux_amd64.deb
+sudo dpkg -i tc_linux_amd64.deb
 ```
 
 **RHEL/Fedora:**
 ```bash
-sudo rpm -i https://github.com/JetBrains/teamcity-cli/releases/download/v0.4.0/tc_0.4.0_linux_amd64.rpm
+sudo rpm -i https://github.com/JetBrains/teamcity-cli/releases/latest/download/tc_linux_amd64.rpm
 ```
 
 **Arch Linux:**
 ```bash
-curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/download/v0.4.0/tc_0.4.0_linux_amd64.pkg.tar.zst
-sudo pacman -U tc_0.4.0_linux_amd64.pkg.tar.zst
+curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/latest/download/tc_linux_amd64.pkg.tar.zst
+sudo pacman -U tc_linux_amd64.pkg.tar.zst
 ```
 
 ### Windows


### PR DESCRIPTION
to be merged with the next release 