### PR TITLE
fix(artifacts): fix download for nested paths and add --path flag

### DIFF
--- a/acceptance/testdata/run/run-artifacts.txtar
+++ b/acceptance/testdata/run/run-artifacts.txtar
@@ -17,7 +17,7 @@ exec teamcity run artifacts $BUILD_ID --path . --no-input
 ! stderr 'Error'
 
 # download to temp dir
-exec teamcity run download $BUILD_ID --dir $WORK/artifacts --no-input
+exec teamcity run download $BUILD_ID -o $WORK/artifacts --no-input
 stdout '(downloaded|No artifacts)'
 ! stderr 'Error'
 

--- a/api/builds.go
+++ b/api/builds.go
@@ -11,6 +11,16 @@ import (
 	"strings"
 )
 
+// encodeArtifactPath escapes each segment of an artifact path individually,
+// preserving "/" as path separators.
+func encodeArtifactPath(p string) string {
+	segments := strings.Split(p, "/")
+	for i, s := range segments {
+		segments[i] = url.PathEscape(s)
+	}
+	return strings.Join(segments, "/")
+}
+
 // BuildsOptions represents options for listing builds
 type BuildsOptions struct {
 	BuildTypeID string
@@ -343,7 +353,7 @@ func (c *Client) GetArtifacts(buildID string, subpath string) (*Artifacts, error
 	}
 	p := fmt.Sprintf("/app/rest/builds/id:%s/artifacts/children", id)
 	if subpath != "" {
-		p += "/" + subpath
+		p += "/" + encodeArtifactPath(subpath)
 	}
 
 	var artifacts Artifacts
@@ -360,7 +370,7 @@ func (c *Client) DownloadArtifact(buildID, artifactPath string) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	path := fmt.Sprintf("/app/rest/builds/id:%s/artifacts/content/%s", id, url.PathEscape(artifactPath))
+	path := fmt.Sprintf("/app/rest/builds/id:%s/artifacts/content/%s", id, encodeArtifactPath(artifactPath))
 
 	resp, err := c.doRequest("GET", path, nil)
 	if err != nil {
@@ -382,7 +392,7 @@ func (c *Client) DownloadArtifactTo(ctx context.Context, buildID, artifactPath s
 		return 0, err
 	}
 
-	path := fmt.Sprintf("/app/rest/builds/id:%s/artifacts/content/%s", id, url.PathEscape(artifactPath))
+	path := fmt.Sprintf("/app/rest/builds/id:%s/artifacts/content/%s", id, encodeArtifactPath(artifactPath))
 	reqURL := fmt.Sprintf("%s%s", c.BaseURL, c.apiPath(path))
 
 	req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -753,8 +753,10 @@ Download artifacts from a completed run:
 
 ```Shell
 teamcity run download 12345
-teamcity run download 12345 --dir ./artifacts
+teamcity run download 12345 --path build/assets
+teamcity run download 12345 -o ./artifacts
 teamcity run download 12345 --artifact "*.jar"
+teamcity run download 12345 --path build/assets -a "*.js"
 ```
 
 ## Test results

--- a/internal/cmd/parse_test.go
+++ b/internal/cmd/parse_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseKotlinErrors(T *testing.T) {
@@ -196,4 +199,92 @@ func TestFlattenArtifacts(T *testing.T) {
 			assert.Equal(t, tc.wantNames, names)
 		})
 	}
+}
+
+// mockArtifactClient implements just GetArtifacts for testing fetchAllArtifacts.
+type mockArtifactClient struct {
+	api.ClientInterface
+	responses map[string]*api.Artifacts
+}
+
+func (m *mockArtifactClient) GetArtifacts(buildID, path string) (*api.Artifacts, error) {
+	key := fmt.Sprintf("%s:%s", buildID, path)
+	resp, ok := m.responses[key]
+	if !ok {
+		return &api.Artifacts{}, nil
+	}
+	return resp, nil
+}
+
+func TestFetchAllArtifacts(T *testing.T) {
+	T.Parallel()
+
+	contentRef := new(api.Content{Href: "/download"})
+
+	T.Run("flat files", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockArtifactClient{responses: map[string]*api.Artifacts{
+			"1:": {Count: 2, File: []api.Artifact{
+				{Name: "a.txt", Size: 10, Content: contentRef},
+				{Name: "b.txt", Size: 20, Content: contentRef},
+			}},
+		}}
+
+		got, size, err := fetchAllArtifacts(t.Context(), mock, "1", "")
+		require.NoError(t, err)
+		assert.Equal(t, int64(30), size)
+		assert.Len(t, got, 2)
+		assert.Equal(t, "a.txt", got[0].Name)
+		assert.Equal(t, "b.txt", got[1].Name)
+	})
+
+	T.Run("recursive directories", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockArtifactClient{responses: map[string]*api.Artifacts{
+			"1:": {Count: 2, File: []api.Artifact{
+				{Name: "root.txt", Size: 5, Content: contentRef},
+				{Name: "subdir"},
+			}},
+			"1:subdir": {Count: 1, File: []api.Artifact{
+				{Name: "nested.txt", Size: 15, Content: contentRef},
+			}},
+		}}
+
+		got, size, err := fetchAllArtifacts(t.Context(), mock, "1", "")
+		require.NoError(t, err)
+		assert.Equal(t, int64(20), size)
+		require.Len(t, got, 2)
+		assert.Equal(t, "root.txt", got[0].Name)
+		assert.Equal(t, "subdir/nested.txt", got[1].Name)
+	})
+
+	T.Run("with base path", func(t *testing.T) {
+		t.Parallel()
+		mock := &mockArtifactClient{responses: map[string]*api.Artifacts{
+			"1:build": {Count: 1, File: []api.Artifact{
+				{Name: "app.jar", Size: 100, Content: contentRef},
+			}},
+		}}
+
+		got, size, err := fetchAllArtifacts(t.Context(), mock, "1", "build")
+		require.NoError(t, err)
+		assert.Equal(t, int64(100), size)
+		require.Len(t, got, 1)
+		assert.Equal(t, "build/app.jar", got[0].Name)
+	})
+
+	T.Run("respects context cancellation", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		mock := &mockArtifactClient{responses: map[string]*api.Artifacts{
+			"1:": {Count: 1, File: []api.Artifact{
+				{Name: "a.txt", Size: 10, Content: contentRef},
+			}},
+		}}
+
+		_, _, err := fetchAllArtifacts(ctx, mock, "1", "")
+		assert.ErrorIs(t, err, context.Canceled)
+	})
 }

