### PR TITLE
fix(output): replace `ColumnWidths` with `AutoSizeColumns` for dynamic table sizing

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -111,8 +111,6 @@ func runAgentList(cmd *cobra.Command, opts *agentListOptions) error {
 	headers := []string{"ID", "NAME", "POOL", "STATUS"}
 	var rows [][]string
 
-	widths := output.ColumnWidths(20, 40, 40, 10)
-
 	for _, a := range agents.Agents {
 		status := formatAgentStatus(a)
 		poolName := ""
@@ -122,12 +120,13 @@ func runAgentList(cmd *cobra.Command, opts *agentListOptions) error {
 
 		rows = append(rows, []string{
 			fmt.Sprintf("%d", a.ID),
-			output.Truncate(a.Name, widths[0]),
-			output.Truncate(poolName, widths[1]),
+			a.Name,
+			poolName,
 			status,
 		})
 	}
 
+	output.AutoSizeColumns(headers, rows, 2, 1, 2)
 	output.PrintTable(headers, rows)
 	return nil
 }
@@ -340,15 +339,15 @@ func showCompatibleJobs(client api.ClientInterface, agentID int, jsonOutput bool
 	headers := []string{"ID", "NAME", "PROJECT"}
 	var rows [][]string
 
-	widths := output.ColumnWidths(20, 40, 20, 40, 30)
-
 	for _, j := range jobs.BuildTypes {
 		rows = append(rows, []string{
-			output.Truncate(j.ID, widths[0]),
-			output.Truncate(j.Name, widths[1]),
-			output.Truncate(j.ProjectName, widths[2]),
+			j.ID,
+			j.Name,
+			j.ProjectName,
 		})
 	}
+
+	output.AutoSizeColumns(headers, rows, 2, 0, 1, 2)
 
 	output.PrintTable(headers, rows)
 	return nil

--- a/internal/cmd/job.go
+++ b/internal/cmd/job.go
@@ -93,8 +93,6 @@ func runJobList(cmd *cobra.Command, opts *jobListOptions) error {
 	headers := []string{"ID", "NAME", "PROJECT", "STATUS"}
 	var rows [][]string
 
-	widths := output.ColumnWidths(20, 60, 40, 30, 30)
-
 	for _, j := range jobs.BuildTypes {
 		status := output.Green("Active")
 		if j.Paused {
@@ -102,13 +100,14 @@ func runJobList(cmd *cobra.Command, opts *jobListOptions) error {
 		}
 
 		rows = append(rows, []string{
-			output.Truncate(j.ID, widths[0]),
-			output.Truncate(j.Name, widths[1]),
-			output.Truncate(j.ProjectName, widths[2]),
+			j.ID,
+			j.Name,
+			j.ProjectName,
 			status,
 		})
 	}
 
+	output.AutoSizeColumns(headers, rows, 2, 0, 1, 2)
 	output.PrintTable(headers, rows)
 	return nil
 }

--- a/internal/cmd/param.go
+++ b/internal/cmd/param.go
@@ -105,8 +105,6 @@ func runParamList(id string, opts *paramListOptions, api paramAPI) error {
 	headers := []string{"NAME", "VALUE"}
 	var rows [][]string
 
-	widths := output.ColumnWidths(10, 40, 40, 60)
-
 	for _, p := range params.Property {
 		value := p.Value
 		if p.Type != nil && p.Type.RawValue == "password" {
@@ -114,11 +112,12 @@ func runParamList(id string, opts *paramListOptions, api paramAPI) error {
 		}
 
 		rows = append(rows, []string{
-			output.Truncate(p.Name, widths[0]),
-			output.Truncate(value, widths[1]),
+			p.Name,
+			value,
 		})
 	}
 
+	output.AutoSizeColumns(headers, rows, 2, 0, 1)
 	output.PrintTable(headers, rows)
 	return nil
 }

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -106,8 +106,6 @@ func runProjectList(cmd *cobra.Command, opts *projectListOptions) error {
 	headers := []string{"ID", "NAME", "PARENT"}
 	var rows [][]string
 
-	widths := output.ColumnWidths(20, 40, 33, 34, 33)
-
 	for _, p := range projects.Projects {
 		parent := "-"
 		if p.ParentProjectID != "" {
@@ -115,12 +113,13 @@ func runProjectList(cmd *cobra.Command, opts *projectListOptions) error {
 		}
 
 		rows = append(rows, []string{
-			output.Truncate(p.ID, widths[0]),
-			output.Truncate(p.Name, widths[1]),
-			output.Truncate(parent, widths[2]),
+			p.ID,
+			p.Name,
+			parent,
 		})
 	}
 
+	output.AutoSizeColumns(headers, rows, 2, 0, 1, 2)
 	output.PrintTable(headers, rows)
 	return nil
 }

--- a/internal/cmd/queue.go
+++ b/internal/cmd/queue.go
@@ -93,8 +93,6 @@ func runQueueList(cmd *cobra.Command, opts *queueListOptions) error {
 	headers := []string{"ID", "JOB", "BRANCH", "STATE"}
 	var rows [][]string
 
-	widths := output.ColumnWidths(30, 40, 60, 40)
-
 	for _, r := range queue.Builds {
 		branch := r.BranchName
 		if branch == "" {
@@ -103,12 +101,13 @@ func runQueueList(cmd *cobra.Command, opts *queueListOptions) error {
 
 		rows = append(rows, []string{
 			fmt.Sprintf("%d", r.ID),
-			output.Truncate(r.BuildTypeID, widths[0]),
-			output.Truncate(branch, widths[1]),
+			r.BuildTypeID,
+			branch,
 			r.State,
 		})
 	}
 
+	output.AutoSizeColumns(headers, rows, 2, 1, 2)
 	output.PrintTable(headers, rows)
 	return nil
 }

--- a/internal/cmd/run_list.go
+++ b/internal/cmd/run_list.go
@@ -164,15 +164,6 @@ func runRunList(cmd *cobra.Command, opts *runListOptions) error {
 	}
 	var rows [][]string
 
-	widths := output.ColumnWidths(47, 30, 40, 35, 25)
-
-	maybeTruncate := func(s string, maxLen int) string {
-		if opts.plain {
-			return s
-		}
-		return output.Truncate(s, maxLen)
-	}
-
 	for _, r := range runs.Builds {
 		var status, runRef string
 		if opts.plain {
@@ -216,14 +207,17 @@ func runRunList(cmd *cobra.Command, opts *runListOptions) error {
 		rows = append(rows, []string{
 			status,
 			runRef,
-			maybeTruncate(r.BuildTypeID, widths[0]),
-			maybeTruncate(branch, widths[1]),
-			maybeTruncate(triggeredBy, widths[2]),
+			r.BuildTypeID,
+			branch,
+			triggeredBy,
 			duration,
 			age,
 		})
 	}
 
+	if !opts.plain {
+		output.AutoSizeColumns(headers, rows, 2, 2, 3, 4)
+	}
 	if opts.plain {
 		output.PrintPlainTable(headers, rows, opts.noHeader)
 	} else {


### PR DESCRIPTION
## Summary

Table columns were truncated even on wide terminals because `ColumnWidths` distributed space using fixed percentages, ignoring actual content. Short columns (e.g. BRANCH = "master") hoarded space while long ones (JOB) got starved.

## Changes

- Replaced percentage-based `ColumnWidths` with data-driven `AutoSizeColumns` that measures actual content widths
- Fixed columns keep their natural width; remaining space is distributed among flexible columns using a fair-share algorithm
- Headers are included in width measurement to match lipgloss rendering and prevent line wrapping
- Updated all 7 callsites (`run list`, `queue`, `agent list`, `agent jobs`, `job list`, `project list`, `param list`)

## Design Decisions

The distribution algorithm (`distributeSpace`) works in rounds: columns that fit within their fair share get their full width and release the surplus; remaining columns split what's left proportionally. This avoids both starvation (one column gets nothing) and waste (short columns hoard space).

## Example

Before (fixed 40/35/25% split — BRANCH and TRIGGERED BY waste space):
```
JOB                                     BRANCH              TRIGGERED BY
ijplatform_master_CIDR_AppCode_Regr...  master              vcs
```

After (short columns shrink, JOB gets the freed space):
```
JOB                                                                    BRANCH   TRIGGERED BY
ijplatform_master_CIDR_AppCode_RegressionTests_DebuggingTests_Debu...  master   vcs
```

## Test Plan

- [x] Tests pass (`go test ./...`)
- [x] Manually tested on narrow (80) and wide (200+) terminals
- [x] Verified no line wrapping with long job names