### PR TITLE
fix(api): ensure API paths consistently start with "/" in `apiPath` (#126)

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -190,6 +190,9 @@ func NewGuestClient(baseURL string, opts ...ClientOption) *Client {
 
 // apiPath returns the API path, optionally with version prefix
 func (c *Client) apiPath(path string) string {
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
 	if c.APIVersion != "" && strings.HasPrefix(path, "/app/rest/") {
 		path = strings.Replace(path, "/app/rest/", "/app/rest/"+c.APIVersion+"/", 1)
 	}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -144,6 +144,8 @@ func TestAPIPath(T *testing.T) {
 		{"no version", "", "/app/rest/builds", "/app/rest/builds"},
 		{"with version", "2023.1", "/app/rest/builds", "/app/rest/2023.1/builds"},
 		{"non-rest path unchanged", "2023.1", "/downloadBuildLog.html", "/downloadBuildLog.html"},
+		{"missing leading slash", "", "app/rest/builds", "/app/rest/builds"},
+		{"missing leading slash with version", "2023.1", "app/rest/builds", "/app/rest/2023.1/builds"},
 	}
 
 	for _, tc := range tests {
@@ -835,6 +837,7 @@ func TestGuestClientAPIPath(T *testing.T) {
 		{"rest path with version", "/app/rest/builds", "/guestAuth/app/rest/builds"},
 		{"non-rest path", "/downloadBuildLog.html", "/guestAuth/downloadBuildLog.html"},
 		{"already prefixed", "/guestAuth/app/rest/server", "/guestAuth/app/rest/server"},
+		{"missing leading slash", "app/rest/server", "/guestAuth/app/rest/server"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

Fixes #126

`teamcity api app/rest/version` (without leading `/`) produced `dial tcp: lookup demo.teamcity.comapp: no such host` because `apiPath` concatenated base URL and path without ensuring a separator.

## Changes

- Prepend `/` to path in `apiPath()` when missing
- Add test cases for missing leading slash (standard, versioned, guest auth)

## Example

```bash
# Before: fails with DNS error
teamcity api app/rest/version
# Error: dial tcp: lookup demo.teamcity.comapp: no such host

# After: works identically to the slash-prefixed form
teamcity api app/rest/version
# "2025.11"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)