--- a/internal/cmd/run_artifacts.go
+++ b/internal/cmd/run_artifacts.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -116,7 +117,11 @@ func runRunArtifacts(runID string, opts *runArtifactsOptions) error {
 		fmt.Printf("%-*s  %s\n", nameWidth, a.Name, output.Faint(fmt.Sprintf("%10s", size)))
 	}
 
-	fmt.Printf("\nDownload all: teamcity run download %s\n", runID)
+	if opts.path != "" {
+		fmt.Printf("\nDownload dir: teamcity run download %s --path %s\n", runID, opts.path)
+	} else {
+		fmt.Printf("\nDownload all: teamcity run download %s\n", runID)
+	}
 	fmt.Printf("Download one: teamcity run download %s -a \"<name>\"\n", runID)
 	return nil
 }
@@ -134,15 +139,84 @@ func flattenArtifacts(artifacts []api.Artifact, prefix string) ([]api.Artifact, 
 			result = append(result, nested...)
 			totalSize += size
 		} else {
-			result = append(result, api.Artifact{Name: name, Size: a.Size})
+			result = append(result, api.Artifact{Name: name, Size: a.Size, Content: a.Content, Children: a.Children})
 			totalSize += a.Size
 		}
 	}
 	return result, totalSize
 }
 
+const maxArtifactDepth = 20
+
+// fetchAllArtifacts recursively fetches artifacts, expanding directories via additional API calls.
+func fetchAllArtifacts(ctx context.Context, client api.ClientInterface, runID, basePath string) ([]api.Artifact, int64, error) {
+	return fetchArtifactsRecursive(ctx, client, runID, basePath, 0)
+}
+
+func fetchArtifactsRecursive(ctx context.Context, client api.ClientInterface, runID, basePath string, depth int) ([]api.Artifact, int64, error) {
+	if depth > maxArtifactDepth {
+		return nil, 0, fmt.Errorf("artifact tree exceeds maximum depth (%d)", maxArtifactDepth)
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, 0, ctx.Err()
+	default:
+	}
+
+	artifacts, err := client.GetArtifacts(runID, basePath)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var result []api.Artifact
+	var totalSize int64
+	for _, a := range artifacts.File {
+		name := a.Name
+		if basePath != "" {
+			name = basePath + "/" + a.Name
+		}
+		if a.Content != nil {
+			result = append(result, api.Artifact{Name: name, Size: a.Size, Content: a.Content})
+			totalSize += a.Size
+		} else {
+			nested, size, err := fetchArtifactsRecursive(ctx, client, runID, name, depth+1)
+			if err != nil {
+				return nil, 0, err
+			}
+			result = append(result, nested...)
+			totalSize += size
+		}
+	}
+	return result, totalSize, nil
+}
+
+func filterArtifacts(artifacts []api.Artifact, pattern string) ([]api.Artifact, int64, error) {
+	if _, err := path.Match(pattern, ""); err != nil {
+		return nil, 0, fmt.Errorf("invalid artifact pattern %q: %w", pattern, err)
+	}
+
+	var filtered []api.Artifact
+	var filteredSize int64
+
+	for _, a := range artifacts {
+		if matched, _ := path.Match(pattern, a.Name); matched {
+			filtered = append(filtered, a)
+			filteredSize += a.Size
+			continue
+		}
+		if matched, _ := path.Match(pattern, path.Base(a.Name)); matched {
+			filtered = append(filtered, a)
+			filteredSize += a.Size
+		}
+	}
+
+	return filtered, filteredSize, nil
+}
+
 type runDownloadOptions struct {
-	dir      string
+	output   string
+	path     string
 	artifact string
 }
 
