### PR TITLE
fix(auth): only show guest access hint when server supports it

### DIFF
--- a/acceptance/testdata/auth/auth-status-invalid-token.txtar
+++ b/acceptance/testdata/auth/auth-status-invalid-token.txtar
@@ -2,6 +2,7 @@
 
 env TEAMCITY_URL=$TC_HOST
 env TEAMCITY_TOKEN=definitely-not-a-valid-token
+env TEAMCITY_GUEST=
 
 exec teamcity auth status --no-input
 stdout 'Token is invalid or expired'

--- a/internal/cmd/agent_terminal.go
+++ b/internal/cmd/agent_terminal.go
@@ -65,7 +65,7 @@ func connectToAgent(ctx context.Context, nameOrID string, showProgress bool) (*t
 	serverURL := config.GetServerURL()
 	token := config.GetToken()
 	if serverURL == "" || token == "" {
-		return nil, tcerrors.NotAuthenticated()
+		return nil, notAuthenticatedError(serverURL)
 	}
 
 	client, err := getClient()

--- a/internal/cmd/project.go
+++ b/internal/cmd/project.go
@@ -826,7 +826,7 @@ func defaultGetClient() (api.ClientInterface, error) {
 		return api.NewClientWithBasicAuth(serverURL, buildAuth.Username, buildAuth.Password, debugOpt, roOpt), nil
 	}
 
-	return nil, tcerrors.NotAuthenticated()
+	return nil, notAuthenticatedError(serverURL)
 }
 
 func newProjectTreeCmd() *cobra.Command {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -36,7 +36,7 @@ func WithSuggestion(message, suggestion string) *UserError {
 func NotAuthenticated() *UserError {
 	return &UserError{
 		Message:    "Not authenticated",
-		Suggestion: "Run 'teamcity auth login' to authenticate, or set TEAMCITY_GUEST=1 for guest access",
+		Suggestion: "Run 'teamcity auth login' to authenticate",
 	}
 }
 

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -53,6 +53,7 @@ func TestNotAuthenticated(T *testing.T) {
 	err := NotAuthenticated()
 	assert.Contains(T, err.Message, "Not authenticated")
 	assert.Contains(T, err.Suggestion, "teamcity auth login")
+	assert.NotContains(T, err.Suggestion, "TEAMCITY_GUEST")
 }
 
 func TestNotFound(T *testing.T) {


### PR DESCRIPTION
## Summary

The "Not authenticated" hint always showed `set TEAMCITY_GUEST=1 for guest access` even on servers without guest access enabled.

## Changes

- Remove hardcoded guest hint from `errors.NotAuthenticated()`
- Extract `probeGuestAccess()` from `printLoginHint` for reuse
- Add `notAuthenticatedError(serverURL)` that probes the server and appends the guest hint only when supported
- Use it in `defaultGetClient` and `connectToAgent`

## Example

```bash
# Server without guest access — no guest hint shown
$ TEAMCITY_URL=https://no-guest.example.com teamcity run list
Error: Not authenticated

Hint: Run 'teamcity auth login' to authenticate

# Server with guest access — hint included
$ TEAMCITY_URL=https://guest-enabled.example.com teamcity run list
Error: Not authenticated

Hint: Run 'teamcity auth login' to authenticate, or set TEAMCITY_GUEST=1 for guest access
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)