### PR TITLE
Improve failed tests view

### DIFF
--- a/api/builds.go
+++ b/api/builds.go
@@ -677,7 +677,7 @@ func (c *Client) GetBuildTests(buildID string, failedOnly bool, limit int) (*Tes
 		detailLocator += fmt.Sprintf(",count:%d", summary.Count)
 	}
 
-	detailFields := "testOccurrence(id,name,status,duration,details)"
+	detailFields := "testOccurrence(id,name,status,duration,details,newFailure,firstFailed(build(id,number)))"
 	detailPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", url.QueryEscape(detailLocator), url.QueryEscape(detailFields))
 
 	var details TestOccurrences

--- a/api/types.go
+++ b/api/types.go
@@ -302,13 +302,17 @@ type FileChange struct {
 }
 
 type TestOccurrence struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Status   string `json:"status"` // SUCCESS, FAILURE, IGNORED
-	Duration int    `json:"duration,omitempty"`
-	Details  string `json:"details,omitempty"`
-	Ignored  bool   `json:"ignored,omitempty"`
-	Href     string `json:"href,omitempty"`
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Status     string `json:"status"` // SUCCESS, FAILURE, IGNORED
+	Duration   int    `json:"duration,omitempty"`
+	Details    string `json:"details,omitempty"`
+	NewFailure bool   `json:"newFailure,omitempty"`
+	Ignored    bool   `json:"ignored,omitempty"`
+	Href       string `json:"href,omitempty"`
+
+	FirstFailed *TestOccurrence `json:"firstFailed,omitempty"`
+	Build       *Build          `json:"build,omitempty"`
 }
 
 type TestOccurrences struct {

--- a/internal/cmd/failure_summary.go
+++ b/internal/cmd/failure_summary.go
@@ -54,6 +54,11 @@ func printFailureSummary(client api.ClientInterface, buildID, buildNumber, webUR
 				dur := time.Duration(t.Duration) * time.Millisecond
 				line += " " + output.Faint("("+output.FormatDuration(dur)+")")
 			}
+			if t.NewFailure {
+				line += " " + output.Yellow("(new)")
+			} else if t.FirstFailed != nil && t.FirstFailed.Build != nil {
+				line += " " + output.Faint(fmt.Sprintf("(failing since #%s)", t.FirstFailed.Build.Number))
+			}
 			fmt.Println(line)
 			if t.Details != "" {
 				for dl := range strings.SplitSeq(strings.TrimSpace(t.Details), "\n") {

--- a/internal/cmd/run_analysis.go
+++ b/internal/cmd/run_analysis.go
@@ -198,7 +198,11 @@ func runRunTests(runID string, opts *runTestsOptions) error {
 	}
 
 	if tests.Count == 0 {
-		output.Info("No tests in this run")
+		if opts.failed {
+			output.Success("No failed tests in this run")
+		} else {
+			output.Info("No tests in this run")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
## Summary

Fixes #99

Show full failure diagnostics in `tc run log <id> --failed` — the practical middle ground between terse test names (`--failed`) and the full raw log (`--raw`).

## Changes

- **Full stack traces**: Removed `firstLine()` + `Truncate(120)` truncation — test failure details now display all lines, indented for readability
- **New/pre-existing markers**: Each failed test shows `(new)` or `(failing since #NNN)` so you can instantly triage which failures need attention
- **API fields**: Added `newFailure` and `firstFailed(build(id,number))` to the test occurrences query
- **Better empty state**: `run tests --failed` on a passing build now shows `✓ No failed tests in this run` instead of the misleading `No tests in this run`

## Design Decisions

Instead of adding a new `--failed-details` flag (as discussed in #99), this enhances the existing `--failed` output directly. The truncated single-line display wasn't useful for triage — nobody wants a 120-char prefix of a stack trace. Full details are always better here, and the `maxFailedTestsToShow = 10` cap keeps output bounded.

## Example

```
$ teamcity run log 677938 --failed

✗ Build 677938  #246 failed: Tests failed: 1, passed: 22, ignored: 2

Problems:
  • Process exited with code 1 (Step: Run Tests (Gradle))

Failed tests (1):
  • EndToEndIndexingTest.testLocalOssRepoSearch (3s) (failing since #245)
    HTTPStatusException$InternalServerError: request to .../search with code 500
    	at ai.grazie.model.cloud.exceptions.HTTPStatusException$Companion.from(HTTPStatusException.kt:281)
    	at ai.grazie.utils.http.UtilsKt.of(utils.kt:130)
    	at ai.grazie.client.ktor.GrazieKtorHTTPClient.sendAndWaitBody(GrazieKtorHTTPClient.kt:168)
    	...

View details: https://jetbrains-ai.internal.teamcity.cloud/...
```

New failures are highlighted differently:
```
  • GermanRuleTest.testRule{Rule[11] (2s) (new)
    org.opentest4j.AssertionFailedError: Found 1 failures ==> expected: <2096/3367
    ...
```

## Test Plan

- [x] Tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run`)
- [x] Manually tested against jetbrains-ai.internal.teamcity.cloud