### PR TITLE
fix(run): fix personal builds and add --revision flag

### DIFF
--- a/internal/api/interface.go
+++ b/internal/api/interface.go
@@ -40,6 +40,7 @@ type ClientInterface interface {
 	CreateBuildType(projectID string, req CreateBuildTypeRequest) (*BuildType, error)
 	BuildTypeExists(id string) bool
 	CreateBuildStep(buildTypeID string, step BuildStep) error
+	GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error)
 	SetBuildTypeSetting(buildTypeID, setting, value string) error
 
 	// Builds (Runs)

--- a/internal/api/jobs.go
+++ b/internal/api/jobs.go
@@ -113,6 +113,18 @@ func (c *Client) CreateBuildStep(buildTypeID string, step BuildStep) error {
 	return c.doNoContent("POST", path, bytes.NewReader(body), "")
 }
 
+// GetVcsRootEntries returns the VCS root entries attached to a build configuration
+func (c *Client) GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error) {
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/vcs-root-entries", buildTypeID)
+
+	var result VcsRootEntries
+	if err := c.get(path, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // SetBuildTypeSetting sets a build configuration setting
 func (c *Client) SetBuildTypeSetting(buildTypeID, setting, value string) error {
 	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings/%s", buildTypeID, setting)

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -176,15 +176,33 @@ type TriggerBuildRequest struct {
 	Revisions         *Revisions         `json:"revisions,omitempty"`
 }
 
-// Revisions represents a list of VCS revisions for a build
 type Revisions struct {
 	Revision []Revision `json:"revision"`
 }
 
-// Revision represents a specific VCS revision
 type Revision struct {
-	Version       string `json:"version"`
-	VcsBranchName string `json:"vcsBranchName,omitempty"`
+	Version         string              `json:"version"`
+	VcsBranchName   string              `json:"vcsBranchName,omitempty"`
+	VcsRootInstance *VcsRootInstanceRef `json:"vcs-root-instance,omitempty"`
+}
+
+type VcsRootInstanceRef struct {
+	VcsRootID string `json:"vcs-root-id"`
+}
+
+type VcsRootEntries struct {
+	Count        int            `json:"count"`
+	VcsRootEntry []VcsRootEntry `json:"vcs-root-entry"`
+}
+
+type VcsRootEntry struct {
+	ID      string      `json:"id,omitempty"`
+	VcsRoot *VcsRootRef `json:"vcs-root,omitempty"`
+}
+
+type VcsRootRef struct {
+	ID   string `json:"id"`
+	Name string `json:"name,omitempty"`
 }
 
 // LastChanges represents the changes to include in a build

--- a/internal/cmd/git_helpers.go
+++ b/internal/cmd/git_helpers.go
@@ -36,19 +36,6 @@ func getCurrentBranch() (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// getHeadCommit returns the SHA of the current HEAD commit
-func getHeadCommit() (string, error) {
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", tcerrors.WithSuggestion(
-			"failed to get HEAD commit",
-			"Ensure you are in a git repository with at least one commit",
-		)
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
 // branchExistsOnRemote checks if the branch exists on the remote
 func branchExistsOnRemote(branch string) bool {
 	remote := getRemoteForBranch(branch)

--- a/internal/cmd/git_helpers_test.go
+++ b/internal/cmd/git_helpers_test.go
@@ -156,33 +156,6 @@ func TestGetRemoteForBranch(t *testing.T) {
 	})
 }
 
-func TestGetHeadCommit(t *testing.T) {
-	t.Run("returns commit SHA", func(t *testing.T) {
-		dir := setupGitRepo(t)
-		restore := chdir(t, dir)
-		defer restore()
-
-		// Create initial commit
-		createFile(t, dir, "test.txt", "content")
-		runGit(t, dir, "add", ".")
-		runGit(t, dir, "commit", "-m", "initial")
-
-		commit, err := getHeadCommit()
-		require.NoError(t, err)
-		assert.Len(t, commit, 40) // SHA-1 hash is 40 hex chars
-		assert.Regexp(t, "^[0-9a-f]{40}$", commit)
-	})
-
-	t.Run("error when no commits", func(t *testing.T) {
-		dir := setupGitRepo(t)
-		restore := chdir(t, dir)
-		defer restore()
-
-		_, err := getHeadCommit()
-		assert.Error(t, err)
-	})
-}
-
 func TestBranchExistsOnRemote(t *testing.T) {
 	t.Run("returns false when no remote", func(t *testing.T) {
 		dir := setupGitRepo(t)


### PR DESCRIPTION
## Summary

- **Fix**: `tc run start <job> --local-changes` was failing with a server-side NPE because the `revisions` block was sent without the required `vcs-root-instance` reference
- **Feature**: Add `--revision` flag to pin builds to a specific Git commit SHA, with proper `vcs-root-instance` included
- Both flags can be combined: `--local-changes --revision <sha>`

## Root Cause

When triggering a personal build, the CLI was sending a `revisions` block without the required `vcs-root-instance` reference, causing TeamCity's `findVcsRootEntry` to NPE on the null `vcsRoot` field.

## Changes

- **`types.go`** — Add `Revisions` field back to `TriggerBuildRequest` with proper types (`Revisions`, `Revision`, `VcsRootInstanceRef`, `VcsRootEntries`, `VcsRootEntry`, `VcsRootRef`)
- **`jobs.go`** — Add `GetVcsRootEntries(buildTypeID)` to fetch VCS roots from `GET /app/rest/buildTypes/id:{id}/vcs-root-entries`
- **`interface.go`** — Add `GetVcsRootEntries` to `ClientInterface`
- **`builds.go`** — Remove automatic revision sending from personal builds; add `Revision` field to `RunBuildOptions` that fetches VCS root entries and builds the revisions block with `vcs-root-instance` for each VCS root
- **`run_lifecycle.go`** — Add `--revision` flag, dry-run output, and example

## Verification

All tested against a live TeamCity instance:

```bash
# Personal build with local changes (was NPE, now works)
$ tc run start Sandbox_Test --local-changes
✓ Uploaded changes (ID: 104)
✓ Queued run 1425 for Sandbox_Test

# Build pinned to specific revision
$ tc run start Sandbox_Test --revision ab18b81... --branch tv/fix-local-builds
✓ Queued run 1426 for Sandbox_Test

# Combined: personal build pinned to revision
$ tc run start Sandbox_Test --local-changes --revision ab18b81...
✓ Uploaded changes (ID: 104)
✓ Queued run 1427 for Sandbox_Test
```

## Test Plan

- [x] `go build ./...` compiles
- [x] `go test ./...` passes
- [x] `tc run start <job> --local-changes` — personal build works (no NPE)
- [x] `tc run start <job> --revision <sha> --branch <branch>` — pinned revision build works
- [x] `tc run start <job> --local-changes --revision <sha>` — combined works

🤖 Generated with [Claude Code](https://claude.com/claude-code)