### PR TITLE
fix(tc): rename binary from `tc` to `teamcity`

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
         "source": "url",
         "url": "https://github.com/JetBrains/teamcity-cli.git"
       },
-      "description": "Agent skill for interacting with TeamCity CI/CD using the tc CLI. Enables Claude to explore builds, view logs, start jobs, manage queues, agents, and more.",
+      "description": "Agent skill for interacting with TeamCity CI/CD using the teamcity CLI. Enables Claude to explore builds, view logs, start jobs, manage queues, agents, and more.",
       "version": "0.2.0",
       "strict": true
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "teamcity-cli",
-  "description": "Agent skill for interacting with TeamCity CI/CD using the tc CLI. Enables Claude to explore builds, view logs, start jobs, manage queues, agents, and more.",
+  "description": "Agent skill for interacting with TeamCity CI/CD using the teamcity CLI. Enables Claude to explore builds, view logs, start jobs, manage queues, agents, and more.",
   "version": "0.2.0",
   "author": {
     "name": "JetBrains"

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -11,7 +11,7 @@ body:
     id: version
     attributes:
       label: CLI Version
-      description: Run `tc --version` to get this
+      description: Run `teamcity --version` to get this
       placeholder: "v0.2.0"
     validations:
       required: true
@@ -39,7 +39,7 @@ body:
     attributes:
       label: What happened?
       description: Describe the bug clearly and concisely
-      placeholder: When I run `tc run start ...` it fails with...
+      placeholder: When I run `teamcity run start ...` it fails with...
     validations:
       required: true
 
@@ -57,7 +57,7 @@ body:
       label: Steps to reproduce
       description: How can we reproduce this issue?
       placeholder: |
-        1. Run `tc ...`
+        1. Run `teamcity ...`
         2. See error
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -38,7 +38,7 @@ body:
       description: How do you think this should work?
       placeholder: |
         ```bash
-        tc <command> --flag
+        teamcity <command> --flag
         ```
     validations:
       required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@
 <!-- For CLI changes: show command + output. Delete if not applicable. -->
 
 ```bash
-tc <command>
+teamcity <command>
 ```
 
 ## Test Plan

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,8 @@
 version: 2
-project_name: tc
+project_name: teamcity
 
 builds:
-  - binary: tc
+  - binary: teamcity
     main: ./tc
     env:
       - CGO_ENABLED=0
@@ -22,7 +22,7 @@ builds:
             sh -c '
             if [ "{{ .IsSnapshot }}" = "false" ] && [ "{{ .Os }}" = "$(go env GOOS)" ] && [ "{{ .Arch }}" = "$(go env GOARCH)" ]; then
               ver=$(chmod +x "{{ .Path }}"; "{{ .Path }}" --version)
-              expected="tc version {{ .Version }}"
+              expected="teamcity version {{ .Version }}"
               if [ "$ver" != "$expected" ]; then
                 echo "Version mismatch: expected \"$expected\" but got \"$ver\""
                 exit 1
@@ -34,8 +34,8 @@ builds:
             sh -c '
             set -e
             if [ "{{ .IsSnapshot }}" = "false" ] && [ "{{ .Os }}" != "linux" ] && [ "$SIGN" = "true" ]; then
-              DIST_DIR="./dist/tc_{{ .Os }}_{{ .Arch }}{{ if eq .Arch "amd64" }}_v1{{ end }}{{ if eq .Arch "arm64" }}_v8.0{{ end }}"
-              BINARY_NAME="tc{{ if eq .Os "windows" }}.exe{{ end }}"
+              DIST_DIR="./dist/teamcity_{{ .Os }}_{{ .Arch }}{{ if eq .Arch "amd64" }}_v1{{ end }}{{ if eq .Arch "arm64" }}_v8.0{{ end }}"
+              BINARY_NAME="teamcity{{ if eq .Os "windows" }}.exe{{ end }}"
               echo "Signing $DIST_DIR/$BINARY_NAME"
               codesign-client {{ if eq .Os "darwin" }}-denoted-content-type=application/x-mac-app-bin {{ end }}-signed-files-dir="$DIST_DIR/" "$DIST_DIR/$BINARY_NAME"
             fi'
@@ -51,7 +51,7 @@ archives:
       - README.md
 
 nfpms:
-  - package_name: tc
+  - package_name: teamcity
     file_name_template: '{{ .PackageName }}_{{ .Os }}_{{ .Arch }}'
     vendor: JetBrains s.r.o.
     homepage: https://github.com/JetBrains/teamcity-cli
@@ -66,12 +66,12 @@ nfpms:
     bindir: /usr/bin
     contents:
       - src: LICENSE
-        dst: /usr/share/licenses/tc/LICENSE
+        dst: /usr/share/licenses/teamcity/LICENSE
       - src: README.md
-        dst: /usr/share/doc/tc/README.md
+        dst: /usr/share/doc/teamcity/README.md
 
 brews:
-  - name: tc
+  - name: teamcity
     repository:
       owner: JetBrains
       name: homebrew-utils
@@ -84,7 +84,7 @@ brews:
     description: A command-line interface for TeamCity CI/CD server
     license: Apache-2.0
     install: |
-      bin.install "tc"
+      bin.install "teamcity"
 
 scoops:
   - repository:
@@ -99,7 +99,7 @@ scoops:
     license: Apache-2.0
 
 chocolateys:
-  - name: tc
+  - name: teamcity
     title: TeamCity CLI
     authors: JetBrains
     owners: JetBrains
@@ -126,13 +126,13 @@ chocolateys:
     source_repo: https://push.chocolatey.org/
 
 winget:
-  - name: tc
+  - name: teamcity
     publisher: JetBrains
     publisher_url: https://www.jetbrains.com/
     publisher_support_url: https://jb.gg/tc/issues
     short_description: A command-line interface for TeamCity CI/CD server
     description: |
-      tc is a command-line interface for interacting with TeamCity CI/CD server.
+      teamcity is a command-line interface for interacting with TeamCity CI/CD server.
       Manage builds, jobs, and projects without leaving your terminal.
     license: Apache-2.0
     license_url: https://github.com/JetBrains/teamcity-cli/blob/main/LICENSE
@@ -149,7 +149,7 @@ winget:
     repository:
       owner: tiulpin
       name: winget-pkgs
-      branch: "JetBrains.tc-{{.Version}}"
+      branch: "JetBrains.teamcity-{{.Version}}"
       token: "{{ .Env.GITHUB_TOKEN }}"
       pull_request:
         enabled: true
@@ -160,7 +160,7 @@ winget:
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
-    commit_msg_template: "New version: JetBrains.tc version {{.Version}}"
+    commit_msg_template: "New version: JetBrains.teamcity version {{.Version}}"
 
 checksum:
   name_template: checksums.txt
@@ -199,7 +199,7 @@ release:
 
     **Homebrew (recommended):**
     ```bash
-    brew install jetbrains/utils/tc
+    brew install jetbrains/utils/teamcity
     ```
 
     **Install script:**
@@ -209,40 +209,40 @@ release:
 
     **Debian/Ubuntu:**
     ```bash
-    curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/download/v{{ .Version }}/tc_{{ .Version }}_linux_amd64.deb
-    sudo dpkg -i tc_{{ .Version }}_linux_amd64.deb
+    curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/download/v{{ .Version }}/teamcity_{{ .Version }}_linux_amd64.deb
+    sudo dpkg -i teamcity_{{ .Version }}_linux_amd64.deb
     ```
 
     **RHEL/Fedora:**
     ```bash
-    sudo rpm -i https://github.com/JetBrains/teamcity-cli/releases/download/v{{ .Version }}/tc_{{ .Version }}_linux_amd64.rpm
+    sudo rpm -i https://github.com/JetBrains/teamcity-cli/releases/download/v{{ .Version }}/teamcity_{{ .Version }}_linux_amd64.rpm
     ```
 
     **Arch Linux:**
     ```bash
-    curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/download/v{{ .Version }}/tc_{{ .Version }}_linux_amd64.pkg.tar.zst
-    sudo pacman -U tc_{{ .Version }}_linux_amd64.pkg.tar.zst
+    curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/download/v{{ .Version }}/teamcity_{{ .Version }}_linux_amd64.pkg.tar.zst
+    sudo pacman -U teamcity_{{ .Version }}_linux_amd64.pkg.tar.zst
     ```
 
     ### Windows
     **Winget (recommended):**
     ```powershell
-    winget install JetBrains.tc
+    winget install JetBrains.teamcity
     ```
 
     **Chocolatey:**
     ```powershell
-    choco install tc
+    choco install teamcity
     ```
 
     **Scoop:**
     ```powershell
     scoop bucket add jetbrains https://github.com/JetBrains/scoop-utils
-    scoop install tc
+    scoop install teamcity
     ```
 
     **Manual:**
-    Download `tc_{{ .Version }}_windows_x86_64.zip`, extract, and add to PATH.
+    Download `teamcity_{{ .Version }}_windows_x86_64.zip`, extract, and add to PATH.
 
     ### Go Install
 
@@ -254,13 +254,13 @@ release:
 
     ```bash
     # Authenticate with your TeamCity server
-    tc auth login
+    teamcity auth login
 
     # List recent builds
-    tc run list
+    teamcity run list
 
     # Start a build
-    tc run start MyProject_Build --branch main --watch
+    teamcity run start MyProject_Build --branch main --watch
     ```
 
     See the [README](https://jb.gg/tc/docs) for full documentation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Set up your machine
 
-`tc` is written in [Go](https://golang.org/).
+`teamcity` is written in [Go](https://golang.org/).
 
 Prerequisites:
 
@@ -36,7 +36,7 @@ cp .env.example .env
 ## Development workflow
 
 ```sh
-just build        # build binary to bin/tc
+just build        # build binary to bin/teamcity
 just unit         # run unit tests only
 just test         # run all tests (unit + integration) with coverage
 just lint         # go fmt + golangci-lint
@@ -52,7 +52,7 @@ All new features and bug fixes must include tests. We have a solid integration t
 
 ## AI-assisted contributions
 
-We're fine with AI tools — Junie, Claude Code, Copilot, whatever helps you move faster. But you must understand the code you're submitting. `tc` is a tool where we prioritize security and reliability. PRs with AI-generated code that the author can't explain or defend during review will not be merged.
+We're fine with AI tools — Junie, Claude Code, Copilot, whatever helps you move faster. But you must understand the code you're submitting. `teamcity` is a tool where we prioritize security and reliability. PRs with AI-generated code that the author can't explain or defend during review will not be merged.
 
 ## Submit a pull request
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A CLI for [TeamCity](https://www.jetbrains.com/teamcity/). Start builds, tail lo
 
 <!-- TOC -->
 * [TeamCity CLI](#teamcity-cli)
-  * [Why tc?](#why-tc)
+  * [Why teamcity?](#why-teamcity)
   * [Installation](#installation)
     * [macOS & Linux](#macos--linux)
     * [Windows](#windows)
@@ -104,13 +104,13 @@ A CLI for [TeamCity](https://www.jetbrains.com/teamcity/). Start builds, tail lo
 
 </details>
 
-## Why tc?
+## Why teamcity?
 
 - **[Stay in your terminal](#quick-start)** – Start builds, view logs, manage queues — no browser needed
-- **[Remote agent access](#agent-term)** – Shell into any build agent with [`tc agent term`](#agent-term), or run commands with [`tc agent exec`](#agent-exec)
-- **[Real-time logs](#run-watch)** – Stream build output as it happens with [`tc run watch --logs`](#run-watch)
-- **[Scriptable](#json-output)** – `--json` and `--plain` output for pipelines, plus direct REST API access via [`tc api`](#api)
-- **[AI agent ready](#for-ai-agents)** – Built-in [skill](https://agentskills.io) for Claude Code, Cursor, and other AI coding agents — just run `tc skill install`
+- **[Remote agent access](#agent-term)** – Shell into any build agent with [`teamcity agent term`](#agent-term), or run commands with [`teamcity agent exec`](#agent-exec)
+- **[Real-time logs](#run-watch)** – Stream build output as it happens with [`teamcity run watch --logs`](#run-watch)
+- **[Scriptable](#json-output)** – `--json` and `--plain` output for pipelines, plus direct REST API access via [`teamcity api`](#api)
+- **[AI agent ready](#for-ai-agents)** – Built-in [skill](https://agentskills.io) for Claude Code, Cursor, and other AI coding agents — just run `teamcity skill install`
 
 ## Installation
 
@@ -118,7 +118,7 @@ A CLI for [TeamCity](https://www.jetbrains.com/teamcity/). Start builds, tail lo
 
 **Homebrew (recommended):**
 ```bash
-brew install jetbrains/utils/tc
+brew install jetbrains/utils/teamcity
 ```
 
 **Install script:**
@@ -128,26 +128,26 @@ curl -fsSL https://jb.gg/tc/install | bash
 
 **Debian/Ubuntu:**
 ```bash
-curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/latest/download/tc_linux_amd64.deb
-sudo dpkg -i tc_linux_amd64.deb
+curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/latest/download/teamcity_linux_amd64.deb
+sudo dpkg -i teamcity_linux_amd64.deb
 ```
 
 **RHEL/Fedora:**
 ```bash
-sudo rpm -i https://github.com/JetBrains/teamcity-cli/releases/latest/download/tc_linux_amd64.rpm
+sudo rpm -i https://github.com/JetBrains/teamcity-cli/releases/latest/download/teamcity_linux_amd64.rpm
 ```
 
 **Arch Linux:**
 ```bash
-curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/latest/download/tc_linux_amd64.pkg.tar.zst
-sudo pacman -U tc_linux_amd64.pkg.tar.zst
+curl -fsSLO https://github.com/JetBrains/teamcity-cli/releases/latest/download/teamcity_linux_amd64.pkg.tar.zst
+sudo pacman -U teamcity_linux_amd64.pkg.tar.zst
 ```
 
 ### Windows
 
 **Winget (recommended):**
 ```powershell
-winget install JetBrains.tc
+winget install JetBrains.teamcity
 ```
 
 **PowerShell:**
@@ -162,13 +162,13 @@ curl -fsSL https://jb.gg/tc/install.cmd -o install.cmd && install.cmd && del ins
 
 **Chocolatey:**
 ```powershell
-choco install tc
+choco install teamcity
 ```
 
 **Scoop:**
 ```powershell
 scoop bucket add jetbrains https://github.com/JetBrains/scoop-utils
-scoop install tc
+scoop install teamcity
 ```
 
 ### Go
@@ -182,37 +182,37 @@ go install github.com/JetBrains/teamcity-cli/tc@latest
 ```bash
 git clone https://github.com/JetBrains/teamcity-cli.git
 cd teamcity-cli
-go build -o tc ./tc
+go build -o teamcity ./tc
 ```
 
 ## Quick Start
 
 ```bash
 # Authenticate with your TeamCity server
-tc auth login
+teamcity auth login
 
 # List recent builds
-tc run list --limit 10
+teamcity run list --limit 10
 
 # Start a build and watch it run
-tc run start MyProject_Build --branch main --watch
+teamcity run start MyProject_Build --branch main --watch
 
 # View logs from the latest build of a job
-tc run log --job MyProject_Build
+teamcity run log --job MyProject_Build
 
 # Check what's in the queue
-tc queue list
+teamcity queue list
 ```
 
 ## For AI Agents
 
-An [Agent Skill](https://agentskills.io) is included with `tc`. It teaches AI coding agents how to use `tc` for common TeamCity workflows.
+An [Agent Skill](https://agentskills.io) is included with `teamcity`. It teaches AI coding agents how to use `teamcity` for common TeamCity workflows.
 
 ```bash
-tc skill install           # auto-detects installed agents (Claude Code, Cursor, etc.)
-tc skill install --project # install to current project only
-tc skill update            # update to latest version bundled with tc
-tc skill remove            # uninstall
+teamcity skill install           # auto-detects installed agents (Claude Code, Cursor, etc.)
+teamcity skill install --project # install to current project only
+teamcity skill update            # update to latest version bundled with teamcity
+teamcity skill remove            # uninstall
 ```
 
 or specifically for **Claude Code:**
@@ -225,43 +225,43 @@ The skill is located in [`skills/teamcity-cli/`](skills/teamcity-cli/) and follo
 
 ## Commands
 
-| Command               | Description                         |
-|-----------------------|-------------------------------------|
-| **auth**              |                                     |
-| `tc auth login`       | Authenticate with a TeamCity server |
-| `tc auth logout`      | Log out from the current server     |
-| `tc auth status`      | Show authentication status          |
-| **run**               |                                     |
-| `tc run list`         | List recent builds                  |
-| `tc run start`        | Start a new build                   |
-| `tc run view`         | View build details                  |
-| `tc run watch`        | Watch a build in real-time          |
-| `tc run log`          | View build log output               |
-| `tc run changes`      | Show commits included in a build    |
-| `tc run tests`        | Show test results                   |
-| `tc run cancel`       | Cancel a running or queued build    |
-| `tc run download`     | Download artifacts                  |
-| `tc run restart`      | Restart with same configuration     |
-| `tc run pin/unpin`    | Pin or unpin a build                |
-| `tc run tag/untag`    | Add or remove tags                  |
-| `tc run comment`      | Set or view build comment           |
-| **job**               |                                     |
-| `tc job list`         | List build configurations           |
-| `tc job view`         | View job details                    |
-| `tc job pause/resume` | Pause or resume a job               |
-| `tc job param`        | Manage job parameters               |
-| **project**           |                                     |
-| `tc project list`     | List projects                       |
-| `tc project view`     | View project details                |
-| `tc project param`    | Manage project parameters           |
-| `tc project token`    | Manage secure tokens                |
-| **queue**             |                                     |
-| `tc queue list`       | List queued builds                  |
-| `tc queue approve`    | Approve a queued build              |
-| `tc queue remove`     | Remove from queue                   |
-| `tc queue top`        | Move to top of queue                |
-| **api**               |                                     |
-| `tc api`              | Make raw API requests               |
+| Command                    | Description                         |
+|----------------------------|-------------------------------------|
+| **auth**                   |                                     |
+| `teamcity auth login`      | Authenticate with a TeamCity server |
+| `teamcity auth logout`     | Log out from the current server     |
+| `teamcity auth status`     | Show authentication status          |
+| **run**                    |                                     |
+| `teamcity run list`        | List recent builds                  |
+| `teamcity run start`       | Start a new build                   |
+| `teamcity run view`        | View build details                  |
+| `teamcity run watch`       | Watch a build in real-time          |
+| `teamcity run log`         | View build log output               |
+| `teamcity run changes`     | Show commits included in a build    |
+| `teamcity run tests`       | Show test results                   |
+| `teamcity run cancel`      | Cancel a running or queued build    |
+| `teamcity run download`    | Download artifacts                  |
+| `teamcity run restart`     | Restart with same configuration     |
+| `teamcity run pin/unpin`   | Pin or unpin a build                |
+| `teamcity run tag/untag`   | Add or remove tags                  |
+| `teamcity run comment`     | Set or view build comment           |
+| **job**                    |                                     |
+| `teamcity job list`        | List build configurations           |
+| `teamcity job view`        | View job details                    |
+| `teamcity job pause/resume`| Pause or resume a job               |
+| `teamcity job param`       | Manage job parameters               |
+| **project**                |                                     |
+| `teamcity project list`    | List projects                       |
+| `teamcity project view`    | View project details                |
+| `teamcity project param`   | Manage project parameters           |
+| `teamcity project token`   | Manage secure tokens                |
+| **queue**                  |                                     |
+| `teamcity queue list`      | List queued builds                  |
+| `teamcity queue approve`   | Approve a queued build              |
+| `teamcity queue remove`    | Remove from queue                   |
+| `teamcity queue top`       | Move to top of queue                |
+| **api**                    |                                     |
+| `teamcity api`             | Make raw API requests               |
 
 ## Configuration
 
@@ -284,25 +284,25 @@ You can authenticate with multiple TeamCity servers. Each server's credentials a
 
 ```bash
 # Log in to your first server
-tc auth login --server https://teamcity1.example.com
+teamcity auth login --server https://teamcity1.example.com
 
 # Log in to additional servers (becomes the new default)
-tc auth login --server https://teamcity2.example.com
+teamcity auth login --server https://teamcity2.example.com
 ```
 
 **Switching between servers:**
 
 ```bash
 # Option 1: Use environment variable (recommended for scripts)
-TEAMCITY_URL=https://teamcity1.example.com tc run list
+TEAMCITY_URL=https://teamcity1.example.com teamcity run list
 
 # Option 2: Export for your session
 export TEAMCITY_URL=https://teamcity1.example.com
-tc run list  # uses teamcity1
-tc auth status  # shows teamcity1
+teamcity run list  # uses teamcity1
+teamcity auth status  # shows teamcity1
 
 # Option 3: Log in again to change the default
-tc auth login --server https://teamcity1.example.com
+teamcity auth login --server https://teamcity1.example.com
 ```
 
 **Example multi-server config:**
@@ -325,7 +325,7 @@ Environment variables always take precedence over config file settings:
 ```bash
 export TEAMCITY_URL="https://teamcity.example.com"
 export TEAMCITY_TOKEN="your-access-token"
-tc run start MyProject_Build  # uses env vars, ignores config file
+teamcity run start MyProject_Build  # uses env vars, ignores config file
 ```
 
 **Auto-detection from DSL:**
@@ -336,16 +336,16 @@ When working in a project with TeamCity Kotlin DSL configuration, the server URL
 
 ```bash
 # Bash
-tc completion bash > /etc/bash_completion.d/tc
+teamcity completion bash > /etc/bash_completion.d/teamcity
 
 # Zsh
-tc completion zsh > "${fpath[1]}/_tc"
+teamcity completion zsh > "${fpath[1]}/_teamcity"
 
 # Fish
-tc completion fish > ~/.config/fish/completions/tc.fish
+teamcity completion fish > ~/.config/fish/completions/teamcity.fish
 
 # PowerShell
-tc completion powershell > tc.ps1
+teamcity completion powershell > teamcity.ps1
 ```
 
 ## Global Flags
@@ -363,16 +363,16 @@ Commands that list resources (`run list`, `job list`, `project list`, `queue lis
 
 ```bash
 # Default fields (default selection covering most use cases)
-tc run list --json
+teamcity run list --json
 
 # List available fields for a command
-tc run list --json=
+teamcity run list --json=
 
 # Select specific fields
-tc run list --json=id,status,webUrl
+teamcity run list --json=id,status,webUrl
 
 # Use dot notation for nested fields
-tc run list --json=id,status,buildType.name,triggered.user.username
+teamcity run list --json=id,status,buildType.name,triggered.user.username
 ```
 
 **Field notation:**
@@ -388,19 +388,19 @@ Use dot notation to access nested fields. For example, `buildType.name` retrieve
 | `project list` | `id`, `name`, `description`, `parentProjectId`, `href`, `webUrl`                                                                                                                                      |
 | `queue list`   | `id`, `buildTypeId`, `state`, `branchName`, `queuedDate`, `buildType.name`, `triggered.user.name`, `webUrl`                                                                                           |
 
-Run `tc <command> --json=` to see all available fields for that command.
+Run `teamcity <command> --json=` to see all available fields for that command.
 
 **Scripting examples:**
 
 ```bash
 # Get build IDs that failed
-tc run list --status failure --json=id | jq -r '.[].id'
+teamcity run list --status failure --json=id | jq -r '.[].id'
 
 # Export runs to CSV
-tc run list --json=id,status,branchName | jq -r '.[] | [.id,.status,.branchName] | @csv'
+teamcity run list --json=id,status,branchName | jq -r '.[] | [.id,.status,.branchName] | @csv'
 
 # Get web URLs for queued builds
-tc queue list --json=webUrl | jq -r '.[].webUrl'
+teamcity queue list --json=webUrl | jq -r '.[].webUrl'
 ```
 
 <!-- COMMANDS_START -->
@@ -448,13 +448,13 @@ Show authentication status
 
 List artifacts from a run without downloading them.
 
-Shows artifact names and sizes. Use tc run download to download artifacts.
+Shows artifact names and sizes. Use teamcity run download to download artifacts.
 
 ```bash
-tc run artifacts 12345
-tc run artifacts 12345 --json
-tc run artifacts 12345 --path html_reports/coverage
-tc run artifacts --job MyBuild
+teamcity run artifacts 12345
+teamcity run artifacts 12345 --json
+teamcity run artifacts 12345 --path html_reports/coverage
+teamcity run artifacts --job MyBuild
 ```
 
 **Options:**
@@ -467,9 +467,9 @@ tc run artifacts --job MyBuild
 Cancel a running or queued run.
 
 ```bash
-tc run cancel 12345
-tc run cancel 12345 --comment "Cancelling for hotfix"
-tc run cancel 12345 --force
+teamcity run cancel 12345
+teamcity run cancel 12345 --comment "Cancelling for hotfix"
+teamcity run cancel 12345 --force
 ```
 
 **Options:**
@@ -481,9 +481,9 @@ tc run cancel 12345 --force
 Show the VCS changes (commits) included in a run.
 
 ```bash
-tc run changes 12345
-tc run changes 12345 --no-files
-tc run changes 12345 --json
+teamcity run changes 12345
+teamcity run changes 12345 --no-files
+teamcity run changes 12345 --json
 ```
 
 **Options:**
@@ -499,9 +499,9 @@ With a comment argument, sets the comment.
 Use --delete to remove the comment.
 
 ```bash
-tc run comment 12345
-tc run comment 12345 "Deployed to production"
-tc run comment 12345 --delete
+teamcity run comment 12345
+teamcity run comment 12345 "Deployed to production"
+teamcity run comment 12345 --delete
 ```
 
 **Options:**
@@ -512,9 +512,9 @@ tc run comment 12345 --delete
 Download artifacts from a completed run.
 
 ```bash
-tc run download 12345
-tc run download 12345 --dir ./artifacts
-tc run download 12345 --artifact "*.jar"
+teamcity run download 12345
+teamcity run download 12345 --dir ./artifacts
+teamcity run download 12345 --artifact "*.jar"
 ```
 
 **Options:**
@@ -526,14 +526,14 @@ tc run download 12345 --artifact "*.jar"
 List recent runs
 
 ```bash
-tc run list
-tc run list --job Falcon_Build
-tc run list --status failure --limit 10
-tc run list --project Falcon --branch main
-tc run list --since 24h
-tc run list --json
-tc run list --json=id,status,webUrl
-tc run list --plain | grep failure
+teamcity run list
+teamcity run list --job Falcon_Build
+teamcity run list --status failure --limit 10
+teamcity run list --project Falcon --branch main
+teamcity run list --since 24h
+teamcity run list --json
+teamcity run list --json=id,status,webUrl
+teamcity run list --plain | grep failure
 ```
 
 **Options:**
@@ -560,9 +560,9 @@ Pager: / search, n/N next/prev, g/G top/bottom, q quit.
 Use --raw to bypass the pager.
 
 ```bash
-tc run log 12345
-tc run log 12345 --failed
-tc run log --job Falcon_Build
+teamcity run log 12345
+teamcity run log 12345 --failed
+teamcity run log --job Falcon_Build
 ```
 
 **Options:**
@@ -575,8 +575,8 @@ tc run log --job Falcon_Build
 Pin a run to prevent it from being automatically cleaned up by retention policies.
 
 ```bash
-tc run pin 12345
-tc run pin 12345 --comment "Release candidate"
+teamcity run pin 12345
+teamcity run pin 12345 --comment "Release candidate"
 ```
 
 **Options:**
@@ -587,8 +587,8 @@ tc run pin 12345 --comment "Release candidate"
 Restart a run with the same configuration.
 
 ```bash
-tc run restart 12345
-tc run restart 12345 --watch
+teamcity run restart 12345
+teamcity run restart 12345 --watch
 ```
 
 **Options:**
@@ -600,15 +600,15 @@ tc run restart 12345 --watch
 Start a new run
 
 ```bash
-tc run start Falcon_Build
-tc run start Falcon_Build --branch feature/test
-tc run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
-tc run start Falcon_Build --comment "Release build" --tag release --tag v1.0
-tc run start Falcon_Build --clean --rebuild-deps --top
-tc run start Falcon_Build --local-changes # personal build with uncommitted Git changes
-tc run start Falcon_Build --local-changes changes.patch  # from file
-tc run start Falcon_Build --revision abc123def --branch main
-tc run start Falcon_Build --dry-run
+teamcity run start Falcon_Build
+teamcity run start Falcon_Build --branch feature/test
+teamcity run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
+teamcity run start Falcon_Build --comment "Release build" --tag release --tag v1.0
+teamcity run start Falcon_Build --clean --rebuild-deps --top
+teamcity run start Falcon_Build --local-changes # personal build with uncommitted Git changes
+teamcity run start Falcon_Build --local-changes changes.patch  # from file
+teamcity run start Falcon_Build --revision abc123def --branch main
+teamcity run start Falcon_Build --dry-run
 ```
 
 **Options:**
@@ -637,8 +637,8 @@ tc run start Falcon_Build --dry-run
 Add one or more tags to a run for categorization and filtering.
 
 ```bash
-tc run tag 12345 release
-tc run tag 12345 release v1.0 production
+teamcity run tag 12345 release
+teamcity run tag 12345 release v1.0 production
 ```
 
 ### run tests
@@ -648,9 +648,9 @@ Show test results from a run.
 You can specify a run ID directly, or use --job to get the latest run's tests.
 
 ```bash
-tc run tests 12345
-tc run tests 12345 --failed
-tc run tests --job Falcon_Build
+teamcity run tests 12345
+teamcity run tests 12345 --failed
+teamcity run tests --job Falcon_Build
 ```
 
 **Options:**
@@ -664,7 +664,7 @@ tc run tests --job Falcon_Build
 Remove the pin from a run, allowing it to be cleaned up by retention policies.
 
 ```bash
-tc run unpin 12345
+teamcity run unpin 12345
 ```
 
 ### run untag
@@ -672,8 +672,8 @@ tc run unpin 12345
 Remove one or more tags from a run.
 
 ```bash
-tc run untag 12345 release
-tc run untag 12345 release v1.0
+teamcity run untag 12345 release
+teamcity run untag 12345 release v1.0
 ```
 
 ### run view
@@ -681,9 +681,9 @@ tc run untag 12345 release v1.0
 View run details
 
 ```bash
-tc run view 12345
-tc run view 12345 --web
-tc run view 12345 --json
+teamcity run view 12345
+teamcity run view 12345 --web
+teamcity run view 12345 --json
 ```
 
 **Options:**
@@ -695,9 +695,9 @@ tc run view 12345 --json
 Watch a run in real-time until it completes.
 
 ```bash
-tc run watch 12345
-tc run watch 12345 --interval 10
-tc run watch 12345 --logs
+teamcity run watch 12345
+teamcity run watch 12345 --interval 10
+teamcity run watch 12345 --logs
 ```
 
 **Options:**
@@ -715,10 +715,10 @@ tc run watch 12345 --logs
 List jobs
 
 ```bash
-tc job list
-tc job list --project Falcon
-tc job list --json
-tc job list --json=id,name,webUrl
+teamcity job list
+teamcity job list --project Falcon
+teamcity job list --json
+teamcity job list --json=id,name,webUrl
 ```
 
 **Options:**
@@ -731,7 +731,7 @@ tc job list --json=id,name,webUrl
 Delete a parameter from a job.
 
 ```bash
-tc job param delete MyID MY_PARAM
+teamcity job param delete MyID MY_PARAM
 ```
 
 ### job param get
@@ -739,8 +739,8 @@ tc job param delete MyID MY_PARAM
 Get the value of a specific job parameter.
 
 ```bash
-tc job param get MyID MY_PARAM
-tc job param get MyID VERSION
+teamcity job param get MyID MY_PARAM
+teamcity job param get MyID VERSION
 ```
 
 ### job param list
@@ -748,8 +748,8 @@ tc job param get MyID VERSION
 List all parameters for a job.
 
 ```bash
-tc job param list MyID
-tc job param list MyID --json
+teamcity job param list MyID
+teamcity job param list MyID --json
 ```
 
 **Options:**
@@ -760,8 +760,8 @@ tc job param list MyID --json
 Set or update a job parameter value.
 
 ```bash
-tc job param set MyID MY_PARAM "my value"
-tc job param set MyID SECRET_KEY "****" --secure
+teamcity job param set MyID MY_PARAM "my value"
+teamcity job param set MyID SECRET_KEY "****" --secure
 ```
 
 **Options:**
@@ -772,7 +772,7 @@ tc job param set MyID SECRET_KEY "****" --secure
 Pause a job to prevent new runs from being triggered.
 
 ```bash
-tc job pause Falcon_Build
+teamcity job pause Falcon_Build
 ```
 
 ### job resume
@@ -780,7 +780,7 @@ tc job pause Falcon_Build
 Resume a paused job to allow new runs.
 
 ```bash
-tc job resume Falcon_Build
+teamcity job resume Falcon_Build
 ```
 
 ### job view
@@ -788,8 +788,8 @@ tc job resume Falcon_Build
 View job details
 
 ```bash
-tc job view Falcon_Build
-tc job view Falcon_Build --web
+teamcity job view Falcon_Build
+teamcity job view Falcon_Build --web
 ```
 
 **Options:**
@@ -805,10 +805,10 @@ tc job view Falcon_Build --web
 List all TeamCity projects.
 
 ```bash
-tc project list
-tc project list --parent Falcon
-tc project list --json
-tc project list --json=id,name,webUrl
+teamcity project list
+teamcity project list --parent Falcon
+teamcity project list --json
+teamcity project list --json=id,name,webUrl
 ```
 
 **Options:**
@@ -821,7 +821,7 @@ tc project list --json=id,name,webUrl
 Delete a parameter from a project.
 
 ```bash
-tc project param delete MyID MY_PARAM
+teamcity project param delete MyID MY_PARAM
 ```
 
 ### project param get
@@ -829,8 +829,8 @@ tc project param delete MyID MY_PARAM
 Get the value of a specific project parameter.
 
 ```bash
-tc project param get MyID MY_PARAM
-tc project param get MyID VERSION
+teamcity project param get MyID MY_PARAM
+teamcity project param get MyID VERSION
 ```
 
 ### project param list
@@ -838,8 +838,8 @@ tc project param get MyID VERSION
 List all parameters for a project.
 
 ```bash
-tc project param list MyID
-tc project param list MyID --json
+teamcity project param list MyID
+teamcity project param list MyID --json
 ```
 
 **Options:**
@@ -850,8 +850,8 @@ tc project param list MyID --json
 Set or update a project parameter value.
 
 ```bash
-tc project param set MyID MY_PARAM "my value"
-tc project param set MyID SECRET_KEY "****" --secure
+teamcity project param set MyID MY_PARAM "my value"
+teamcity project param set MyID SECRET_KEY "****" --secure
 ```
 
 **Options:**
@@ -870,16 +870,16 @@ By default, exports in Kotlin DSL format.
 
 ```bash
 # Export as Kotlin DSL (default)
-tc project settings export MyProject
+teamcity project settings export MyProject
 
 # Export as Kotlin DSL explicitly
-tc project settings export MyProject --kotlin
+teamcity project settings export MyProject --kotlin
 
 # Export as XML
-tc project settings export MyProject --xml
+teamcity project settings export MyProject --xml
 
 # Save to specific file
-tc project settings export MyProject -o settings.zip
+teamcity project settings export MyProject -o settings.zip
 ```
 
 **Options:**
@@ -900,8 +900,8 @@ Displays:
 - Any warnings or errors from the last sync attempt
 
 ```bash
-tc project settings status MyProject
-tc project settings status MyProject --json
+teamcity project settings status MyProject
+teamcity project settings status MyProject --json
 ```
 
 **Options:**
@@ -915,9 +915,9 @@ Auto-detects .teamcity directory in the current directory or parents.
 Requires Maven (mvn) or uses mvnw wrapper if present in the DSL directory.
 
 ```bash
-tc project settings validate
-tc project settings validate ./path/to/.teamcity
-tc project settings validate --verbose
+teamcity project settings validate
+teamcity project settings validate ./path/to/.teamcity
+teamcity project settings validate --verbose
 ```
 
 **Options:**
@@ -931,8 +931,8 @@ This operation requires CHANGE_SERVER_SETTINGS permission,
 which is only available to System Administrators.
 
 ```bash
-tc project token get Falcon "credentialsJSON:abc123..."
-tc project token get Falcon "abc123..."
+teamcity project token get Falcon "credentialsJSON:abc123..."
+teamcity project token get Falcon "abc123..."
 ```
 
 ### project token put
@@ -947,13 +947,13 @@ Requires EDIT_PROJECT permission (Project Administrator role).
 
 ```bash
 # Store a secret interactively (prompts for value)
-tc project token put Falcon
+teamcity project token put Falcon
 
 # Store a secret from a value
-tc project token put Falcon "my-secret-password"
+teamcity project token put Falcon "my-secret-password"
 
 # Store a secret from stdin (useful for piping)
-echo -n "my-secret" | tc project token put Falcon --stdin
+echo -n "my-secret" | teamcity project token put Falcon --stdin
 
 # Use the token in versioned settings
 # password: credentialsJSON:<returned-token>
@@ -967,8 +967,8 @@ echo -n "my-secret" | tc project token put Falcon --stdin
 View details of a TeamCity project.
 
 ```bash
-tc project view Falcon
-tc project view Falcon --web
+teamcity project view Falcon
+teamcity project view Falcon --web
 ```
 
 **Options:**
@@ -984,7 +984,7 @@ tc project view Falcon --web
 Approve a queued run that requires manual approval before it can run.
 
 ```bash
-tc queue approve 12345
+teamcity queue approve 12345
 ```
 
 ### queue list
@@ -992,10 +992,10 @@ tc queue approve 12345
 List all runs in the TeamCity queue.
 
 ```bash
-tc queue list
-tc queue list --job Falcon_Build
-tc queue list --json
-tc queue list --json=id,state,webUrl
+teamcity queue list
+teamcity queue list --job Falcon_Build
+teamcity queue list --json
+teamcity queue list --json=id,state,webUrl
 ```
 
 **Options:**
@@ -1008,8 +1008,8 @@ tc queue list --json=id,state,webUrl
 Remove a queued run from the TeamCity queue.
 
 ```bash
-tc queue remove 12345
-tc queue remove 12345 --force
+teamcity queue remove 12345
+teamcity queue remove 12345 --force
 ```
 
 **Options:**
@@ -1020,7 +1020,7 @@ tc queue remove 12345 --force
 Move a queued run to the top of the queue, giving it highest priority.
 
 ```bash
-tc queue top 12345
+teamcity queue top 12345
 ```
 
 ---
@@ -1032,8 +1032,8 @@ tc queue top 12345
 Authorize an agent to allow it to connect and run builds.
 
 ```bash
-tc agent authorize 1
-tc agent authorize Agent-Linux-01
+teamcity agent authorize 1
+teamcity agent authorize Agent-Linux-01
 ```
 
 ### agent deauthorize
@@ -1041,8 +1041,8 @@ tc agent authorize Agent-Linux-01
 Deauthorize an agent to revoke its permission to connect.
 
 ```bash
-tc agent deauthorize 1
-tc agent deauthorize Agent-Linux-01
+teamcity agent deauthorize 1
+teamcity agent deauthorize Agent-Linux-01
 ```
 
 ### agent disable
@@ -1050,8 +1050,8 @@ tc agent deauthorize Agent-Linux-01
 Disable an agent to prevent it from running builds.
 
 ```bash
-tc agent disable 1
-tc agent disable Agent-Linux-01
+teamcity agent disable 1
+teamcity agent disable Agent-Linux-01
 ```
 
 ### agent enable
@@ -1059,8 +1059,8 @@ tc agent disable Agent-Linux-01
 Enable an agent to allow it to run builds.
 
 ```bash
-tc agent enable 1
-tc agent enable Agent-Linux-01
+teamcity agent enable 1
+teamcity agent enable Agent-Linux-01
 ```
 
 ### agent exec
@@ -1068,9 +1068,9 @@ tc agent enable Agent-Linux-01
 Execute a command on a TeamCity build agent and return the output.
 
 ```bash
-tc agent exec 1 "ls -la"
-tc agent exec Agent-Linux-01 "cat /etc/os-release"
-tc agent exec Agent-Linux-01 --timeout 10m -- long-running-script.sh
+teamcity agent exec 1 "ls -la"
+teamcity agent exec Agent-Linux-01 "cat /etc/os-release"
+teamcity agent exec Agent-Linux-01 --timeout 10m -- long-running-script.sh
 ```
 
 **Options:**
@@ -1081,10 +1081,10 @@ tc agent exec Agent-Linux-01 --timeout 10m -- long-running-script.sh
 List build configurations (jobs) that are compatible or incompatible with an agent.
 
 ```bash
-tc agent jobs 1
-tc agent jobs Agent-Linux-01
-tc agent jobs Agent-Linux-01 --incompatible
-tc agent jobs 1 --json
+teamcity agent jobs 1
+teamcity agent jobs Agent-Linux-01
+teamcity agent jobs Agent-Linux-01 --incompatible
+teamcity agent jobs 1 --json
 ```
 
 **Options:**
@@ -1096,11 +1096,11 @@ tc agent jobs 1 --json
 List build agents
 
 ```bash
-tc agent list
-tc agent list --pool Default
-tc agent list --connected
-tc agent list --json
-tc agent list --json=id,name,connected,enabled
+teamcity agent list
+teamcity agent list --pool Default
+teamcity agent list --connected
+teamcity agent list --json
+teamcity agent list --json=id,name,connected,enabled
 ```
 
 **Options:**
@@ -1116,8 +1116,8 @@ tc agent list --json=id,name,connected,enabled
 Move an agent to a different agent pool.
 
 ```bash
-tc agent move 1 0
-tc agent move Agent-Linux-01 2
+teamcity agent move 1 0
+teamcity agent move Agent-Linux-01 2
 ```
 
 ### agent reboot
@@ -1130,10 +1130,10 @@ Use --after-build to wait for the current build to finish before rebooting.
 Note: Local agents (running on the same machine as the server) cannot be rebooted.
 
 ```bash
-tc agent reboot 1
-tc agent reboot Agent-Linux-01
-tc agent reboot Agent-Linux-01 --after-build
-tc agent reboot Agent-Linux-01 --yes
+teamcity agent reboot 1
+teamcity agent reboot Agent-Linux-01
+teamcity agent reboot Agent-Linux-01 --after-build
+teamcity agent reboot Agent-Linux-01 --yes
 ```
 
 **Options:**
@@ -1145,8 +1145,8 @@ tc agent reboot Agent-Linux-01 --yes
 Open an interactive shell session to a TeamCity build agent.
 
 ```bash
-tc agent term 1
-tc agent term Agent-Linux-01
+teamcity agent term 1
+teamcity agent term Agent-Linux-01
 ```
 
 ### agent view
@@ -1154,10 +1154,10 @@ tc agent term Agent-Linux-01
 View agent details
 
 ```bash
-tc agent view 1
-tc agent view Agent-Linux-01
-tc agent view Agent-Linux-01 --web
-tc agent view 1 --json
+teamcity agent view 1
+teamcity agent view Agent-Linux-01
+teamcity agent view Agent-Linux-01 --web
+teamcity agent view 1 --json
 ```
 
 **Options:**
@@ -1173,7 +1173,7 @@ tc agent view 1 --json
 Link a project to an agent pool, allowing the project's builds to run on agents in that pool.
 
 ```bash
-tc pool link 1 MyProject
+teamcity pool link 1 MyProject
 ```
 
 ### pool list
@@ -1181,9 +1181,9 @@ tc pool link 1 MyProject
 List agent pools
 
 ```bash
-tc pool list
-tc pool list --json
-tc pool list --json=id,name,maxAgents
+teamcity pool list
+teamcity pool list --json
+teamcity pool list --json=id,name,maxAgents
 ```
 
 **Options:**
@@ -1194,7 +1194,7 @@ tc pool list --json=id,name,maxAgents
 Unlink a project from an agent pool, removing the project's access to agents in that pool.
 
 ```bash
-tc pool unlink 1 MyProject
+teamcity pool unlink 1 MyProject
 ```
 
 ### pool view
@@ -1202,9 +1202,9 @@ tc pool unlink 1 MyProject
 View pool details
 
 ```bash
-tc pool view 0
-tc pool view 1 --web
-tc pool view 1 --json
+teamcity pool view 0
+teamcity pool view 1 --web
+teamcity pool view 1 --json
 ```
 
 **Options:**
@@ -1228,16 +1228,16 @@ This command is useful for:
 
 ```bash
 # Get server info
-tc api /app/rest/server
+teamcity api /app/rest/server
 
 # List projects
-tc api /app/rest/projects
+teamcity api /app/rest/projects
 
 # Create a resource with POST
-tc api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
+teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
 
 # Fetch all pages and combine into array
-tc api /app/rest/builds --paginate --slurp
+teamcity api /app/rest/builds --paginate --slurp
 ```
 
 **Options:**
@@ -1268,28 +1268,28 @@ List configured aliases
 
 ### alias set
 
-Create a shortcut that expands into a full tc command.
+Create a shortcut that expands into a full teamcity command.
 
 Use $1, $2, ... for positional arguments. Extra arguments are appended.
 Use --shell for aliases that need pipes, redirection, or other shell features.
 
 ```bash
 # Quick shortcuts
-tc alias set rl  'run list'
-tc alias set rw  'run view $1 --web'
+teamcity alias set rl  'run list'
+teamcity alias set rw  'run view $1 --web'
 
 # Filtered views
-tc alias set mine    'run list --user=@me'
-tc alias set fails   'run list --status=failure --since=24h'
-tc alias set running 'run list --status=running'
+teamcity alias set mine    'run list --user=@me'
+teamcity alias set fails   'run list --status=failure --since=24h'
+teamcity alias set running 'run list --status=running'
 
 # Trigger-and-watch workflows
-tc alias set go    'run start $1 --watch'
-tc alias set hotfix 'run start $1 --top --clean --watch'
+teamcity alias set go    'run start $1 --watch'
+teamcity alias set hotfix 'run start $1 --top --clean --watch'
 
 # Shell aliases for pipes and external tools
-tc alias set watchnotify '!tc run watch $1 && notify-send "Build $1 done"'
-tc alias set faillog '!tc run list --status=failure --json | jq ".[].id"'
+teamcity alias set watchnotify '!teamcity run watch $1 && notify-send "Build $1 done"'
+teamcity alias set faillog '!teamcity run list --status=failure --json | jq ".[].id"'
 ```
 
 **Options:**
@@ -1301,15 +1301,15 @@ tc alias set faillog '!tc run list --status=failure --json | jq ".[].id"'
 
 ### skill install
 
-Install the teamcity-cli skill so AI coding agents can use tc commands.
+Install the teamcity-cli skill so AI coding agents can use teamcity commands.
 
 Installs globally by default. Use --project to install to the current project only.
 Auto-detects installed agents when --agent is not specified.
 
 ```bash
-tc skill install
-tc skill install --agent claude-code --agent cursor
-tc skill install --project
+teamcity skill install
+teamcity skill install --agent claude-code --agent cursor
+teamcity skill install --project
 ```
 
 **Options:**
@@ -1321,9 +1321,9 @@ tc skill install --project
 Remove the teamcity-cli skill from AI coding agents
 
 ```bash
-tc skill remove
-tc skill remove --agent claude-code
-tc skill remove --project
+teamcity skill remove
+teamcity skill remove --agent claude-code
+teamcity skill remove --project
 ```
 
 **Options:**
@@ -1332,15 +1332,15 @@ tc skill remove --project
 
 ### skill update
 
-Update the teamcity-cli skill to the latest version bundled with this tc release.
+Update the teamcity-cli skill to the latest version bundled with this teamcity release.
 
 Skips if the installed version already matches.
 Auto-detects installed agents when --agent is not specified.
 
 ```bash
-tc skill update
-tc skill update --agent claude-code
-tc skill update --project
+teamcity skill update
+teamcity skill update --agent claude-code
+teamcity skill update --project
 ```
 
 **Options:**
@@ -1355,38 +1355,38 @@ A collection of useful aliases to get started with:
 
 ```bash
 # ── Quick shortcuts ─────────────────────────────────────────────
-tc alias set rl       'run list'                        # List recent runs
-tc alias set rv       'run view $1'                     # View a run
-tc alias set rw       'run view $1 --web'               # Open run in browser
-tc alias set jl       'job list'                        # List jobs
-tc alias set ql       'queue list'                      # List queued runs
+teamcity alias set rl       'run list'                        # List recent runs
+teamcity alias set rv       'run view $1'                     # View a run
+teamcity alias set rw       'run view $1 --web'               # Open run in browser
+teamcity alias set jl       'job list'                        # List jobs
+teamcity alias set ql       'queue list'                      # List queued runs
 
 # ── Filtered views ──────────────────────────────────────────────
-tc alias set mine     'run list --user=@me'             # My runs
-tc alias set fails    'run list --status=failure --since=24h'  # Recent failures
-tc alias set running  'run list --status=running'       # What's running now
-tc alias set morning  'run list --status=failure --since=12h'  # Overnight failures
+teamcity alias set mine     'run list --user=@me'             # My runs
+teamcity alias set fails    'run list --status=failure --since=24h'  # Recent failures
+teamcity alias set running  'run list --status=running'       # What's running now
+teamcity alias set morning  'run list --status=failure --since=12h'  # Overnight failures
 
 # ── Trigger-and-watch ──────────────────────────────────────────
-tc alias set go       'run start $1 --watch'            # Start and watch
-tc alias set try      'run start $1 --local-changes --watch'  # Test local changes
-tc alias set hotfix   'run start $1 --top --clean --watch'    # Priority build
-tc alias set retry    'run restart $1 --watch'          # Re-run a build
+teamcity alias set go       'run start $1 --watch'            # Start and watch
+teamcity alias set try      'run start $1 --local-changes --watch'  # Test local changes
+teamcity alias set hotfix   'run start $1 --top --clean --watch'    # Priority build
+teamcity alias set retry    'run restart $1 --watch'          # Re-run a build
 
 # ── Queue management ───────────────────────────────────────────
-tc alias set rush     'queue top $1'                    # Prioritize a build
-tc alias set ok       'queue approve $1'                # Approve a queued run
+teamcity alias set rush     'queue top $1'                    # Prioritize a build
+teamcity alias set ok       'queue approve $1'                # Approve a queued run
 
 # ── Agent operations ───────────────────────────────────────────
-tc alias set maint    'agent disable $1'                # Put agent in maintenance
-tc alias set unmaint  'agent enable $1'                 # Bring agent back
+teamcity alias set maint    'agent disable $1'                # Put agent in maintenance
+teamcity alias set unmaint  'agent enable $1'                 # Bring agent back
 
 # ── API shortcuts ──────────────────────────────────────────────
-tc alias set whoami   'api /app/rest/users/current'     # Who am I?
+teamcity alias set whoami   'api /app/rest/users/current'     # Who am I?
 
 # ── Shell aliases (pipes & external tools) ─────────────────────
-tc alias set watchnotify '!tc run watch $1 && notify-send "Build $1 done"'
-tc alias set faillog     '!tc run list --status=failure --json | jq ".[].id"'
+teamcity alias set watchnotify '!teamcity run watch $1 && notify-send "Build $1 done"'
+teamcity alias set faillog     '!teamcity run list --status=failure --json | jq ".[].id"'
 ```
 
 ## Contributing

--- a/install.cmd
+++ b/install.cmd
@@ -2,7 +2,7 @@
 setlocal
 
 set "REPO=JetBrains/teamcity-cli"
-set "BIN_NAME=tc.exe"
+set "BIN_NAME=teamcity.exe"
 set "INSTALL_DIR=%USERPROFILE%\.local\bin"
 
 if not exist "%INSTALL_DIR%" (
@@ -21,13 +21,13 @@ powershell -NoProfile -Command ^
     "$tag = $release.tag_name;" ^
     "$version = $tag.TrimStart('v');" ^
     "$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x86_64' };" ^
-    "$assetName = \"tc_$($version)_windows_$($arch).zip\";" ^
+    "$assetName = \"teamcity_$($version)_windows_$($arch).zip\";" ^
     "$asset = $release.assets | Where-Object { $_.name -eq $assetName };" ^
     "if (-not $asset) { Write-Error \"Could not find asset $assetName in release $tag\"; exit 1 };" ^
-    "$tempZip = Join-Path $env:TEMP 'tc.zip';" ^
+    "$tempZip = Join-Path $env:TEMP 'teamcity.zip';" ^
     "Write-Host \"Downloading $assetName...\";" ^
     "Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tempZip;" ^
-    "$tempExtract = Join-Path $env:TEMP 'tc_extract';" ^
+    "$tempExtract = Join-Path $env:TEMP 'teamcity_extract';" ^
     "if (Test-Path $tempExtract) { Remove-Item -Recurse -Force $tempExtract };" ^
     "New-Item -ItemType Directory -Path $tempExtract | Out-Null;" ^
     "Write-Host \"Extracting...\";" ^
@@ -61,13 +61,13 @@ powershell -NoProfile -Command ^
 echo.
 echo Next steps:
 echo   Authenticate with TeamCity
-echo   tc auth login
+echo   teamcity auth login
 echo.
 echo   List recent builds
-echo   tc run list
+echo   teamcity run list
 echo.
 echo   Get help
-echo   tc --help
+echo   teamcity --help
 echo.
 
 endlocal

--- a/install.ps1
+++ b/install.ps1
@@ -17,7 +17,7 @@
 $ErrorActionPreference = "Stop"
 
 $repo = "JetBrains/teamcity-cli"
-$binName = "tc.exe"
+$binName = "teamcity.exe"
 $installDir = "$HOME\.local\bin"
 
 if (-not (Test-Path $installDir)) {
@@ -43,7 +43,7 @@ $version = $tag.TrimStart('v')
 
 $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x86_64" }
 $os = "windows"
-$assetName = "tc_$($version)_$($os)_$($arch).zip"
+$assetName = "teamcity_$($version)_$($os)_$($arch).zip"
 
 $asset = $release.assets | Where-Object { $_.name -eq $assetName }
 if (-not $asset) {
@@ -52,8 +52,8 @@ if (-not $asset) {
 }
 
 $downloadUrl = $asset.browser_download_url
-$tempZip = Join-Path $env:TEMP "tc.zip"
-$tempExtract = Join-Path $env:TEMP "tc_extract"
+$tempZip = Join-Path $env:TEMP "teamcity.zip"
+$tempExtract = Join-Path $env:TEMP "teamcity_extract"
 
 Write-Host "Downloading $assetName from $downloadUrl..."
 Invoke-WebRequest -Uri $downloadUrl -OutFile $tempZip
@@ -93,8 +93,8 @@ Remove-Item -Recurse -Force $tempExtract
 
 Write-Host "`nNext steps:"
 Write-Host "  Authenticate with TeamCity"
-Write-Host "  tc auth login`n"
+Write-Host "  teamcity auth login`n"
 Write-Host "  List recent builds"
-Write-Host "  tc run list`n"
+Write-Host "  teamcity run list`n"
 Write-Host "  Get help"
-Write-Host "  tc --help`n"
+Write-Host "  teamcity --help`n"

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ echo -e '
 '
 
 echo -e "
-This script will download TeamCity CLI to \033[4m$OUT_DIR/tc\033[0m
+This script will download TeamCity CLI to \033[4m$OUT_DIR/teamcity\033[0m
 
 If you get 'permission denied' error:
   - Specify other dir: \033[4mcurl -fsSL https://jb.gg/tc/install | bash -s -- \"\" \$HOME/.local/bin\033[0m
@@ -67,7 +67,7 @@ function install {
         RELEASE=$LATEST
     fi
     USER="JetBrains"
-    PROG="tc"
+    PROG="teamcity"
     INSECURE="false"
     #bash check
     [ ! "$BASH_VERSION" ] && fail "Please use bash instead"
@@ -104,7 +104,7 @@ function install {
     else
         fail "unknown arch: $(uname -m)"
     fi
-    URL="https://github.com/JetBrains/teamcity-cli/releases/download/$RELEASE/tc_${RELEASE#v}_${OS}_${ARCH}.tar.gz"
+    URL="https://github.com/JetBrains/teamcity-cli/releases/download/$RELEASE/teamcity_${RELEASE#v}_${OS}_${ARCH}.tar.gz"
     FTYPE=".tar.gz"
 
     echo -e "\033[0;90m\nInstalling $PROG ($RELEASE) from $URL\033[0m\n"
@@ -119,9 +119,9 @@ function install {
     else
         fail "unknown file type: $FTYPE"
     fi
-    TMP_BIN=$(find . -name "tc" -type f | head -1)
+    TMP_BIN=$(find . -name "teamcity" -type f | head -1)
     if [ ! -f "$TMP_BIN" ]; then
-        fail "could not find tc binary"
+        fail "could not find teamcity binary"
     fi
     chmod +x "$TMP_BIN" || fail "chmod +x failed"
     mv "$TMP_BIN" "$OUT_DIR"/$PROG || fail "mv failed"
@@ -131,11 +131,11 @@ function install {
     header "Next steps"
     echo -e ""
     echo -e "  \033[1mAuthenticate with TeamCity\033[0m"
-    echo -e "  \033[0;90mtc auth login\033[0m\n"
+    echo -e "  \033[0;90mteamcity auth login\033[0m\n"
     echo -e "  \033[1mList recent builds\033[0m"
-    echo -e "  \033[0;90mtc run list\033[0m\n"
+    echo -e "  \033[0;90mteamcity run list\033[0m\n"
     echo -e "  \033[1mGet help\033[0m"
-    echo -e "  \033[0;90mtc --help\033[0m\n"
+    echo -e "  \033[0;90mteamcity --help\033[0m\n"
 }
 
 install

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -699,10 +699,10 @@ func TestBuildLevelAuth(T *testing.T) {
 	// properties file contains localhost which isn't reachable from the container.
 	// Setting TEAMCITY_URL (without TEAMCITY_TOKEN) makes CLI use that URL with build credentials.
 	script := `set -e
-which tc || { echo "tc binary not found"; exit 1; }
+which teamcity || { echo "teamcity binary not found"; exit 1; }
 export TEAMCITY_URL=http://teamcity-server:8111
 unset TEAMCITY_TOKEN
-tc auth status
+teamcity auth status
 `
 
 	if !client.BuildTypeExists(configID) {

--- a/internal/api/builds.go
+++ b/internal/api/builds.go
@@ -441,7 +441,7 @@ func (c *Client) PinBuild(buildID string, comment string) error {
 
 	body := comment
 	if body == "" {
-		body = "Pinned via tc CLI"
+		body = "Pinned via teamcity CLI"
 	}
 
 	return c.doNoContent("PUT", path, strings.NewReader(body), "text/plain")

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -300,15 +300,15 @@ func notFoundHint(message string) string {
 	msg := strings.ToLower(message)
 	switch {
 	case strings.Contains(msg, "agent pool"), strings.Contains(msg, "pool"):
-		return "Use 'tc pool list' to see available pools"
+		return "Use 'teamcity pool list' to see available pools"
 	case strings.Contains(msg, "agent"):
-		return "Use 'tc agent list' to see available agents"
+		return "Use 'teamcity agent list' to see available agents"
 	case strings.Contains(msg, "project"):
-		return "Use 'tc project list' to see available projects"
+		return "Use 'teamcity project list' to see available projects"
 	case strings.Contains(msg, "build type"), strings.Contains(msg, "job"):
-		return "Use 'tc job list' to see available jobs"
+		return "Use 'teamcity job list' to see available jobs"
 	default:
-		return "Use 'tc job list' or 'tc run list' to see available resources"
+		return "Use 'teamcity job list' or 'teamcity run list' to see available resources"
 	}
 }
 

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -624,12 +624,12 @@ func TestNotFoundHint(T *testing.T) {
 		message string
 		want    string
 	}{
-		{"pool message", "Agent pool 'MyPool' not found", "Use 'tc pool list' to see available pools"},
-		{"agent message", "Agent 'MyAgent' not found", "Use 'tc agent list' to see available agents"},
-		{"project message", "Project 'Foo' not found", "Use 'tc project list' to see available projects"},
-		{"build type message", "Build type 'Foo_Bar' not found", "Use 'tc job list' to see available jobs"},
-		{"job message", "job 'Foo' not found", "Use 'tc job list' to see available jobs"},
-		{"default message", "Something else went wrong", "Use 'tc job list' or 'tc run list' to see available resources"},
+		{"pool message", "Agent pool 'MyPool' not found", "Use 'teamcity pool list' to see available pools"},
+		{"agent message", "Agent 'MyAgent' not found", "Use 'teamcity agent list' to see available agents"},
+		{"project message", "Project 'Foo' not found", "Use 'teamcity project list' to see available projects"},
+		{"build type message", "Build type 'Foo_Bar' not found", "Use 'teamcity job list' to see available jobs"},
+		{"job message", "job 'Foo' not found", "Use 'teamcity job list' to see available jobs"},
+		{"default message", "Something else went wrong", "Use 'teamcity job list' or 'teamcity run list' to see available resources"},
 	}
 
 	for _, tc := range tests {

--- a/internal/api/testenv_test.go
+++ b/internal/api/testenv_test.go
@@ -413,11 +413,11 @@ func copyBinaryToAgent(env *testEnv) error {
 	}
 
 	log.Println("Copying binary to agent container...")
-	err = env.agent.CopyFileToContainer(env.ctx, binaryPath, "/usr/local/bin/tc", 0755)
+	err = env.agent.CopyFileToContainer(env.ctx, binaryPath, "/usr/local/bin/teamcity", 0755)
 	if err != nil {
 		return fmt.Errorf("copy to container: %w", err)
 	}
 
-	log.Println("CLI binary installed on agent at /usr/local/bin/tc")
+	log.Println("CLI binary installed on agent at /usr/local/bin/teamcity")
 	return nil
 }

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -50,11 +50,11 @@ func newAgentListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List build agents",
-		Example: `  tc agent list
-  tc agent list --pool Default
-  tc agent list --connected
-  tc agent list --json
-  tc agent list --json=id,name,connected,enabled`,
+		Example: `  teamcity agent list
+  teamcity agent list --pool Default
+  teamcity agent list --connected
+  teamcity agent list --json
+  teamcity agent list --json=id,name,connected,enabled`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentList(cmd, opts)
 		},
@@ -150,10 +150,10 @@ func newAgentViewCmd() *cobra.Command {
 		Use:   "view <agent>",
 		Short: "View agent details",
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc agent view 1
-  tc agent view Agent-Linux-01
-  tc agent view Agent-Linux-01 --web
-  tc agent view 1 --json`,
+		Example: `  teamcity agent view 1
+  teamcity agent view Agent-Linux-01
+  teamcity agent view Agent-Linux-01 --web
+  teamcity agent view 1 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentView(args[0], opts)
 		},
@@ -219,7 +219,7 @@ func runAgentView(nameOrID string, opts *viewOptions) error {
 	fmt.Printf("\n%s %s\n", output.Faint("View in browser:"), output.Green(agent.WebURL))
 
 	if agent.Connected && agent.Authorized && agent.Enabled {
-		fmt.Printf("%s tc agent term %d\n", output.Faint("Open terminal:"), agent.ID)
+		fmt.Printf("%s teamcity agent term %d\n", output.Faint("Open terminal:"), agent.ID)
 	}
 
 	return nil
@@ -250,8 +250,8 @@ func newAgentActionCmd(a agentAction) *cobra.Command {
 		Short: a.short,
 		Long:  a.long,
 		Args:  cobra.ExactArgs(1),
-		Example: fmt.Sprintf(`  tc agent %s 1
-  tc agent %s Agent-Linux-01`, a.use, a.use),
+		Example: fmt.Sprintf(`  teamcity agent %s 1
+  teamcity agent %s Agent-Linux-01`, a.use, a.use),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := getClient()
 			if err != nil {
@@ -288,10 +288,10 @@ func newAgentJobsCmd() *cobra.Command {
 		Short: "Show jobs an agent can run",
 		Long:  `List build configurations (jobs) that are compatible or incompatible with an agent.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc agent jobs 1
-  tc agent jobs Agent-Linux-01
-  tc agent jobs Agent-Linux-01 --incompatible
-  tc agent jobs 1 --json`,
+		Example: `  teamcity agent jobs 1
+  teamcity agent jobs Agent-Linux-01
+  teamcity agent jobs Agent-Linux-01 --incompatible
+  teamcity agent jobs 1 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentJobs(args[0], opts)
 		},
@@ -397,8 +397,8 @@ func newAgentMoveCmd() *cobra.Command {
 		Short: "Move an agent to a different pool",
 		Long:  `Move an agent to a different agent pool.`,
 		Args:  cobra.ExactArgs(2),
-		Example: `  tc agent move 1 0
-  tc agent move Agent-Linux-01 2`,
+		Example: `  teamcity agent move 1 0
+  teamcity agent move Agent-Linux-01 2`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			poolID, err := parseID(args[1], "pool")
 			if err != nil {
@@ -448,10 +448,10 @@ Use --after-build to wait for the current build to finish before rebooting.
 
 Note: Local agents (running on the same machine as the server) cannot be rebooted.`,
 		Args: cobra.ExactArgs(1),
-		Example: `  tc agent reboot 1
-  tc agent reboot Agent-Linux-01
-  tc agent reboot Agent-Linux-01 --after-build
-  tc agent reboot Agent-Linux-01 --yes`,
+		Example: `  teamcity agent reboot 1
+  teamcity agent reboot Agent-Linux-01
+  teamcity agent reboot Agent-Linux-01 --after-build
+  teamcity agent reboot Agent-Linux-01 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentReboot(cmd.Context(), args[0], opts)
 		},

--- a/internal/cmd/agent_terminal.go
+++ b/internal/cmd/agent_terminal.go
@@ -22,8 +22,8 @@ func newAgentTerminalCmd() *cobra.Command {
 		Short: "Open interactive terminal to agent",
 		Long:  `Open an interactive shell session to a TeamCity build agent.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc agent term 1
-  tc agent term Agent-Linux-01`,
+		Example: `  teamcity agent term 1
+  teamcity agent term Agent-Linux-01`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, err := connectToAgent(cmd.Context(), args[0], true)
 			if err != nil {
@@ -42,9 +42,9 @@ func newAgentExecCmd() *cobra.Command {
 		Short: "Execute command on agent",
 		Long:  `Execute a command on a TeamCity build agent and return the output.`,
 		Args:  cobra.MinimumNArgs(2),
-		Example: `  tc agent exec 1 "ls -la"
-  tc agent exec Agent-Linux-01 "cat /etc/os-release"
-  tc agent exec Agent-Linux-01 --timeout 10m -- long-running-script.sh`,
+		Example: `  teamcity agent exec 1 "ls -la"
+  teamcity agent exec Agent-Linux-01 "cat /etc/os-release"
+  teamcity agent exec Agent-Linux-01 --timeout 10m -- long-running-script.sh`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			conn, err := connectToAgent(cmd.Context(), args[0], false)
 			if err != nil {
@@ -81,19 +81,19 @@ func connectToAgent(ctx context.Context, nameOrID string, showProgress bool) (*a
 	if !agent.Connected {
 		return nil, tcerrors.WithSuggestion(
 			fmt.Sprintf("Agent %s is not connected", agent.Name),
-			"Wait for the agent to connect or check agent status with 'tc agent view'",
+			"Wait for the agent to connect or check agent status with 'teamcity agent view'",
 		)
 	}
 	if !agent.Authorized {
 		return nil, tcerrors.WithSuggestion(
 			fmt.Sprintf("Agent %s is not authorized", agent.Name),
-			"Authorize the agent in TeamCity or use 'tc agent authorize'",
+			"Authorize the agent in TeamCity or use 'teamcity agent authorize'",
 		)
 	}
 	if !agent.Enabled {
 		return nil, tcerrors.WithSuggestion(
 			fmt.Sprintf("Agent %s is disabled", agent.Name),
-			"Enable the agent in TeamCity or use 'tc agent enable'",
+			"Enable the agent in TeamCity or use 'teamcity agent enable'",
 		)
 	}
 

--- a/internal/cmd/alias.go
+++ b/internal/cmd/alias.go
@@ -34,26 +34,26 @@ func newAliasSetCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set <name> <expansion>",
 		Short: "Create a command alias",
-		Long: `Create a shortcut that expands into a full tc command.
+		Long: `Create a shortcut that expands into a full teamcity command.
 
 Use $1, $2, ... for positional arguments. Extra arguments are appended.
 Use --shell for aliases that need pipes, redirection, or other shell features.`,
 		Example: `  # Quick shortcuts
-  tc alias set rl  'run list'
-  tc alias set rw  'run view $1 --web'
+  teamcity alias set rl  'run list'
+  teamcity alias set rw  'run view $1 --web'
 
   # Filtered views
-  tc alias set mine    'run list --user=@me'
-  tc alias set fails   'run list --status=failure --since=24h'
-  tc alias set running 'run list --status=running'
+  teamcity alias set mine    'run list --user=@me'
+  teamcity alias set fails   'run list --status=failure --since=24h'
+  teamcity alias set running 'run list --status=running'
 
   # Trigger-and-watch workflows
-  tc alias set go    'run start $1 --watch'
-  tc alias set hotfix 'run start $1 --top --clean --watch'
+  teamcity alias set go    'run start $1 --watch'
+  teamcity alias set hotfix 'run start $1 --top --clean --watch'
 
   # Shell aliases for pipes and external tools
-  tc alias set watchnotify '!tc run watch $1 && notify-send "Build $1 done"'
-  tc alias set faillog '!tc run list --status=failure --json | jq ".[].id"'`,
+  teamcity alias set watchnotify '!teamcity run watch $1 && notify-send "Build $1 done"'
+  teamcity alias set faillog '!teamcity run list --status=failure --json | jq ".[].id"'`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name, expansion := args[0], args[1]
@@ -102,7 +102,7 @@ func newAliasListCmd() *cobra.Command {
 			aliases := config.GetAllAliases()
 
 			if len(aliases) == 0 {
-				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No aliases configured. Use \"tc alias set\" to create one.")
+				_, _ = fmt.Fprintln(cmd.OutOrStdout(), "No aliases configured. Use \"teamcity alias set\" to create one.")
 				return nil
 			}
 

--- a/internal/cmd/alias_test.go
+++ b/internal/cmd/alias_test.go
@@ -39,12 +39,12 @@ func TestAliasSetShellFlag(t *testing.T) {
 	setupAliasTest(t)
 
 	root := cmd.NewRootCmd()
-	root.SetArgs([]string{"alias", "set", "--shell", "failing", "tc run list | jq ."})
+	root.SetArgs([]string{"alias", "set", "--shell", "failing", "teamcity run list | jq ."})
 	require.NoError(t, root.Execute())
 
 	exp, ok := config.GetAlias("failing")
 	assert.True(t, ok)
-	assert.Equal(t, "!tc run list | jq .", exp)
+	assert.Equal(t, "!teamcity run list | jq .", exp)
 }
 
 func TestAliasSetBangPrefix(t *testing.T) {

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -51,16 +51,16 @@ This command is useful for:
 - Debugging and exploration`,
 		Args: cobra.ExactArgs(1),
 		Example: `  # Get server info
-  tc api /app/rest/server
+  teamcity api /app/rest/server
 
   # List projects
-  tc api /app/rest/projects
+  teamcity api /app/rest/projects
 
   # Create a resource with POST
-  tc api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
+  teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
 
   # Fetch all pages and combine into array
-  tc api /app/rest/builds --paginate --slurp`,
+  teamcity api /app/rest/builds --paginate --slurp`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAPI(args[0], opts)
 		},

--- a/internal/cmd/api_test.go
+++ b/internal/cmd/api_test.go
@@ -21,7 +21,7 @@ import (
 // createTestRootCmd creates a fresh root command with the api subcommand for testing.
 func createTestRootCmd() *cobra.Command {
 	rootCmd := &cobra.Command{
-		Use: "tc",
+		Use: "teamcity",
 	}
 	rootCmd.PersistentFlags().Bool("no-color", false, "")
 	rootCmd.PersistentFlags().BoolP("quiet", "q", false, "")

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -202,7 +202,7 @@ func runAuthStatus() error {
 	}
 
 	fmt.Println(output.Red("✗"), "Not logged in to any TeamCity server")
-	fmt.Println("\nRun", output.Cyan("tc auth login"), "to authenticate")
+	fmt.Println("\nRun", output.Cyan("teamcity auth login"), "to authenticate")
 	if config.IsBuildEnvironment() {
 		fmt.Println("\n" + output.Yellow("!") + " Build environment detected but credentials not found in properties file")
 	}

--- a/internal/cmd/job.go
+++ b/internal/cmd/job.go
@@ -39,10 +39,10 @@ func newJobListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List jobs",
-		Example: `  tc job list
-  tc job list --project Falcon
-  tc job list --json
-  tc job list --json=id,name,webUrl`,
+		Example: `  teamcity job list
+  teamcity job list --project Falcon
+  teamcity job list --json
+  teamcity job list --json=id,name,webUrl`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runJobList(cmd, opts)
 		},
@@ -118,8 +118,8 @@ func newJobViewCmd() *cobra.Command {
 		Use:   "view <job-id>",
 		Short: "View job details",
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc job view Falcon_Build
-  tc job view Falcon_Build --web`,
+		Example: `  teamcity job view Falcon_Build
+  teamcity job view Falcon_Build --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runJobView(args[0], opts)
 		},
@@ -181,7 +181,7 @@ func newJobStateCmd(a jobStateAction) *cobra.Command {
 		Short:   a.short,
 		Long:    a.long,
 		Args:    cobra.ExactArgs(1),
-		Example: fmt.Sprintf("  tc job %s Falcon_Build", a.use),
+		Example: fmt.Sprintf("  teamcity job %s Falcon_Build", a.use),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := getClient()
 			if err != nil {

--- a/internal/cmd/param.go
+++ b/internal/cmd/param.go
@@ -70,8 +70,8 @@ func newParamListCmd(resource string, api paramAPI) *cobra.Command {
 		Short: fmt.Sprintf("List %s parameters", resource),
 		Long:  fmt.Sprintf("List all parameters for a %s.", resource),
 		Args:  cobra.ExactArgs(1),
-		Example: fmt.Sprintf(`  tc %s param list MyID
-  tc %s param list MyID --json`, resource, resource),
+		Example: fmt.Sprintf(`  teamcity %s param list MyID
+  teamcity %s param list MyID --json`, resource, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runParamList(args[0], opts, api)
 		},
@@ -128,8 +128,8 @@ func newParamGetCmd(resource string, api paramAPI) *cobra.Command {
 		Short: fmt.Sprintf("Get a %s parameter value", resource),
 		Long:  fmt.Sprintf("Get the value of a specific %s parameter.", resource),
 		Args:  cobra.ExactArgs(2),
-		Example: fmt.Sprintf(`  tc %s param get MyID MY_PARAM
-  tc %s param get MyID VERSION`, resource, resource),
+		Example: fmt.Sprintf(`  teamcity %s param get MyID MY_PARAM
+  teamcity %s param get MyID VERSION`, resource, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runParamGet(args[0], args[1], api)
 		},
@@ -170,8 +170,8 @@ func newParamSetCmd(resource string, api paramAPI) *cobra.Command {
 		Short: fmt.Sprintf("Set a %s parameter value", resource),
 		Long:  fmt.Sprintf("Set or update a %s parameter value.", resource),
 		Args:  cobra.ExactArgs(3),
-		Example: fmt.Sprintf(`  tc %s param set MyID MY_PARAM "my value"
-  tc %s param set MyID SECRET_KEY "****" --secure`, resource, resource),
+		Example: fmt.Sprintf(`  teamcity %s param set MyID MY_PARAM "my value"
+  teamcity %s param set MyID SECRET_KEY "****" --secure`, resource, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runParamSet(args[0], args[1], args[2], opts, api)
 		},
@@ -202,7 +202,7 @@ func newParamDeleteCmd(resource string, api paramAPI) *cobra.Command {
 		Short:   fmt.Sprintf("Delete a %s parameter", resource),
 		Long:    fmt.Sprintf("Delete a parameter from a %s.", resource),
 		Args:    cobra.ExactArgs(2),
-		Example: fmt.Sprintf(`  tc %s param delete MyID MY_PARAM`, resource),
+		Example: fmt.Sprintf(`  teamcity %s param delete MyID MY_PARAM`, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runParamDelete(args[0], args[1], api)
 		},

--- a/internal/cmd/pool.go
+++ b/internal/cmd/pool.go
@@ -37,9 +37,9 @@ func newPoolListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List agent pools",
-		Example: `  tc pool list
-  tc pool list --json
-  tc pool list --json=id,name,maxAgents`,
+		Example: `  teamcity pool list
+  teamcity pool list --json
+  teamcity pool list --json=id,name,maxAgents`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPoolList(cmd, opts)
 		},
@@ -105,9 +105,9 @@ func newPoolViewCmd() *cobra.Command {
 		Use:   "view <pool-id>",
 		Short: "View pool details",
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc pool view 0
-  tc pool view 1 --web
-  tc pool view 1 --json`,
+		Example: `  teamcity pool view 0
+  teamcity pool view 1 --web
+  teamcity pool view 1 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, err := parseID(args[0], "pool")
 			if err != nil {
@@ -211,7 +211,7 @@ func newPoolProjectCmd(a poolProjectAction) *cobra.Command {
 		Short:   a.short,
 		Long:    a.long,
 		Args:    cobra.ExactArgs(2),
-		Example: fmt.Sprintf("  tc pool %s 1 MyProject", a.use),
+		Example: fmt.Sprintf("  teamcity pool %s 1 MyProject", a.use),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			poolID, err := parseID(args[0], "pool")
 			if err != nil {

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -52,10 +52,10 @@ func newProjectListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List projects",
 		Long:  `List all TeamCity projects.`,
-		Example: `  tc project list
-  tc project list --parent Falcon
-  tc project list --json
-  tc project list --json=id,name,webUrl`,
+		Example: `  teamcity project list
+  teamcity project list --parent Falcon
+  teamcity project list --json
+  teamcity project list --json=id,name,webUrl`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProjectList(cmd, opts)
 		},
@@ -131,8 +131,8 @@ func newProjectViewCmd() *cobra.Command {
 		Short: "View project details",
 		Long:  `View details of a TeamCity project.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc project view Falcon
-  tc project view Falcon --web`,
+		Example: `  teamcity project view Falcon
+  teamcity project view Falcon --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProjectView(args[0], opts)
 		},
@@ -216,13 +216,13 @@ and is not committed to version control.
 
 Requires EDIT_PROJECT permission (Project Administrator role).`,
 		Example: `  # Store a secret interactively (prompts for value)
-  tc project token put Falcon
+  teamcity project token put Falcon
 
   # Store a secret from a value
-  tc project token put Falcon "my-secret-password"
+  teamcity project token put Falcon "my-secret-password"
 
   # Store a secret from stdin (useful for piping)
-  echo -n "my-secret" | tc project token put Falcon --stdin
+  echo -n "my-secret" | teamcity project token put Falcon --stdin
 
   # Use the token in versioned settings
   # password: credentialsJSON:<returned-token>`,
@@ -291,8 +291,8 @@ func newProjectTokenGetCmd() *cobra.Command {
 
 This operation requires CHANGE_SERVER_SETTINGS permission,
 which is only available to System Administrators.`,
-		Example: `  tc project token get Falcon "credentialsJSON:abc123..."
-  tc project token get Falcon "abc123..."`,
+		Example: `  teamcity project token get Falcon "credentialsJSON:abc123..."
+  teamcity project token get Falcon "abc123..."`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProjectTokenGet(args[0], args[1])
@@ -359,8 +359,8 @@ Displays:
 - Last successful sync timestamp
 - VCS root and format information
 - Any warnings or errors from the last sync attempt`,
-		Example: `  tc project settings status MyProject
-  tc project settings status MyProject --json`,
+		Example: `  teamcity project settings status MyProject
+  teamcity project settings status MyProject --json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProjectSettingsStatus(args[0], opts)
@@ -494,16 +494,16 @@ The exported archive can be used to:
 
 By default, exports in Kotlin DSL format.`,
 		Example: `  # Export as Kotlin DSL (default)
-  tc project settings export MyProject
+  teamcity project settings export MyProject
 
   # Export as Kotlin DSL explicitly
-  tc project settings export MyProject --kotlin
+  teamcity project settings export MyProject --kotlin
 
   # Export as XML
-  tc project settings export MyProject --xml
+  teamcity project settings export MyProject --xml
 
   # Save to specific file
-  tc project settings export MyProject -o settings.zip`,
+  teamcity project settings export MyProject -o settings.zip`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runProjectSettingsExport(args[0], opts)
@@ -619,9 +619,9 @@ func newProjectSettingsValidateCmd() *cobra.Command {
 
 Auto-detects .teamcity directory in the current directory or parents.
 Requires Maven (mvn) or uses mvnw wrapper if present in the DSL directory.`,
-		Example: `  tc project settings validate
-  tc project settings validate ./path/to/.teamcity
-  tc project settings validate --verbose`,
+		Example: `  teamcity project settings validate
+  teamcity project settings validate ./path/to/.teamcity
+  teamcity project settings validate --verbose`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -650,7 +650,7 @@ func runProjectSettingsValidate(opts *projectSettingsValidateOptions) error {
 	}
 
 	if dslDir == "" {
-		return fmt.Errorf("no TeamCity DSL directory found\n\nLooking for .teamcity in current directory and parents.\nSpecify path explicitly: tc project settings validate ./path/to/settings")
+		return fmt.Errorf("no TeamCity DSL directory found\n\nLooking for .teamcity in current directory and parents.\nSpecify path explicitly: teamcity project settings validate ./path/to/settings")
 	}
 
 	pomPath := filepath.Join(dslDir, "pom.xml")

--- a/internal/cmd/queue.go
+++ b/internal/cmd/queue.go
@@ -39,10 +39,10 @@ func newQueueListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "List queued runs",
 		Long:  `List all runs in the TeamCity queue.`,
-		Example: `  tc queue list
-  tc queue list --job Falcon_Build
-  tc queue list --json
-  tc queue list --json=id,state,webUrl`,
+		Example: `  teamcity queue list
+  teamcity queue list --job Falcon_Build
+  teamcity queue list --json
+  teamcity queue list --json=id,state,webUrl`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runQueueList(cmd, opts)
 		},
@@ -124,8 +124,8 @@ func newQueueRemoveCmd() *cobra.Command {
 		Short: "Remove a run from the queue",
 		Long:  `Remove a queued run from the TeamCity queue.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc queue remove 12345
-  tc queue remove 12345 --force`,
+		Example: `  teamcity queue remove 12345
+  teamcity queue remove 12345 --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runQueueRemove(args[0], opts)
 		},
@@ -192,7 +192,7 @@ func newQueueActionCmd(a queueAction) *cobra.Command {
 		Short:   a.short,
 		Long:    a.long,
 		Args:    cobra.ExactArgs(1),
-		Example: fmt.Sprintf("  tc queue %s 12345", a.use),
+		Example: fmt.Sprintf("  teamcity queue %s 12345", a.use),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := getClient()
 			if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,13 +21,13 @@ var (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "tc",
+	Use:   "teamcity",
 	Short: "TeamCity CLI",
 	Long: "TeamCity CLI v" + Version + `
 
 A command-line interface for interacting with TeamCity CI/CD server.
 
-tc provides a complete experience for managing
+teamcity provides a complete experience for managing
 TeamCity runs, jobs, projects and more from the command line.
 
 Documentation:  https://jb.gg/tc/docs
@@ -38,7 +38,7 @@ Report issues:  https://jb.gg/tc/issues`,
 		fmt.Println()
 		fmt.Println("TeamCity CLI " + output.Faint("v"+Version) + " - " + output.Faint("https://jb.gg/tc/docs"))
 		fmt.Println()
-		fmt.Println("Usage: tc <command> [flags]")
+		fmt.Println("Usage: teamcity <command> [flags]")
 		fmt.Println()
 		fmt.Println("Common commands:")
 		fmt.Println("  auth login              Authenticate with TeamCity")
@@ -47,12 +47,12 @@ Report issues:  https://jb.gg/tc/issues`,
 		fmt.Println("  run view <id>           View run details")
 		fmt.Println("  job list                List jobs")
 		fmt.Println()
-		fmt.Println(output.Faint("Run 'tc --help' for full command list, or 'tc <command> --help' for details"))
+		fmt.Println(output.Faint("Run 'teamcity --help' for full command list, or 'teamcity <command> --help' for details"))
 	},
 }
 
 func init() {
-	rootCmd.SetVersionTemplate("tc version {{.Version}}\n")
+	rootCmd.SetVersionTemplate("teamcity version {{.Version}}\n")
 	rootCmd.SuggestionsMinimumDistance = 2
 
 	rootCmd.PersistentFlags().BoolVar(&NoColor, "no-color", false, "Disable colored output")
@@ -120,7 +120,7 @@ func GetRootCmd() *RootCommand {
 // Callers must call RegisterAliases explicitly if alias expansion is needed.
 func NewRootCmd() *RootCommand {
 	cmd := &cobra.Command{
-		Use:     "tc",
+		Use:     "teamcity",
 		Short:   "TeamCity CLI",
 		Version: Version,
 	}

--- a/internal/cmd/run_analysis.go
+++ b/internal/cmd/run_analysis.go
@@ -24,9 +24,9 @@ func newRunChangesCmd() *cobra.Command {
 		Short: "Show VCS changes in a run",
 		Long:  `Show the VCS changes (commits) included in a run.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run changes 12345
-  tc run changes 12345 --no-files
-  tc run changes 12345 --json`,
+		Example: `  teamcity run changes 12345
+  teamcity run changes 12345 --no-files
+  teamcity run changes 12345 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunChanges(args[0], opts)
 		},
@@ -141,9 +141,9 @@ You can specify a run ID directly, or use --job to get the latest run's tests.`,
 			}
 			return cobra.MaximumNArgs(1)(cmd, args)
 		},
-		Example: `  tc run tests 12345
-  tc run tests 12345 --failed
-  tc run tests --job Falcon_Build`,
+		Example: `  teamcity run tests 12345
+  teamcity run tests 12345 --failed
+  teamcity run tests --job Falcon_Build`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var runID string
 			if len(args) > 0 {

--- a/internal/cmd/run_artifacts.go
+++ b/internal/cmd/run_artifacts.go
@@ -31,17 +31,17 @@ func newRunArtifactsCmd() *cobra.Command {
 		Short: "List run artifacts",
 		Long: `List artifacts from a run without downloading them.
 
-Shows artifact names and sizes. Use tc run download to download artifacts.`,
+Shows artifact names and sizes. Use teamcity run download to download artifacts.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && cmd.Flags().Changed("job") {
 				return tcerrors.MutuallyExclusive("run-id", "job")
 			}
 			return cobra.MaximumNArgs(1)(cmd, args)
 		},
-		Example: `  tc run artifacts 12345
-  tc run artifacts 12345 --json
-  tc run artifacts 12345 --path html_reports/coverage
-  tc run artifacts --job MyBuild`,
+		Example: `  teamcity run artifacts 12345
+  teamcity run artifacts 12345 --json
+  teamcity run artifacts 12345 --path html_reports/coverage
+  teamcity run artifacts --job MyBuild`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var runID string
 			if len(args) > 0 {
@@ -115,8 +115,8 @@ func runRunArtifacts(runID string, opts *runArtifactsOptions) error {
 		fmt.Printf("%-*s  %s\n", nameWidth, a.Name, output.Faint(fmt.Sprintf("%10s", size)))
 	}
 
-	fmt.Printf("\nDownload all: tc run download %s\n", runID)
-	fmt.Printf("Download one: tc run download %s -a \"<name>\"\n", runID)
+	fmt.Printf("\nDownload all: teamcity run download %s\n", runID)
+	fmt.Printf("Download one: teamcity run download %s -a \"<name>\"\n", runID)
 	return nil
 }
 
@@ -153,9 +153,9 @@ func newRunDownloadCmd() *cobra.Command {
 		Short: "Download run artifacts",
 		Long:  `Download artifacts from a completed run.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run download 12345
-  tc run download 12345 --dir ./artifacts
-  tc run download 12345 --artifact "*.jar"`,
+		Example: `  teamcity run download 12345
+  teamcity run download 12345 --dir ./artifacts
+  teamcity run download 12345 --artifact "*.jar"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunDownload(args[0], opts)
 		},
@@ -332,9 +332,9 @@ Use --raw to bypass the pager.`,
 			}
 			return cobra.MaximumNArgs(1)(cmd, args)
 		},
-		Example: `  tc run log 12345
-  tc run log 12345 --failed
-  tc run log --job Falcon_Build`,
+		Example: `  teamcity run log 12345
+  teamcity run log 12345 --failed
+  teamcity run log --job Falcon_Build`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var runID string
 			if len(args) > 0 {

--- a/internal/cmd/run_lifecycle.go
+++ b/internal/cmd/run_lifecycle.go
@@ -52,15 +52,15 @@ func newRunStartCmd() *cobra.Command {
 		Use:   "start <job-id>",
 		Short: "Start a new run",
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run start Falcon_Build
-  tc run start Falcon_Build --branch feature/test
-  tc run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
-  tc run start Falcon_Build --comment "Release build" --tag release --tag v1.0
-  tc run start Falcon_Build --clean --rebuild-deps --top
-  tc run start Falcon_Build --local-changes # personal build with uncommitted Git changes
-  tc run start Falcon_Build --local-changes changes.patch  # from file
-  tc run start Falcon_Build --revision abc123def --branch main
-  tc run start Falcon_Build --dry-run`,
+		Example: `  teamcity run start Falcon_Build
+  teamcity run start Falcon_Build --branch feature/test
+  teamcity run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
+  teamcity run start Falcon_Build --comment "Release build" --tag release --tag v1.0
+  teamcity run start Falcon_Build --clean --rebuild-deps --top
+  teamcity run start Falcon_Build --local-changes # personal build with uncommitted Git changes
+  teamcity run start Falcon_Build --local-changes changes.patch  # from file
+  teamcity run start Falcon_Build --revision abc123def --branch main
+  teamcity run start Falcon_Build --dry-run`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunStart(args[0], opts)
 		},
@@ -239,9 +239,9 @@ func runRunStart(jobID string, opts *runStartOptions) error {
 
 	output.Info("  URL: %s", build.WebURL)
 	if opts.agent > 0 {
-		fmt.Printf("  %s tc agent term %d\n", output.Faint("Agent terminal:"), opts.agent)
+		fmt.Printf("  %s teamcity agent term %d\n", output.Faint("Agent terminal:"), opts.agent)
 	} else {
-		fmt.Printf("  %s tc agent term <agent-id>\n", output.Faint("Agent terminal:"))
+		fmt.Printf("  %s teamcity agent term <agent-id>\n", output.Faint("Agent terminal:"))
 	}
 
 	if opts.web {
@@ -269,9 +269,9 @@ func newRunCancelCmd() *cobra.Command {
 		Short: "Cancel a running build",
 		Long:  `Cancel a running or queued run.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run cancel 12345
-  tc run cancel 12345 --comment "Cancelling for hotfix"
-  tc run cancel 12345 --force`,
+		Example: `  teamcity run cancel 12345
+  teamcity run cancel 12345 --comment "Cancelling for hotfix"
+  teamcity run cancel 12345 --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunCancel(args[0], opts)
 		},
@@ -308,7 +308,7 @@ func runRunCancel(runID string, opts *runCancelOptions) error {
 
 	comment := opts.comment
 	if comment == "" {
-		comment = "Cancelled via tc CLI"
+		comment = "Cancelled via teamcity CLI"
 	}
 
 	if err := client.CancelBuild(runID, comment); err != nil {
@@ -334,9 +334,9 @@ func newRunWatchCmd() *cobra.Command {
 		Short: "Watch a run until it completes",
 		Long:  `Watch a run in real-time until it completes.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run watch 12345
-  tc run watch 12345 --interval 10
-  tc run watch 12345 --logs`,
+		Example: `  teamcity run watch 12345
+  teamcity run watch 12345 --interval 10
+  teamcity run watch 12345 --logs`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := doRunWatch(args[0], opts)
 			var exitErr *ExitError
@@ -390,7 +390,7 @@ func doRunWatch(runID string, opts *runWatchOptions) error {
 			if !opts.quiet {
 				fmt.Println()
 				fmt.Println(output.Faint("Interrupted. Run continues in background."))
-				fmt.Printf("%s Resume watching: tc run watch %s\n", output.Faint("Hint:"), runID)
+				fmt.Printf("%s Resume watching: teamcity run watch %s\n", output.Faint("Hint:"), runID)
 			}
 			cancel()
 		case <-ctx.Done():
@@ -527,8 +527,8 @@ func newRunRestartCmd() *cobra.Command {
 		Short: "Restart a run",
 		Long:  `Restart a run with the same configuration.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run restart 12345
-  tc run restart 12345 --watch`,
+		Example: `  teamcity run restart 12345
+  teamcity run restart 12345 --watch`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunRestart(args[0], opts)
 		},
@@ -629,7 +629,7 @@ func loadLocalChanges(source string) ([]byte, error) {
 		if len(patch) == 0 {
 			return nil, tcerrors.WithSuggestion(
 				"no changes provided via stdin",
-				"Pipe a diff file to stdin, e.g.: git diff | tc run start Job --local-changes -",
+				"Pipe a diff file to stdin, e.g.: git diff | teamcity run start Job --local-changes -",
 			)
 		}
 		return patch, nil

--- a/internal/cmd/run_list.go
+++ b/internal/cmd/run_list.go
@@ -34,14 +34,14 @@ func newRunListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List recent runs",
-		Example: `  tc run list
-  tc run list --job Falcon_Build
-  tc run list --status failure --limit 10
-  tc run list --project Falcon --branch main
-  tc run list --since 24h
-  tc run list --json
-  tc run list --json=id,status,webUrl
-  tc run list --plain | grep failure`,
+		Example: `  teamcity run list
+  teamcity run list --job Falcon_Build
+  teamcity run list --status failure --limit 10
+  teamcity run list --project Falcon --branch main
+  teamcity run list --since 24h
+  teamcity run list --json
+  teamcity run list --json=id,status,webUrl
+  teamcity run list --plain | grep failure`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunList(cmd, opts)
 		},
@@ -227,9 +227,9 @@ func newRunViewCmd() *cobra.Command {
 		Use:   "view <run-id>",
 		Short: "View run details",
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run view 12345
-  tc run view 12345 --web
-  tc run view 12345 --json`,
+		Example: `  teamcity run view 12345
+  teamcity run view 12345 --web
+  teamcity run view 12345 --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunView(args[0], opts)
 		},
@@ -300,7 +300,7 @@ func runRunView(runID string, opts *viewOptions) error {
 	if build.Agent != nil {
 		fmt.Printf("\nAgent: %s", output.Faint(build.Agent.Name))
 		if build.State == "running" {
-			fmt.Printf("  %s tc agent term %d", output.Faint("·"), build.Agent.ID)
+			fmt.Printf("  %s teamcity agent term %d", output.Faint("·"), build.Agent.ID)
 		}
 		fmt.Println()
 	}

--- a/internal/cmd/run_metadata.go
+++ b/internal/cmd/run_metadata.go
@@ -15,8 +15,8 @@ func newRunPinCmd() *cobra.Command {
 		Short: "Pin a run to prevent cleanup",
 		Long:  `Pin a run to prevent it from being automatically cleaned up by retention policies.`,
 		Args:  cobra.ExactArgs(1),
-		Example: `  tc run pin 12345
-  tc run pin 12345 --comment "Release candidate"`,
+		Example: `  teamcity run pin 12345
+  teamcity run pin 12345 --comment "Release candidate"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := getClient()
 			if err != nil {
@@ -42,7 +42,7 @@ func newRunUnpinCmd() *cobra.Command {
 		Short:   "Unpin a run",
 		Long:    `Remove the pin from a run, allowing it to be cleaned up by retention policies.`,
 		Args:    cobra.ExactArgs(1),
-		Example: `  tc run unpin 12345`,
+		Example: `  teamcity run unpin 12345`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := getClient()
 			if err != nil {
@@ -63,8 +63,8 @@ func newRunTagCmd() *cobra.Command {
 		Short: "Add tags to a run",
 		Long:  `Add one or more tags to a run for categorization and filtering.`,
 		Args:  cobra.MinimumNArgs(2),
-		Example: `  tc run tag 12345 release
-  tc run tag 12345 release v1.0 production`,
+		Example: `  teamcity run tag 12345 release
+  teamcity run tag 12345 release v1.0 production`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunTag(args[0], args[1:])
 		},
@@ -105,8 +105,8 @@ func newRunUntagCmd() *cobra.Command {
 		Short: "Remove tags from a run",
 		Long:  `Remove one or more tags from a run.`,
 		Args:  cobra.MinimumNArgs(2),
-		Example: `  tc run untag 12345 release
-  tc run untag 12345 release v1.0`,
+		Example: `  teamcity run untag 12345 release
+  teamcity run untag 12345 release v1.0`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunUntag(args[0], args[1:])
 		},
@@ -163,9 +163,9 @@ Without a comment argument, displays the current comment.
 With a comment argument, sets the comment.
 Use --delete to remove the comment.`,
 		Args: cobra.RangeArgs(1, 2),
-		Example: `  tc run comment 12345
-  tc run comment 12345 "Deployed to production"
-  tc run comment 12345 --delete`,
+		Example: `  teamcity run comment 12345
+  teamcity run comment 12345 "Deployed to production"
+  teamcity run comment 12345 --delete`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			comment := ""
 			if len(args) > 1 {

--- a/internal/cmd/skill.go
+++ b/internal/cmd/skill.go
@@ -36,13 +36,13 @@ func newSkillInstallCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "install",
 		Short: "Install the teamcity-cli skill for AI coding agents",
-		Long: `Install the teamcity-cli skill so AI coding agents can use tc commands.
+		Long: `Install the teamcity-cli skill so AI coding agents can use teamcity commands.
 
 Installs globally by default. Use --project to install to the current project only.
 Auto-detects installed agents when --agent is not specified.`,
-		Example: `  tc skill install
-  tc skill install --agent claude-code --agent cursor
-  tc skill install --project`,
+		Example: `  teamcity skill install
+  teamcity skill install --agent claude-code --agent cursor
+  teamcity skill install --project`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSkillInstall(opts, false)
 		},
@@ -58,13 +58,13 @@ func newSkillUpdateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "update",
 		Short: "Update the teamcity-cli skill for AI coding agents",
-		Long: `Update the teamcity-cli skill to the latest version bundled with this tc release.
+		Long: `Update the teamcity-cli skill to the latest version bundled with this teamcity release.
 
 Skips if the installed version already matches.
 Auto-detects installed agents when --agent is not specified.`,
-		Example: `  tc skill update
-  tc skill update --agent claude-code
-  tc skill update --project`,
+		Example: `  teamcity skill update
+  teamcity skill update --agent claude-code
+  teamcity skill update --project`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSkillInstall(opts, true)
 		},
@@ -130,9 +130,9 @@ func newSkillRemoveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove",
 		Short: "Remove the teamcity-cli skill from AI coding agents",
-		Example: `  tc skill remove
-  tc skill remove --agent claude-code
-  tc skill remove --project`,
+		Example: `  teamcity skill remove
+  teamcity skill remove --agent claude-code
+  teamcity skill remove --project`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSkillRemove(opts)
 		},

--- a/internal/cmd/watchtui.go
+++ b/internal/cmd/watchtui.go
@@ -272,7 +272,7 @@ func runWatchTUI(client api.ClientInterface, runID string, interval int) error {
 			}
 		} else {
 			fmt.Println(output.Faint("Build still running in background"))
-			fmt.Printf("Resume: tc run watch %s --logs\n", fm.runID)
+			fmt.Printf("Resume: teamcity run watch %s --logs\n", fm.runID)
 		}
 		fmt.Printf("View details: %s\n", fm.build.WebURL)
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -36,7 +36,7 @@ func WithSuggestion(message, suggestion string) *UserError {
 func NotAuthenticated() *UserError {
 	return &UserError{
 		Message:    "Not authenticated",
-		Suggestion: "Run 'tc auth login' to authenticate with TeamCity",
+		Suggestion: "Run 'teamcity auth login' to authenticate with TeamCity",
 	}
 }
 
@@ -44,7 +44,7 @@ func NotAuthenticated() *UserError {
 func NotFound(resource, id string) *UserError {
 	return &UserError{
 		Message:    fmt.Sprintf("%s '%s' not found", resource, id),
-		Suggestion: fmt.Sprintf("Run 'tc %s list' to see available %ss", resource, resource),
+		Suggestion: fmt.Sprintf("Run 'teamcity %s list' to see available %ss", resource, resource),
 	}
 }
 
@@ -52,7 +52,7 @@ func NotFound(resource, id string) *UserError {
 func AuthenticationFailed() *UserError {
 	return &UserError{
 		Message:    "Authentication failed: invalid or expired token",
-		Suggestion: "Run 'tc auth login' to re-authenticate",
+		Suggestion: "Run 'teamcity auth login' to re-authenticate",
 	}
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -52,7 +52,7 @@ func TestNotAuthenticated(T *testing.T) {
 	T.Parallel()
 	err := NotAuthenticated()
 	assert.Contains(T, err.Message, "Not authenticated")
-	assert.Contains(T, err.Suggestion, "tc auth login")
+	assert.Contains(T, err.Suggestion, "teamcity auth login")
 }
 
 func TestNotFound(T *testing.T) {
@@ -67,7 +67,7 @@ func TestAuthenticationFailed(T *testing.T) {
 	T.Parallel()
 	err := AuthenticationFailed()
 	assert.Contains(T, err.Message, "Authentication failed")
-	assert.Contains(T, err.Suggestion, "tc auth login")
+	assert.Contains(T, err.Suggestion, "teamcity auth login")
 }
 
 func TestPermissionDenied(T *testing.T) {

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ set quiet
 
 # Build the CLI binary
 build:
-    go build -o bin/tc ./tc
+    go build -o bin/teamcity ./tc
 
 # Format and lint the codebase
 lint:

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -2,24 +2,24 @@
 name: teamcity-cli
 version: "0.5.0"
 author: JetBrains
-description: Use when working with TeamCity CI/CD or when user provides a TeamCity build URL. Use `tc` CLI for builds, logs, jobs, queues, agents, and pipelines.
+description: Use when working with TeamCity CI/CD or when user provides a TeamCity build URL. Use `teamcity` CLI for builds, logs, jobs, queues, agents, and pipelines.
 ---
 
-# TeamCity CLI (`tc`)
+# TeamCity CLI (`teamcity`)
 
 ## Quick Start
 
 ```bash
-tc auth status                    # Check authentication
-tc run list --status failure      # Find failed builds
-tc run log <id> --failed          # View failed build log
+teamcity auth status                    # Check authentication
+teamcity run list --status failure      # Find failed builds
+teamcity run log <id> --failed          # View failed build log
 ```
 
 ## Before Running Commands
 
-**Do not guess subcommands, flags, or syntax.** Only use commands and flags documented in the [Command Reference](references/commands.md) or shown by `tc <command> --help`. If a command doesn't support what you need, fall back to `tc api /app/rest/...`.
+**Do not guess subcommands, flags, or syntax.** Only use commands and flags documented in the [Command Reference](references/commands.md) or shown by `teamcity <command> --help`. If a command doesn't support what you need, fall back to `teamcity api /app/rest/...`.
 
-**Terminology:** There is no `build`, `pipeline`, or `config` subcommand. Builds are **runs** (`tc run`). Build configurations are **jobs** (`tc job`).
+**Terminology:** There is no `build`, `pipeline`, or `config` subcommand. Builds are **runs** (`teamcity run`). Build configurations are **jobs** (`teamcity job`).
 
 ## Core Commands
 
@@ -33,14 +33,14 @@ tc run log <id> --failed          # View failed build log
 | Queue     | `queue list`, `approve`, `remove`, `top`                                              |
 | Agents    | `agent list`, `view`, `enable/disable`, `authorize`, `exec`, `term`, `reboot`, `move` |
 | Pools     | `pool list`, `view`, `link/unlink`                                                    |
-| API       | `tc api <endpoint>` — raw REST API access                                             |
+| API       | `teamcity api <endpoint>` — raw REST API access                                             |
 
 ## Quick Workflows
 
-**Investigate failure:** `tc run list --status failure` → `tc run log <id> --failed` → `tc run tests <id> --failed`
-**From a URL:** Extract build ID from `https://host/buildConfiguration/ConfigId/12345` → `tc run view 12345`
-**Start build:** `tc run start <job-id> --branch <branch> --watch`
-**Find jobs:** `tc project list` → `tc job list --project <id>`
+**Investigate failure:** `teamcity run list --status failure` → `teamcity run log <id> --failed` → `teamcity run tests <id> --failed`
+**From a URL:** Extract build ID from `https://host/buildConfiguration/ConfigId/12345` → `teamcity run view 12345`
+**Start build:** `teamcity run start <job-id> --branch <branch> --watch`
+**Find jobs:** `teamcity project list` → `teamcity job list --project <id>`
 
 ## References
 

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -1,39 +1,39 @@
 # Command Reference
 
-## Authentication (`tc auth`)
+## Authentication (`teamcity auth`)
 
 | Command                  | Description                       |
 |--------------------------|-----------------------------------|
-| `tc auth login -s <url>` | Authenticate with TeamCity server |
-| `tc auth logout`         | Log out from current server       |
-| `tc auth status`         | Show auth status and server info  |
+| `teamcity auth login -s <url>` | Authenticate with TeamCity server |
+| `teamcity auth logout`         | Log out from current server       |
+| `teamcity auth status`         | Show auth status and server info  |
 
 Login options:
 - `-s, --server <url>` - TeamCity server URL
 - `-t, --token <token>` - Access token
 
-## Builds/Runs (`tc run`)
+## Builds/Runs (`teamcity run`)
 
 | Command                    | Description                |
 |----------------------------|----------------------------|
-| `tc run list`              | List recent builds         |
-| `tc run view <id>`         | View build details         |
-| `tc run start <job-id>`    | Start a new build          |
-| `tc run cancel <id>`       | Cancel a build             |
-| `tc run restart <id>`      | Restart a build            |
-| `tc run watch <id>`        | Watch build in real-time   |
-| `tc run log <id>`          | View build log             |
-| `tc run tests <id>`        | View test results          |
-| `tc run changes <id>`      | View VCS changes           |
-| `tc run artifacts <id>`    | List artifacts             |
-| `tc run download <id>`     | Download artifacts         |
-| `tc run pin <id>`          | Pin build                  |
-| `tc run unpin <id>`        | Unpin build                |
-| `tc run tag <id> <tags>`   | Add tags                   |
-| `tc run untag <id> <tags>` | Remove tags                |
-| `tc run comment <id>`      | Manage comments            |
+| `teamcity run list`              | List recent builds         |
+| `teamcity run view <id>`         | View build details         |
+| `teamcity run start <job-id>`    | Start a new build          |
+| `teamcity run cancel <id>`       | Cancel a build             |
+| `teamcity run restart <id>`      | Restart a build            |
+| `teamcity run watch <id>`        | Watch build in real-time   |
+| `teamcity run log <id>`          | View build log             |
+| `teamcity run tests <id>`        | View test results          |
+| `teamcity run changes <id>`      | View VCS changes           |
+| `teamcity run artifacts <id>`    | List artifacts             |
+| `teamcity run download <id>`     | Download artifacts         |
+| `teamcity run pin <id>`          | Pin build                  |
+| `teamcity run unpin <id>`        | Unpin build                |
+| `teamcity run tag <id> <tags>`   | Add tags                   |
+| `teamcity run untag <id> <tags>` | Remove tags                |
+| `teamcity run comment <id>`      | Manage comments            |
 
-### Flags for `tc run list`
+### Flags for `teamcity run list`
 
 Shows all branches and all build states (including canceled, personal, composite sub-builds) by default — matching the TeamCity UI. Use `--branch` to narrow to a specific branch.
 
@@ -50,7 +50,7 @@ Shows all branches and all build states (including canceled, personal, composite
 - `--no-header` - Omit header row (use with --plain)
 - `-w, --web` - Open in browser
 
-### Flags for `tc run start`
+### Flags for `teamcity run start`
 
 - `-b, --branch <name>` - Branch to build
 - `-P, --param <k=v>` - Build parameter (repeatable)
@@ -71,186 +71,186 @@ Shows all branches and all build states (including canceled, personal, composite
 - `--json` - Output as JSON (for scripting)
 - `-w, --web` - Open run in browser
 
-### Flags for `tc run log`
+### Flags for `teamcity run log`
 
 - `--failed` - Show failure summary (problems and failed tests)
 - `-j, --job <id>` - Get log for latest run of this job
 - `--raw` - Show raw log without formatting
 
-### Flags for `tc run watch`
+### Flags for `teamcity run watch`
 
 - `-i, --interval <s>` - Refresh interval in seconds
 - `--logs` - Stream build logs while watching
 - `-Q, --quiet` - Minimal output, show only state changes and result
 - `--timeout <duration>` - Timeout duration (e.g., 30m, 1h)
 
-### Flags for `tc run view`
+### Flags for `teamcity run view`
 
 - `--json` - Output as JSON
 - `-w, --web` - Open in browser
 
-### Flags for `tc run tests`
+### Flags for `teamcity run tests`
 
 - `--failed` - Show only failed tests
 - `-j, --job <id>` - Get tests for latest run of this job
 - `--json` - Output as JSON
 - `-n, --limit <n>` - Maximum number of tests to show
 
-### Flags for `tc run changes`
+### Flags for `teamcity run changes`
 
 - `--json` - Output as JSON
 - `--no-files` - Hide file list, show commits only
 
-### Flags for `tc run artifacts`
+### Flags for `teamcity run artifacts`
 
 - `-j, --job <id>` - List artifacts from latest run of this job
 - `--json` - Output as JSON
 
-### Flags for `tc run download`
+### Flags for `teamcity run download`
 
 - `-a, --artifact <pattern>` - Artifact name pattern to download
 - `-d, --dir <path>` - Directory to download artifacts to
 
-### Flags for `tc run cancel`
+### Flags for `teamcity run cancel`
 
 - `--comment <text>` - Comment for cancellation
 - `-f, --force` - Skip confirmation prompt
 
-### Flags for `tc run restart`
+### Flags for `teamcity run restart`
 
 - `--watch` - Watch the new run after restarting
 - `-w, --web` - Open run in browser
 
-### Flags for `tc run pin`
+### Flags for `teamcity run pin`
 
 - `-m, --comment <text>` - Comment explaining why the run is pinned
 
-### Flags for `tc run comment`
+### Flags for `teamcity run comment`
 
 - `--delete` - Delete the comment
 
-## Jobs (`tc job`)
+## Jobs (`teamcity job`)
 
 | Command                              | Description               |
 |--------------------------------------|---------------------------|
-| `tc job list`                        | List build configurations |
-| `tc job view <id>`                   | View job details          |
-| `tc job pause <id>`                  | Pause job                 |
-| `tc job resume <id>`                 | Resume job                |
-| `tc job param list <id>`             | List parameters           |
-| `tc job param get <id> <name>`       | Get parameter             |
-| `tc job param set <id> <name> <val>` | Set parameter             |
-| `tc job param delete <id> <name>`    | Delete parameter          |
+| `teamcity job list`                        | List build configurations |
+| `teamcity job view <id>`                   | View job details          |
+| `teamcity job pause <id>`                  | Pause job                 |
+| `teamcity job resume <id>`                 | Resume job                |
+| `teamcity job param list <id>`             | List parameters           |
+| `teamcity job param get <id> <name>`       | Get parameter             |
+| `teamcity job param set <id> <name> <val>` | Set parameter             |
+| `teamcity job param delete <id> <name>`    | Delete parameter          |
 
-### Flags for `tc job list`
+### Flags for `teamcity job list`
 
 - `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
 - `-n, --limit <n>` - Maximum number of jobs
 - `-p, --project <id>` - Filter by project ID
 
-### Flags for `tc job view`
+### Flags for `teamcity job view`
 
 - `--json` - Output as JSON
 - `-w, --web` - Open in browser
 
-### Flags for `tc job param list`
+### Flags for `teamcity job param list`
 
 - `--json` - Output as JSON
 
-### Flags for `tc job param set`
+### Flags for `teamcity job param set`
 
 - `--secure` - Mark as secure/password parameter
 
-## Projects (`tc project`)
+## Projects (`teamcity project`)
 
 | Command                                  | Description                  |
 |------------------------------------------|------------------------------|
-| `tc project list`                        | List projects                |
-| `tc project view <id>`                   | View project details         |
-| `tc project param list <id>`             | List parameters              |
-| `tc project param get <id> <name>`       | Get parameter                |
-| `tc project param set <id> <name> <val>` | Set parameter                |
-| `tc project param delete <id> <name>`    | Delete parameter             |
-| `tc project token put <id>`              | Store secret, get token      |
-| `tc project token get <id> <token>`      | Retrieve secret              |
-| `tc project settings export <id>`        | Export settings as ZIP       |
-| `tc project settings status <id>`        | Show versioned settings sync |
-| `tc project settings validate`           | Validate Kotlin DSL config   |
+| `teamcity project list`                        | List projects                |
+| `teamcity project view <id>`                   | View project details         |
+| `teamcity project param list <id>`             | List parameters              |
+| `teamcity project param get <id> <name>`       | Get parameter                |
+| `teamcity project param set <id> <name> <val>` | Set parameter                |
+| `teamcity project param delete <id> <name>`    | Delete parameter             |
+| `teamcity project token put <id>`              | Store secret, get token      |
+| `teamcity project token get <id> <token>`      | Retrieve secret              |
+| `teamcity project settings export <id>`        | Export settings as ZIP       |
+| `teamcity project settings status <id>`        | Show versioned settings sync |
+| `teamcity project settings validate`           | Validate Kotlin DSL config   |
 
-### Flags for `tc project list`
+### Flags for `teamcity project list`
 
 - `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
 - `-n, --limit <n>` - Maximum number of projects
 - `-p, --parent <id>` - Filter by parent project ID
 
-### Flags for `tc project view`
+### Flags for `teamcity project view`
 
 - `--json` - Output as JSON
 - `-w, --web` - Open in browser
 
-### Flags for `tc project param list`
+### Flags for `teamcity project param list`
 
 - `--json` - Output as JSON
 
-### Flags for `tc project param set`
+### Flags for `teamcity project param set`
 
 - `--secure` - Mark as secure/password parameter
 
-### Flags for `tc project settings export`
+### Flags for `teamcity project settings export`
 
 - `--kotlin` - Export as Kotlin DSL (default)
 - `--xml` - Export as XML
 - `-o, --output <path>` - Output file path (default: projectSettings.zip)
 - `--relative-ids` - Use relative IDs in exported settings
 
-### Flags for `tc project settings status`
+### Flags for `teamcity project settings status`
 
 - `--json` - Output as JSON
 
-### Flags for `tc project settings validate`
+### Flags for `teamcity project settings validate`
 
 - `-v, --verbose` - Show full Maven output
 
-### Flags for `tc project token put`
+### Flags for `teamcity project token put`
 
 - `--stdin` - Read value from stdin
 
-## Queue (`tc queue`)
+## Queue (`teamcity queue`)
 
 | Command                 | Description           |
 |-------------------------|-----------------------|
-| `tc queue list`         | List queued builds    |
-| `tc queue remove <id>`  | Remove from queue     |
-| `tc queue top <id>`     | Move to top of queue  |
-| `tc queue approve <id>` | Approve waiting build |
+| `teamcity queue list`         | List queued builds    |
+| `teamcity queue remove <id>`  | Remove from queue     |
+| `teamcity queue top <id>`     | Move to top of queue  |
+| `teamcity queue approve <id>` | Approve waiting build |
 
-### Flags for `tc queue list`
+### Flags for `teamcity queue list`
 
 - `-j, --job <id>` - Filter by job ID
 - `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
 - `-n, --limit <n>` - Maximum number of queued runs
 
-### Flags for `tc queue remove`
+### Flags for `teamcity queue remove`
 
 - `-f, --force` - Skip confirmation prompt
 
-## Agents (`tc agent`)
+## Agents (`teamcity agent`)
 
 | Command                     | Description                       |
 |-----------------------------|-----------------------------------|
-| `tc agent list`             | List build agents                 |
-| `tc agent view <id>`        | View agent details                |
-| `tc agent authorize <id>`   | Authorize agent to run builds     |
-| `tc agent deauthorize <id>` | Revoke agent authorization        |
-| `tc agent enable <id>`      | Enable agent                      |
-| `tc agent disable <id>`     | Disable agent                     |
-| `tc agent move <id> <pool>` | Move agent to different pool      |
-| `tc agent jobs <id>`        | List compatible/incompatible jobs |
-| `tc agent exec <id> <cmd>`  | Execute command on agent          |
-| `tc agent term <id>`        | Open interactive shell on agent   |
-| `tc agent reboot <id>`      | Reboot a build agent              |
+| `teamcity agent list`             | List build agents                 |
+| `teamcity agent view <id>`        | View agent details                |
+| `teamcity agent authorize <id>`   | Authorize agent to run builds     |
+| `teamcity agent deauthorize <id>` | Revoke agent authorization        |
+| `teamcity agent enable <id>`      | Enable agent                      |
+| `teamcity agent disable <id>`     | Disable agent                     |
+| `teamcity agent move <id> <pool>` | Move agent to different pool      |
+| `teamcity agent jobs <id>`        | List compatible/incompatible jobs |
+| `teamcity agent exec <id> <cmd>`  | Execute command on agent          |
+| `teamcity agent term <id>`        | Open interactive shell on agent   |
+| `teamcity agent reboot <id>`      | Reboot a build agent              |
 
-### Flags for `tc agent list`
+### Flags for `teamcity agent list`
 
 - `-p, --pool <name>` - Filter by agent pool
 - `--connected` - Show only connected agents
@@ -259,59 +259,59 @@ Shows all branches and all build states (including canceled, personal, composite
 - `-n, --limit <n>` - Limit results
 - `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
 
-### Flags for `tc agent view`
+### Flags for `teamcity agent view`
 
 - `--json` - Output as JSON
 - `-w, --web` - Open in browser
 
-### Flags for `tc agent jobs`
+### Flags for `teamcity agent jobs`
 
 - `--incompatible` - Show incompatible jobs with reasons
 - `--json` - Output as JSON
 
-### Flags for `tc agent exec`
+### Flags for `teamcity agent exec`
 
 - `--timeout <duration>` - Command timeout
 
-### Flags for `tc agent reboot`
+### Flags for `teamcity agent reboot`
 
 - `--after-build` - Wait for current build to finish before rebooting
 - `-y, --yes` - Skip confirmation prompt
 
-## Agent Pools (`tc pool`)
+## Agent Pools (`teamcity pool`)
 
 | Command                          | Description              |
 |----------------------------------|--------------------------|
-| `tc pool list`                   | List agent pools         |
-| `tc pool view <id>`              | View pool details        |
-| `tc pool link <id> <project>`    | Link project to pool     |
-| `tc pool unlink <id> <project>`  | Unlink project from pool |
+| `teamcity pool list`                   | List agent pools         |
+| `teamcity pool view <id>`              | View pool details        |
+| `teamcity pool link <id> <project>`    | Link project to pool     |
+| `teamcity pool unlink <id> <project>`  | Unlink project from pool |
 
-### Flags for `tc pool list`
+### Flags for `teamcity pool list`
 
 - `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
 
-### Flags for `tc pool view`
+### Flags for `teamcity pool view`
 
 - `--json` - Output as JSON
 - `-w, --web` - Open in browser
 
-## Direct API (`tc api`)
+## Direct API (`teamcity api`)
 
 For features not covered by specific commands. Endpoints always start with `/app/rest/`.
 
 ```bash
 # GET request
-tc api /app/rest/server
+teamcity api /app/rest/server
 
 # POST request
-tc api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
+teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
 
 # With pagination
-tc api /app/rest/builds --paginate --slurp
+teamcity api /app/rest/builds --paginate --slurp
 
 # Browse artifact subdirectory
-tc api /app/rest/builds/id:BUILD_ID/artifacts/children/SUBPATH
+teamcity api /app/rest/builds/id:BUILD_ID/artifacts/children/SUBPATH
 ```
 
 ### Flags

--- a/skills/teamcity-cli/references/output.md
+++ b/skills/teamcity-cli/references/output.md
@@ -16,22 +16,22 @@ Most commands support multiple output formats for different use cases.
 
 **Default JSON (all fields):**
 ```bash
-tc run list --json
+teamcity run list --json
 ```
 
 **List available fields:**
 ```bash
-tc run list --json=
+teamcity run list --json=
 ```
 
 **Select specific fields:**
 ```bash
-tc run list --json=id,status,webUrl
+teamcity run list --json=id,status,webUrl
 ```
 
 **Nested fields (dot notation):**
 ```bash
-tc run list --json=id,buildType.name,triggered.user.username
+teamcity run list --json=id,buildType.name,triggered.user.username
 ```
 
 ## Available JSON Fields by Command
@@ -45,43 +45,43 @@ tc run list --json=id,buildType.name,triggered.user.username
 | `agent list`   | `id`, `name`, `connected`, `enabled`, `authorized`                                                                                                                                                    |
 | `pool list`    | `id`, `name`, `maxAgents`                                                                                                                                                                             |
 
-Run `tc <command> --json=` to see all available fields for that command.
+Run `teamcity <command> --json=` to see all available fields for that command.
 
 ## Scripting Examples
 
 **Get build IDs of failed builds:**
 ```bash
-tc run list --status failure --plain --no-header | awk '{print $1}'
+teamcity run list --status failure --plain --no-header | awk '{print $1}'
 ```
 
 **JSON with jq:**
 ```bash
-tc run list --json | jq '.[] | {id, status, branch}'
+teamcity run list --json | jq '.[] | {id, status, branch}'
 ```
 
 **Get build IDs that failed (JSON):**
 ```bash
-tc run list --status failure --json=id | jq -r '.[].id'
+teamcity run list --status failure --json=id | jq -r '.[].id'
 ```
 
 **Export runs to CSV:**
 ```bash
-tc run list --json=id,status,branchName | jq -r '.[] | [.id,.status,.branchName] | @csv'
+teamcity run list --json=id,status,branchName | jq -r '.[] | [.id,.status,.branchName] | @csv'
 ```
 
 **Filter builds by pattern:**
 ```bash
-tc run list --json | jq '.[] | select(.branch | contains("feature"))'
+teamcity run list --json | jq '.[] | select(.branch | contains("feature"))'
 ```
 
 **Count builds by status:**
 ```bash
-tc run list --json | jq 'group_by(.status) | map({status: .[0].status, count: length})'
+teamcity run list --json | jq 'group_by(.status) | map({status: .[0].status, count: length})'
 ```
 
 **Get web URLs for queued builds:**
 ```bash
-tc queue list --json=webUrl | jq -r '.[].webUrl'
+teamcity queue list --json=webUrl | jq -r '.[].webUrl'
 ```
 
 ## Environment Variables
@@ -93,7 +93,7 @@ export TEAMCITY_URL="https://teamcity.example.com"
 export TEAMCITY_TOKEN="your-api-token"
 
 # Commands will use these automatically
-tc run list
+teamcity run list
 ```
 
 Environment variables always take precedence over config file settings.
@@ -102,15 +102,15 @@ Environment variables always take precedence over config file settings.
 
 **Open in browser:**
 ```bash
-tc run view <id> -w
+teamcity run view <id> -w
 ```
 
 **Pipe to less with color:**
 ```bash
-tc run list | less -R
+teamcity run list | less -R
 ```
 
 **Watch and notify:**
 ```bash
-tc run watch <id> && notify-send "Build complete"
+teamcity run watch <id> && notify-send "Build complete"
 ```

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -2,452 +2,452 @@
 
 ## Inspecting a Build from a TeamCity URL
 
-When a user provides a TeamCity URL, parse it and map to `tc` commands.
+When a user provides a TeamCity URL, parse it and map to `teamcity` commands.
 
 **Format 1: Specific build** — `https://host/buildConfiguration/ConfigId/12345`
 ```bash
 # Extract build ID (last numeric path segment): 12345
-tc run view 12345
+teamcity run view 12345
 # If failed:
-tc run log 12345 --failed
-tc run tests 12345 --failed
+teamcity run log 12345 --failed
+teamcity run tests 12345 --failed
 ```
 
 **Format 2: Build configuration** — `https://host/buildConfiguration/ConfigId`
 ```bash
 # Extract config ID (last non-numeric path segment): ConfigId
-tc run list --job ConfigId
+teamcity run list --job ConfigId
 ```
 
 **Format 3: Project** — `https://host/project/ProjectId`
 ```bash
 # Extract project ID: ProjectId
-tc job list --project ProjectId
+teamcity job list --project ProjectId
 ```
 
 Strip query params (`?mode=builds`) and fragments (`#all-projects`) before parsing.
 
 ## Investigating a Build Failure
 
-When a build has **FAILURE** status, proactively suggest: `tc run log <id> --failed` (failure summary), `tc run tests <id> --failed` (failed tests), `tc run changes <id>` (triggering changes).
+When a build has **FAILURE** status, proactively suggest: `teamcity run log <id> --failed` (failure summary), `teamcity run tests <id> --failed` (failed tests), `teamcity run changes <id>` (triggering changes).
 
-For **composite/matrix builds** (snapshot dependencies, no agent), find failed children with `tc run list --status failure` and appropriate filters.
+For **composite/matrix builds** (snapshot dependencies, no agent), find failed children with `teamcity run list --status failure` and appropriate filters.
 
 1. **Find the failed build:**
    ```bash
-   tc run list --status failure -n 10
+   teamcity run list --status failure -n 10
    ```
 
 2. **View build details:**
    ```bash
-   tc run view <run-id>
+   teamcity run view <run-id>
    ```
 
 3. **Check the build log:**
    ```bash
-   tc run log <run-id>
+   teamcity run log <run-id>
    ```
 
    For failed steps only:
    ```bash
-   tc run log <run-id> --failed
+   teamcity run log <run-id> --failed
    ```
 
 4. **View test results:**
    ```bash
-   tc run tests <run-id>
+   teamcity run tests <run-id>
    ```
 
    For failed tests only:
    ```bash
-   tc run tests <run-id> --failed
+   teamcity run tests <run-id> --failed
    ```
 
 5. **See what changes triggered the build:**
    ```bash
-   tc run changes <run-id>
+   teamcity run changes <run-id>
    ```
 
 ## Starting and Monitoring Builds
 
 **Start a build:**
 ```bash
-tc run start <job-id>
+teamcity run start <job-id>
 ```
 
 **Start with specific branch:**
 ```bash
-tc run start <job-id> --branch feature/my-branch
+teamcity run start <job-id> --branch feature/my-branch
 ```
 
 **Start with parameters:**
 ```bash
-tc run start <job-id> -P "param1=value1" -P "param2=value2"
+teamcity run start <job-id> -P "param1=value1" -P "param2=value2"
 ```
 
 **Start with env vars and system properties:**
 ```bash
-tc run start <job-id> -P version=1.0 -S build.number=123 -E CI=true
+teamcity run start <job-id> -P version=1.0 -S build.number=123 -E CI=true
 ```
 
 **Start and watch:**
 ```bash
-tc run start <job-id> --watch
+teamcity run start <job-id> --watch
 ```
 
 **Start with comment and tags:**
 ```bash
-tc run start <job-id> --comment "Release build" --tag release --tag v1.0
+teamcity run start <job-id> --comment "Release build" --tag release --tag v1.0
 ```
 
 **Start with clean checkout and rebuild deps:**
 ```bash
-tc run start <job-id> --clean --rebuild-deps --top
+teamcity run start <job-id> --clean --rebuild-deps --top
 ```
 
 **Dry run (see what would be triggered):**
 ```bash
-tc run start <job-id> --dry-run
+teamcity run start <job-id> --dry-run
 ```
 
 **Watch an existing build:**
 ```bash
-tc run watch <run-id>
+teamcity run watch <run-id>
 ```
 
 **Stream logs while watching:**
 ```bash
-tc run watch <run-id> --logs
+teamcity run watch <run-id> --logs
 ```
 
 **Watch with timeout:**
 ```bash
-tc run watch <run-id> --timeout 30m --quiet
+teamcity run watch <run-id> --timeout 30m --quiet
 ```
 
 ## Personal Builds (Local Changes)
 
 **Run build with uncommitted git changes:**
 ```bash
-tc run start <job-id> --local-changes
+teamcity run start <job-id> --local-changes
 ```
 
 **Run build from a patch file:**
 ```bash
-tc run start <job-id> --local-changes changes.patch
+teamcity run start <job-id> --local-changes changes.patch
 ```
 
 **Personal build with specific branch:**
 ```bash
-tc run start <job-id> --personal --branch my-feature --watch
+teamcity run start <job-id> --personal --branch my-feature --watch
 ```
 
 **Skip auto-push:**
 ```bash
-tc run start <job-id> --local-changes --no-push
+teamcity run start <job-id> --local-changes --no-push
 ```
 
 ## Finding Jobs and Projects
 
 **List all projects:**
 ```bash
-tc project list
+teamcity project list
 ```
 
 **List sub-projects:**
 ```bash
-tc project list --parent <project-id>
+teamcity project list --parent <project-id>
 ```
 
 **List jobs in a project:**
 ```bash
-tc job list --project <project-id>
+teamcity job list --project <project-id>
 ```
 
 **View job details:**
 ```bash
-tc job view <job-id>
+teamcity job view <job-id>
 ```
 
 **Search for a job by name:**
 ```bash
-tc job list --json | jq '.[] | select(.name | contains("deploy"))'
+teamcity job list --json | jq '.[] | select(.name | contains("deploy"))'
 ```
 
 ## Working with Build Artifacts
 
 **List artifacts from a build:**
 ```bash
-tc run artifacts <run-id>
+teamcity run artifacts <run-id>
 ```
 
 **List artifacts from latest build of a job:**
 ```bash
-tc run artifacts --job <job-id>
+teamcity run artifacts --job <job-id>
 ```
 
 **Download all artifacts:**
 ```bash
-tc run download <run-id>
+teamcity run download <run-id>
 ```
 
 **Download to specific directory:**
 ```bash
-tc run download <run-id> --dir ./artifacts
+teamcity run download <run-id> --dir ./artifacts
 ```
 
 **Download specific artifact:**
 ```bash
-tc run download <run-id> --artifact "*.jar"
+teamcity run download <run-id> --artifact "*.jar"
 ```
 
 **Browse artifact subdirectory:**
 ```bash
-tc api /app/rest/builds/id:<run-id>/artifacts/children/html_reports
+teamcity api /app/rest/builds/id:<run-id>/artifacts/children/html_reports
 ```
 
 ## Build Metadata
 
 **Pin a build (prevent cleanup):**
 ```bash
-tc run pin <run-id> --comment "Release candidate"
+teamcity run pin <run-id> --comment "Release candidate"
 ```
 
 **Unpin a build:**
 ```bash
-tc run unpin <run-id>
+teamcity run unpin <run-id>
 ```
 
 **Tag a build:**
 ```bash
-tc run tag <run-id> deployed production
+teamcity run tag <run-id> deployed production
 ```
 
 **Remove tags:**
 ```bash
-tc run untag <run-id> deployed
+teamcity run untag <run-id> deployed
 ```
 
 **Add a comment:**
 ```bash
-tc run comment <run-id> "Verified by QA"
+teamcity run comment <run-id> "Verified by QA"
 ```
 
 **View existing comment:**
 ```bash
-tc run comment <run-id>
+teamcity run comment <run-id>
 ```
 
 **Delete a comment:**
 ```bash
-tc run comment <run-id> --delete
+teamcity run comment <run-id> --delete
 ```
 
 ## Managing the Build Queue
 
 **View queued builds:**
 ```bash
-tc queue list
+teamcity queue list
 ```
 
 **Filter queue by job:**
 ```bash
-tc queue list --job <job-id>
+teamcity queue list --job <job-id>
 ```
 
 **Move a build to top of queue:**
 ```bash
-tc queue top <run-id>
+teamcity queue top <run-id>
 ```
 
 **Remove from queue:**
 ```bash
-tc queue remove <run-id>
+teamcity queue remove <run-id>
 ```
 
 **Approve a build waiting for approval:**
 ```bash
-tc queue approve <run-id>
+teamcity queue approve <run-id>
 ```
 
 ## Managing Job and Project Parameters
 
 **List job parameters:**
 ```bash
-tc job param list <job-id>
+teamcity job param list <job-id>
 ```
 
 **Set a parameter:**
 ```bash
-tc job param set <job-id> MY_PARAM "my value"
+teamcity job param set <job-id> MY_PARAM "my value"
 ```
 
 **Set a secure parameter:**
 ```bash
-tc job param set <job-id> SECRET_KEY "****" --secure
+teamcity job param set <job-id> SECRET_KEY "****" --secure
 ```
 
 **Get a parameter:**
 ```bash
-tc job param get <job-id> MY_PARAM
+teamcity job param get <job-id> MY_PARAM
 ```
 
 **Delete a parameter:**
 ```bash
-tc job param delete <job-id> MY_PARAM
+teamcity job param delete <job-id> MY_PARAM
 ```
 
-Project parameters work the same way with `tc project param`.
+Project parameters work the same way with `teamcity project param`.
 
 ## Project Settings (Versioned/DSL)
 
 **Validate Kotlin DSL configuration:**
 ```bash
-tc project settings validate
+teamcity project settings validate
 ```
 
 **Validate with verbose Maven output:**
 ```bash
-tc project settings validate --verbose
+teamcity project settings validate --verbose
 ```
 
 **Check versioned settings sync status:**
 ```bash
-tc project settings status <project-id>
+teamcity project settings status <project-id>
 ```
 
 **Export project settings as Kotlin DSL:**
 ```bash
-tc project settings export <project-id>
+teamcity project settings export <project-id>
 ```
 
 **Export as XML:**
 ```bash
-tc project settings export <project-id> --xml -o settings.zip
+teamcity project settings export <project-id> --xml -o settings.zip
 ```
 
 ## Secure Tokens
 
 **Store a secret and get a token reference:**
 ```bash
-tc project token put <project-id> "my-secret-password"
+teamcity project token put <project-id> "my-secret-password"
 ```
 
 **Store from stdin (for piping):**
 ```bash
-echo -n "my-secret" | tc project token put <project-id> --stdin
+echo -n "my-secret" | teamcity project token put <project-id> --stdin
 ```
 
 **Retrieve a token value (requires System Admin):**
 ```bash
-tc project token get <project-id> "credentialsJSON:abc123..."
+teamcity project token get <project-id> "credentialsJSON:abc123..."
 ```
 
 ## Managing Agents
 
 **List all agents:**
 ```bash
-tc agent list
+teamcity agent list
 ```
 
 **List connected agents only:**
 ```bash
-tc agent list --connected
+teamcity agent list --connected
 ```
 
 **Filter agents by pool:**
 ```bash
-tc agent list --pool Default
+teamcity agent list --pool Default
 ```
 
 **View agent details:**
 ```bash
-tc agent view <agent-id>
+teamcity agent view <agent-id>
 ```
 
 **See what jobs an agent can run:**
 ```bash
-tc agent jobs <agent-id>
+teamcity agent jobs <agent-id>
 ```
 
 **See why jobs are incompatible with an agent:**
 ```bash
-tc agent jobs <agent-id> --incompatible
+teamcity agent jobs <agent-id> --incompatible
 ```
 
 **Enable/disable an agent:**
 ```bash
-tc agent enable <agent-id>
-tc agent disable <agent-id>
+teamcity agent enable <agent-id>
+teamcity agent disable <agent-id>
 ```
 
 **Authorize/deauthorize an agent:**
 ```bash
-tc agent authorize <agent-id>
-tc agent deauthorize <agent-id>
+teamcity agent authorize <agent-id>
+teamcity agent deauthorize <agent-id>
 ```
 
 **Move agent to a different pool:**
 ```bash
-tc agent move <agent-id> <pool-id>
+teamcity agent move <agent-id> <pool-id>
 ```
 
 **Reboot an agent:**
 ```bash
-tc agent reboot <agent-id>
+teamcity agent reboot <agent-id>
 ```
 
 **Reboot after current build finishes:**
 ```bash
-tc agent reboot <agent-id> --after-build
+teamcity agent reboot <agent-id> --after-build
 ```
 
 ## Remote Agent Access
 
 **Open interactive shell on an agent:**
 ```bash
-tc agent term <agent-id>
+teamcity agent term <agent-id>
 ```
 
 **Execute a command on an agent:**
 ```bash
-tc agent exec <agent-id> "ls -la"
+teamcity agent exec <agent-id> "ls -la"
 ```
 
 **Execute with timeout:**
 ```bash
-tc agent exec <agent-id> --timeout 10m -- long-running-script.sh
+teamcity agent exec <agent-id> --timeout 10m -- long-running-script.sh
 ```
 
 ## Managing Agent Pools
 
 **List all pools:**
 ```bash
-tc pool list
+teamcity pool list
 ```
 
 **View pool details:**
 ```bash
-tc pool view <pool-id>
+teamcity pool view <pool-id>
 ```
 
 **Link a project to a pool:**
 ```bash
-tc pool link <pool-id> <project-id>
+teamcity pool link <pool-id> <project-id>
 ```
 
 **Unlink a project from a pool:**
 ```bash
-tc pool unlink <pool-id> <project-id>
+teamcity pool unlink <pool-id> <project-id>
 ```
 
 ## Tips
 
 1. **Use `--json` for programmatic access** - Parse with `jq` for complex queries
 
-2. **Use `tc run log` interactively** - It has built-in search (`/`), navigation (`n`, `N`, `g`, `G`), and filtering (`&pattern`)
+2. **Use `teamcity run log` interactively** - It has built-in search (`/`), navigation (`n`, `N`, `g`, `G`), and filtering (`&pattern`)
 
-3. **Use `tc api` as escape hatch** - When a specific command doesn't exist, use raw API access
+3. **Use `teamcity api` as escape hatch** - When a specific command doesn't exist, use raw API access
 
 4. **Environment variables** - Set `TEAMCITY_URL` and `TEAMCITY_TOKEN` for non-interactive use
 
@@ -455,14 +455,14 @@ tc pool unlink <pool-id> <project-id>
 
 6. **Auto-detection from DSL** – When working in a project with Kotlin DSL config, the server URL is auto-detected from `.teamcity/pom.xml`
 
-7. **Multiple servers** - Use `TEAMCITY_URL` env var to switch between servers, or `tc auth login --server <url>` to add servers
+7. **Multiple servers** - Use `TEAMCITY_URL` env var to switch between servers, or `teamcity auth login --server <url>` to add servers
 
 ## Troubleshooting
 
 | Symptom | Likely Cause | Action |
 |---------|--------------|--------|
-| `401 Unauthorized` | Invalid or expired token | Run `tc auth status` to check; re-login with `tc auth login` |
+| `401 Unauthorized` | Invalid or expired token | Run `teamcity auth status` to check; re-login with `teamcity auth login` |
 | `403 Forbidden` | Insufficient permissions | Build config may require different access rights; check with TeamCity admin |
 | `404 Not Found` | Build deleted or wrong ID | Verify the build ID/URL; the build may have been cleaned up |
-| Connection refused / timeout | Server unreachable | Check if TeamCity instance is accessible; verify server URL with `tc auth status` |
-| `No server configured` | Missing auth config | Run `tc auth login -s <url>` or set `TEAMCITY_URL` and `TEAMCITY_TOKEN` env vars |
+| Connection refused / timeout | Server unreachable | Check if TeamCity instance is accessible; verify server URL with `teamcity auth status` |
+| `No server configured` | Missing auth config | Run `teamcity auth login -s <url>` or set `TEAMCITY_URL` and `TEAMCITY_TOKEN` env vars |


### PR DESCRIPTION
The binary name `tc` clashes with Linux's `tc` (traffic control from iproute2). On distros that merge /usr/sbin into /usr/bin, installing a `tc` package creates a direct file conflict.

Rename the binary to `teamcity` across the entire codebase:
- .goreleaser.yaml: binary, project_name, package_name, nfpm contents, brew install, chocolatey/winget/scoop names, release footer examples, version check hook, signing hook paths
- internal/cmd/: root Use field, version template, all ~48 Example strings, error suggestions, help text
- internal/api/: error hint messages, pin comment, test binary paths
- internal/errors/: user-facing suggestion messages
- install.sh/ps1/cmd: binary name variables, asset URL patterns, find patterns, usage examples
- justfile: build output path
- README.md: 100+ command examples, install instructions, shell completions, alias examples
- CONTRIBUTING.md: build instructions
- skills/: all command references in SKILL.md, commands.md, workflows.md, output.md
- .github/: issue templates, PR template
- .claude-plugin/: plugin descriptions

Unchanged (intentional):
- Config directory ~/.config/tc (avoid orphaning user configs)
- Go package path ./tc (module structure, not binary name)
- DSL directory detection .tc/.teamcity
- Environment variables TC_* (TeamCity env vars)
- Short URLs jb.gg/tc/* (redirect-based)

Users who prefer the short name can create a shell alias:
  alias tc=teamcity