@@ -155,15 +229,18 @@ func newRunDownloadCmd() *cobra.Command {
 		Long:  `Download artifacts from a completed run.`,
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity run download 12345
-  teamcity run download 12345 --dir ./artifacts
-  teamcity run download 12345 --artifact "*.jar"`,
+  teamcity run download 12345 --path build/assets
+  teamcity run download 12345 -o ./artifacts
+  teamcity run download 12345 --artifact "*.jar"
+  teamcity run download 12345 --path build/assets -a "*.js"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunDownload(args[0], opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.dir, "dir", "d", ".", "Directory to download artifacts to")
-	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Artifact name pattern to download")
+	cmd.Flags().StringVarP(&opts.output, "output", "o", ".", "Local directory to save artifacts to")
+	cmd.Flags().StringVarP(&opts.path, "path", "p", "", "Download artifacts under this subdirectory")
+	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Artifact name pattern to filter")
 
 	return cmd
 }
@@ -174,36 +251,36 @@ func runRunDownload(runID string, opts *runDownloadOptions) error {
 		return err
 	}
 
-	if err := os.MkdirAll(opts.dir, 0755); err != nil {
+	absOutput, err := filepath.Abs(opts.output)
+	if err != nil {
+		return fmt.Errorf("failed to resolve output path: %w", err)
+	}
+
+	if err := os.MkdirAll(absOutput, 0755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	artifacts, err := client.GetArtifacts(runID, "")
+	ctx := context.Background()
+
+	flatList, totalSize, err := fetchAllArtifacts(ctx, client, runID, opts.path)
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}
 
-	if artifacts.Count == 0 {
-		fmt.Println("No artifacts found for this run")
+	if len(flatList) == 0 {
+		if opts.path != "" {
+			fmt.Printf("No artifacts found under %s\n", opts.path)
+		} else {
+			fmt.Println("No artifacts found for this run")
+		}
 		return nil
 	}
 
-	flatList, totalSize := flattenArtifacts(artifacts.File, "")
-
 	if opts.artifact != "" {
-		if _, err := filepath.Match(opts.artifact, ""); err != nil {
-			return fmt.Errorf("invalid artifact pattern %q: %w", opts.artifact, err)
+		flatList, totalSize, err = filterArtifacts(flatList, opts.artifact)
+		if err != nil {
+			return err
 		}
-		var filtered []api.Artifact
-		var filteredSize int64
-		for _, a := range flatList {
-			if matched, _ := filepath.Match(opts.artifact, filepath.Base(a.Name)); matched {
-				filtered = append(filtered, a)
-				filteredSize += a.Size
-			}
-		}
-		flatList = filtered
-		totalSize = filteredSize
 	}
 
 	if len(flatList) == 0 {
@@ -220,13 +297,17 @@ func runRunDownload(runID string, opts *runDownloadOptions) error {
 
 	fmt.Printf("Downloading %d %s (%s total) to %s\n\n",
 		len(flatList), english.PluralWord(len(flatList), "file", "files"),
-		humanize.IBytes(uint64(totalSize)), opts.dir)
+		humanize.IBytes(uint64(totalSize)), opts.output)
 	fmt.Printf("%-*s  %10s\n", nameWidth, "NAME", "SIZE")
 
-	ctx := context.Background()
 	downloaded := 0
 	for _, artifact := range flatList {
-		outputPath := filepath.Join(opts.dir, artifact.Name)
+		rel, err := filepath.Rel(absOutput, filepath.Join(absOutput, artifact.Name))
+		if err != nil || !filepath.IsLocal(rel) {
+			fmt.Printf("%-*s  %10s  %s path escapes output directory\n", nameWidth, artifact.Name, "", output.Red("   ✗"))
+			continue
+		}
+		outputPath := filepath.Join(absOutput, rel)
 		size := humanize.IBytes(uint64(artifact.Size))
 
 		if err := downloadArtifact(ctx, client, runID, artifact, outputPath, nameWidth); err != nil {

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamcity-cli
-version: "0.7.0"
+version: "0.8.0"
 author: JetBrains
 description: Use when working with TeamCity CI/CD or when user provides a TeamCity build URL. Use `teamcity` CLI for builds, logs, jobs, queues, and agents.
 ---

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -111,8 +111,9 @@ Shows all branches and all build states (including canceled, personal, composite
 
 ### Flags for `teamcity run download`
 
-- `-a, --artifact <pattern>` - Artifact name pattern to download
-- `-d, --dir <path>` - Directory to download artifacts to
+- `-a, --artifact <pattern>` - Artifact name pattern to filter (matches full path and basename)
+- `-p, --path <subdir>` - Download artifacts under this subdirectory
+- `-o, --output <path>` - Local directory to save artifacts to
 
 ### Flags for `teamcity run cancel`
 

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -193,17 +193,22 @@ teamcity run download <run-id>
 
 **Download to specific directory:**
 ```bash
-teamcity run download <run-id> --dir ./artifacts
+teamcity run download <run-id> -o ./artifacts
 ```
 
-**Download specific artifact:**
+**Download a subdirectory:**
+```bash
+teamcity run download <run-id> --path build/assets
+```
+
+**Download specific artifact pattern:**
 ```bash
 teamcity run download <run-id> --artifact "*.jar"
 ```
 
-**Browse artifact subdirectory:**
+**Combine path and pattern:**
 ```bash
-teamcity api /app/rest/builds/id:<run-id>/artifacts/children/html_reports
+teamcity run download <run-id> --path build/assets -a "*.js"
 ```
 
 ## Build Metadata


### PR DESCRIPTION
## Summary

Fixes #138 

Artifact downloads were broken for nested paths (`build/assets/*` matched nothing, downloading any nested artifact 400'd). This PR fixes path handling and makes `download` consistent with `artifacts` by adding `--path`.

Fixes three bugs:
- `url.PathEscape` encoded `/` as `%2F` in artifact download URLs, causing 400 errors for any nested artifact
- `-a` pattern only matched against basename, so `build/assets/*` never matched `build/assets/index.js`
- No way to download a directory — `artifacts` had `--path` but `download` didn't

## Changes

**`api/builds.go`**
- Add `encodeArtifactPath()` that escapes each path segment individually, preserving `/` separators
- Use it in `DownloadArtifact` and `DownloadArtifactTo` instead of `url.PathEscape`

**`internal/cmd/run_artifacts.go`**
- Add `--path`/`-p` flag to `download` command (consistent with `artifacts`)
- Add `fetchAllArtifacts()` — recursively expands directories via API calls (TeamCity API only returns one level deep)
- Add `filterArtifacts()` — matches `-a` pattern against full path first, then basename
- Rename `--dir`/`-d` to `--output`/`-o` to avoid confusion with `--path`
  - Also, AI agents prefer --output more  
- Preserve `Content`/`Children` fields in `flattenArtifacts` so files vs directories can be distinguished

## Design Decisions

- `--path` scopes server-side (fewer API calls for large artifact trees), `-a` filters client-side (glob flexibility)
- `--output`/`-o` replaces `--dir`/`-d` — follows the `curl -o` / `gcc -o` convention and is clearly "local" vs `--path` which is "remote"
- `fetchAllArtifacts` distinguishes files from directories using the `Content` field (files have it, directories don't)

## Example

```bash
# Download entire subdirectory
teamcity run download 761008 --path build/assets

# Filter by glob within a path
teamcity run download 761008 --path build/assets -a "*.css"

# Full-path glob still works
teamcity run download 761008 -a "build/assets/*"
```

## Test Plan

- [x] Verified `--path build/assets` downloads all 167 files recursively
- [x] Verified `-a "build/assets/*"` matches direct children only
- [x] Verified `--path build/assets -a "*.css"` combines both filters
- [ ] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`