### PR TITLE
feat(goreleaser): add symlink for `teamcity` binary

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,6 +69,9 @@ nfpms:
         dst: /usr/share/licenses/tc/LICENSE
       - src: README.md
         dst: /usr/share/doc/tc/README.md
+      - src: /usr/bin/tc
+        dst: /usr/bin/teamcity
+        type: symlink
 
 brews:
   - name: tc
@@ -85,6 +88,7 @@ brews:
     license: Apache-2.0
     install: |
       bin.install "tc"
+      bin.install_symlink "tc" => "teamcity"
 
 scoops:
   - repository:


### PR DESCRIPTION
## Summary

Ship a `teamcity` symlink/alias alongside the `tc` binary to avoid name clashes with Linux's `tc` (traffic control from `iproute2`, typically at `/usr/sbin/tc`).

## Problem

On many Linux distributions, `tc` is the traffic control utility from the `iproute2` package. Installing the TeamCity CLI as `tc` via system packages (deb/rpm/arch) can conflict with or shadow this system tool, depending on `PATH` ordering — especially on distros that merge `/usr/sbin` into `/usr/bin`.

## Approach

Instead of renaming the binary (which would break existing users, scripts, shell completions, and documentation), we keep `tc` as the primary binary name and ship `teamcity` as an additional symlink on platforms where it's free to do so:

- **Linux packages (deb/rpm/apk/archlinux)** — nfpm `contents` entry: `/usr/bin/teamcity` → `/usr/bin/tc` symlink
- **Homebrew (macOS/Linux)** — `bin.install_symlink "tc" => "teamcity"` in the formula
- **Windows (Scoop/Chocolatey/Winget)** — no change needed, there's no `tc` clash on Windows

Users affected by the iproute2 conflict can use `teamcity` instead of `tc`. Everyone else continues using `tc` as before.

## What stays the same

- Binary name: `tc`
- Config path: `~/.config/tc`
- Go install path: `go install github.com/JetBrains/teamcity-cli/tc@latest`
- Shell completions: registered as `tc`
- All CLI help text and examples
- Package names on registries

## Changes

- `.goreleaser.yaml`: added `teamcity` symlink in nfpm contents and Homebrew install block

## Test Plan

- [ ] `goreleaser release --snapshot --clean` produces correct archives
- [ ] Linux package (deb) includes `/usr/bin/teamcity` symlink pointing to `/usr/bin/tc`
- [ ] Homebrew formula includes `install_symlink` directive
- [ ] `tc` and `teamcity` both work after installation