### PR TITLE
fix(output): include build IDs in formatted output strings for improved clarity

### DIFF
--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -209,8 +209,9 @@ func runAgentView(nameOrID string, opts *viewOptions) error {
 	}
 
 	if agent.Build != nil {
-		fmt.Printf("\nCurrent build: %s #%s (%s)\n",
+		fmt.Printf("\nCurrent build: %s %d  #%s (%s)\n",
 			agent.Build.BuildType.Name,
+			agent.Build.ID,
 			agent.Build.Number,
 			agent.Build.Status)
 	}

--- a/internal/cmd/failure_summary.go
+++ b/internal/cmd/failure_summary.go
@@ -12,7 +12,7 @@ import (
 const maxFailedTestsToShow = 10
 
 func printFailureSummary(client api.ClientInterface, buildID, buildNumber, webURL, statusText string) {
-	header := fmt.Sprintf("%s Build #%s failed", output.Red("✗"), buildNumber)
+	header := fmt.Sprintf("%s Build %s  #%s failed", output.Red("✗"), buildID, buildNumber)
 	if statusText != "" {
 		header += ": " + statusText
 	}

--- a/internal/cmd/run_artifacts.go
+++ b/internal/cmd/run_artifacts.go
@@ -73,7 +73,7 @@ func runRunArtifacts(runID string, opts *runArtifactsOptions) error {
 			return fmt.Errorf("no runs found for job %s", opts.job)
 		}
 		runID = fmt.Sprintf("%d", runs.Builds[0].ID)
-		output.Info("Listing artifacts for run #%s (ID: %s)", runs.Builds[0].Number, runID)
+		output.Info("Listing artifacts for run %s  #%s", runID, runs.Builds[0].Number)
 	} else if runID == "" {
 		return fmt.Errorf("run ID required (or use --job to get latest run)")
 	}
@@ -406,7 +406,7 @@ func runRunLog(runID string, opts *runLogOptions) error {
 			return fmt.Errorf("no runs found for job %s", opts.job)
 		}
 		runID = fmt.Sprintf("%d", runs.Builds[0].ID)
-		output.Info("Showing log for run #%s (ID: %s)", runs.Builds[0].Number, runID)
+		output.Info("Showing log for run %s  #%s", runID, runs.Builds[0].Number)
 	} else if runID == "" {
 		return fmt.Errorf("run ID required (or use --job to get latest run)")
 	}
@@ -417,7 +417,7 @@ func runRunLog(runID string, opts *runLogOptions) error {
 			return fmt.Errorf("failed to get build: %w", err)
 		}
 		if build.Status == "SUCCESS" {
-			output.Success("Build #%s succeeded", build.Number)
+			output.Success("Build %d  #%s succeeded", build.ID, build.Number)
 			return nil
 		}
 		printFailureSummary(client, runID, build.Number, build.WebURL, build.StatusText)

--- a/internal/cmd/run_lifecycle.go
+++ b/internal/cmd/run_lifecycle.go
@@ -224,9 +224,9 @@ func runRunStart(jobID string, opts *runStartOptions) error {
 		return output.PrintJSON(build)
 	}
 
-	runRef := fmt.Sprintf("#%s", build.Number)
+	runRef := fmt.Sprintf("%d  #%s", build.ID, build.Number)
 	if build.Number == "" {
-		runRef = fmt.Sprintf("(ID: %d)", build.ID)
+		runRef = fmt.Sprintf("%d", build.ID)
 	}
 	output.Success("Queued run %s for %s", runRef, jobID)
 
@@ -473,9 +473,10 @@ func doRunWatch(runID string, opts *runWatchOptions) error {
 			if build.PercentageComplete > 0 {
 				progress = fmt.Sprintf(" (%d%%)", build.PercentageComplete)
 			}
-			fmt.Printf("\r%s %s #%s %s · %s%s    ",
+			fmt.Printf("\r%s %s %d  #%s %s · %s%s    ",
 				output.StatusIcon(build.Status, build.State),
 				output.Cyan(jobName),
+				build.ID,
 				build.Number,
 				output.Faint(build.WebURL),
 				status,
@@ -490,7 +491,7 @@ func doRunWatch(runID string, opts *runWatchOptions) error {
 
 			switch build.Status {
 			case "SUCCESS":
-				fmt.Printf("%s %s #%s succeeded\n", output.Green("✓"), output.Cyan(jobName), build.Number)
+				fmt.Printf("%s %s %d  #%s succeeded\n", output.Green("✓"), output.Cyan(jobName), build.ID, build.Number)
 				if !opts.quiet {
 					fmt.Printf("\nView details: %s\n", build.WebURL)
 				}
@@ -499,7 +500,7 @@ func doRunWatch(runID string, opts *runWatchOptions) error {
 				printFailureSummary(client, runID, build.Number, build.WebURL, build.StatusText)
 				return &ExitError{Code: ExitFailure}
 			default:
-				fmt.Printf("%s Build #%s cancelled\n", output.Yellow("○"), build.Number)
+				fmt.Printf("%s Build %d  #%s cancelled\n", output.Yellow("○"), build.ID, build.Number)
 				return &ExitError{Code: ExitCancelled}
 			}
 		}
@@ -560,11 +561,11 @@ func runRunRestart(runID string, opts *runRestartOptions) error {
 		return fmt.Errorf("failed to trigger run: %w", err)
 	}
 
-	newRef := fmt.Sprintf("#%s", newBuild.Number)
+	newRef := fmt.Sprintf("%d  #%s", newBuild.ID, newBuild.Number)
 	if newBuild.Number == "" {
-		newRef = fmt.Sprintf("(ID: %d)", newBuild.ID)
+		newRef = fmt.Sprintf("%d", newBuild.ID)
 	}
-	fmt.Printf("%s Queued run %s (restart of #%s)\n", output.Green("✓"), newRef, originalBuild.Number)
+	fmt.Printf("%s Queued run %s (restart of %d)\n", output.Green("✓"), newRef, originalBuild.ID)
 	fmt.Printf("  Job: %s\n", originalBuild.BuildTypeID)
 	if originalBuild.BranchName != "" {
 		fmt.Printf("  Branch: %s\n", originalBuild.BranchName)

--- a/internal/cmd/run_list.go
+++ b/internal/cmd/run_list.go
@@ -171,7 +171,7 @@ func runRunList(cmd *cobra.Command, opts *runListOptions) error {
 			runRef = fmt.Sprintf("%d", r.ID)
 		} else {
 			status = fmt.Sprintf("%s %s", output.StatusIcon(r.Status, r.State), output.StatusText(r.Status, r.State))
-			runRef = fmt.Sprintf("#%s (%d)", r.Number, r.ID)
+			runRef = fmt.Sprintf("%d  #%s", r.ID, r.Number)
 		}
 
 		triggeredBy := "-"
@@ -268,7 +268,7 @@ func runRunView(runID string, opts *viewOptions) error {
 		jobName = build.BuildType.Name
 	}
 
-	fmt.Printf("%s %s #%s", icon, output.Cyan(jobName), build.Number)
+	fmt.Printf("%s %s %d  #%s", icon, output.Cyan(jobName), build.ID, build.Number)
 	if build.BranchName != "" {
 		fmt.Printf(" · %s", build.BranchName)
 	}

--- a/internal/cmd/watchtui.go
+++ b/internal/cmd/watchtui.go
@@ -211,7 +211,7 @@ func (m watchModel) renderHeader() string {
 	icon := output.StatusIcon(m.build.Status, m.build.State)
 	status := output.StatusText(m.build.Status, m.build.State)
 
-	header := fmt.Sprintf("%s %s #%s %s · %s", icon, output.Bold(jobName), m.build.Number, output.Faint(m.build.WebURL), status)
+	header := fmt.Sprintf("%s %s %d  #%s %s · %s", icon, output.Bold(jobName), m.build.ID, m.build.Number, output.Faint(m.build.WebURL), status)
 	if m.build.PercentageComplete > 0 && m.build.State != "finished" {
 		header += fmt.Sprintf(" (%d%%)", m.build.PercentageComplete)
 	}
@@ -275,9 +275,9 @@ func runWatchTUI(client api.ClientInterface, runID string, interval int) error {
 		icon := output.StatusIcon(fm.build.Status, fm.build.State)
 		if fm.build.State == "finished" {
 			if fm.build.Status == "SUCCESS" {
-				fmt.Printf("%s %s #%s completed\n", icon, output.Cyan(jobName), fm.build.Number)
+				fmt.Printf("%s %s %d  #%s completed\n", icon, output.Cyan(jobName), fm.build.ID, fm.build.Number)
 			} else {
-				fmt.Printf("%s %s #%s failed: %s\n", icon, output.Cyan(jobName), fm.build.Number, fm.build.StatusText)
+				fmt.Printf("%s %s %d  #%s failed: %s\n", icon, output.Cyan(jobName), fm.build.ID, fm.build.Number, fm.build.StatusText)
 			}
 		} else {
 			fmt.Println(output.Faint("Build still running in background"))


### PR DESCRIPTION
## Summary

Include build IDs alongside build numbers in all formatted output strings across the CLI, making it easier to reference specific builds when using commands like `tc run view <id>`.

## Changes

- **agent.go** — Show build ID in agent view's current build line
- **failure_summary.go** — Add build ID to failure summary header
- **run_artifacts.go** — Include build ID in artifact listing, log viewing, and success messages
- **run_lifecycle.go** — Add build ID to start/restart/watch output (queued, progress, success, failure, cancelled states)
- **run_list.go** — Show `<id>  #<number>` format in run list and run view
- **watchtui.go** — Add build ID to TUI header and final status lines

## Design Decisions

All output now uses a consistent `<id>  #<number>` format (e.g. `12345  #42`) instead of the previous `#<number> (ID: <id>)` or `#<number>` without ID. This puts the ID first since it's the primary identifier used by other CLI commands.

## Example

```bash
$ tc run list --job MyBuild
✓ 12345  #42  SUCCESS  main  2m ago
● 12340  #41  RUNNING  main  5m ago

$ tc run view 12345
✓ MyBuild 12345  #42 · main
```

## Test Plan

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Manually tested