### PR TITLE
fix(install): refactor install scripts

### DIFF
--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -19,6 +19,19 @@ jobs:
       - type: script
         name: Acceptance Tests
         script-content: go test -count=1 -shuffle=on -v -tags=acceptance ./acceptance -timeout 10m
+      - type: script
+        name: Verify install.ps1
+        script-content: |
+          set "TC_INSTALL_DIR=%%TEMP%%\tc-install-ps1"
+          powershell -ExecutionPolicy Bypass -Command "iex (Get-Content install.ps1 -Raw -Encoding UTF8)"
+          "%%TEMP%%\tc-install-ps1\teamcity.exe" --version
+          rmdir /s /q "%%TEMP%%\tc-install-ps1"
+      - type: script
+        name: Verify install.cmd
+        script-content: |
+          call install.cmd "" "%%TEMP%%\tc-install-cmd"
+          "%%TEMP%%\tc-install-cmd\teamcity.exe" --version
+          rmdir /s /q "%%TEMP%%\tc-install-cmd"
   test_linux:
     name: Test Linux
     runs-on: Ubuntu-24.04-Large
@@ -51,6 +64,13 @@ jobs:
           head -1 coverage-integration.out > coverage.out
           tail -n +2 coverage-integration.out >> coverage.out
           tail -n +2 coverage-guest.out >> coverage.out
+      - type: script
+        name: Verify install.sh
+        script-content: |
+          INSTALL_DIR=$(mktemp -d)
+          bash install.sh "" "$INSTALL_DIR"
+          "$INSTALL_DIR/teamcity" --version
+          rm -rf "$INSTALL_DIR"
   test_linux_arm64:
     name: Test Linux ARM64
     runs-on: Ubuntu-24.04-Large-Arm64

--- a/install.cmd
+++ b/install.cmd
@@ -1,60 +1,152 @@
 @echo off
-setlocal
+::
+:: Copyright 2021-2026 JetBrains s.r.o.
+::
+:: Licensed under the Apache License, Version 2.0 (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+:: https://www.apache.org/licenses/LICENSE-2.0
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
 
-set "REPO=JetBrains/teamcity-cli"
+setlocal enabledelayedexpansion
+
+set "RELEASE=%~1"
+set "INSTALL_DIR=%~2"
+if "!INSTALL_DIR!"=="" set "INSTALL_DIR=%USERPROFILE%\.local\bin"
 set "BIN_NAME=teamcity.exe"
-set "INSTALL_DIR=%USERPROFILE%\.local\bin"
+set "REPO=JetBrains/teamcity-cli"
 
-if not exist "%INSTALL_DIR%" (
-    mkdir "%INSTALL_DIR%"
+echo.
+echo  ========= ======
+echo  ==   ==        TeamCity CLI (installer)
+echo     ==   ==        Documentation
+echo     ==   ==        https://jb.gg/tc/docs
+echo     ==    ======   Report issues
+echo     ==     =====   https://jb.gg/tc/issues
+echo.
+echo This script will download TeamCity CLI to !INSTALL_DIR!\!BIN_NAME!
+echo.
+echo To install a specific version: install.cmd v0.7.0
+echo.
+
+:: Check curl is available (ships with Windows 10+)
+curl --version >nul 2>&1
+if !ERRORLEVEL! neq 0 (
+    echo Error: curl is required but not found. Use install.ps1 instead. >&2
+    exit /b 1
 )
 
-echo.
-
-echo This script will download TeamCity CLI to %INSTALL_DIR%\%BIN_NAME%
-echo.
-
-:: Use PowerShell to get the latest release info and download the asset
-powershell -NoProfile -Command ^
-    "$releasesUrl = 'https://api.github.com/repos/%REPO%/releases/latest';" ^
-    "$release = Invoke-RestMethod -Uri $releasesUrl;" ^
-    "$tag = $release.tag_name;" ^
-    "$version = $tag.TrimStart('v');" ^
-    "$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'arm64' } else { 'x86_64' };" ^
-    "$assetName = \"teamcity_$($version)_windows_$($arch).zip\";" ^
-    "$asset = $release.assets | Where-Object { $_.name -eq $assetName };" ^
-    "if (-not $asset) { Write-Error \"Could not find asset $assetName in release $tag\"; exit 1 };" ^
-    "$tempZip = Join-Path $env:TEMP 'teamcity.zip';" ^
-    "Write-Host \"Downloading $assetName...\";" ^
-    "Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $tempZip;" ^
-    "$tempExtract = Join-Path $env:TEMP 'teamcity_extract';" ^
-    "if (Test-Path $tempExtract) { Remove-Item -Recurse -Force $tempExtract };" ^
-    "New-Item -ItemType Directory -Path $tempExtract | Out-Null;" ^
-    "Write-Host \"Extracting...\";" ^
-    "Expand-Archive -Path $tempZip -DestinationPath $tempExtract -Force;" ^
-    "$exePath = Get-ChildItem -Path $tempExtract -Filter '%BIN_NAME%' -Recurse | Select-Object -First 1;" ^
-    "Move-Item -Path $exePath.FullName -Destination '%INSTALL_DIR%\%BIN_NAME%' -Force;" ^
-    "Remove-Item $tempZip -Force;" ^
-    "Remove-Item -Recurse -Force $tempExtract;"
-
-if %ERRORLEVEL% neq 0 (
-    echo.
-    echo Error: Installation failed.
-    exit /b %ERRORLEVEL%
+:: Resolve latest release via 302 redirect if no version specified
+if "!RELEASE!"=="" (
+    for /f "delims=" %%a in ('curl -s -o nul -w "%%{redirect_url}" "https://github.com/!REPO!/releases/latest"') do set "LOCATION=%%a"
+    if "!LOCATION!"=="" (
+        echo Error: failed to resolve latest release >&2
+        exit /b 1
+    )
+    for %%t in ("!LOCATION!") do set "RELEASE=%%~nxt"
 )
 
-echo.
-echo v Installed at %INSTALL_DIR%\%BIN_NAME%
+if "!RELEASE!"=="" (
+    echo Error: failed to resolve latest release >&2
+    exit /b 1
+)
+
+:: Strip leading 'v' for version
+set "VERSION=!RELEASE!"
+if "!VERSION:~0,1!"=="v" set "VERSION=!VERSION:~1!"
+
+:: Detect architecture
+if /i "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+    set "ARCH=arm64"
+) else (
+    set "ARCH=x86_64"
+)
+
+set "ASSET_NAME=teamcity_!VERSION!_windows_!ARCH!.zip"
+set "URL=https://github.com/!REPO!/releases/download/!RELEASE!/!ASSET_NAME!"
+
+echo Installing teamcity (!RELEASE!) from !URL!
 echo.
 
-"%INSTALL_DIR%\%BIN_NAME%" --version
+:: Create install dir
+if not exist "!INSTALL_DIR!" mkdir "!INSTALL_DIR!"
+
+:: Create unique temp paths
+set "TEMP_ZIP=%TEMP%\teamcity_%RANDOM%%RANDOM%.zip"
+set "TEMP_DIR=%TEMP%\teamcity_extract_%RANDOM%%RANDOM%"
+
+:: Download
+curl -fsSL "!URL!" -o "!TEMP_ZIP!"
+if !ERRORLEVEL! neq 0 (
+    echo Error: download failed for !ASSET_NAME! >&2
+    if exist "!TEMP_ZIP!" del "!TEMP_ZIP!"
+    exit /b 1
+)
+
+:: Extract using tar (ships with Windows 10+, handles zip)
+mkdir "!TEMP_DIR!"
+tar -xf "!TEMP_ZIP!" -C "!TEMP_DIR!"
+if !ERRORLEVEL! neq 0 (
+    echo Error: extraction failed >&2
+    del "!TEMP_ZIP!" 2>nul
+    rmdir /s /q "!TEMP_DIR!" 2>nul
+    exit /b 1
+)
+
+:: Find the binary
+set "FOUND_BIN="
+for /r "!TEMP_DIR!" %%f in (!BIN_NAME!) do (
+    if exist "%%f" set "FOUND_BIN=%%f"
+)
+
+if "!FOUND_BIN!"=="" (
+    echo Error: could not find !BIN_NAME! in archive >&2
+    del "!TEMP_ZIP!" 2>nul
+    rmdir /s /q "!TEMP_DIR!" 2>nul
+    exit /b 1
+)
+
+:: Atomic install: copy to staged file, then rename
+set "STAGED=!INSTALL_DIR!\.teamcity_staged_%RANDOM%.exe"
+copy "!FOUND_BIN!" "!STAGED!" >nul
+if !ERRORLEVEL! neq 0 (
+    echo Error: failed to stage binary >&2
+    del "!TEMP_ZIP!" 2>nul
+    rmdir /s /q "!TEMP_DIR!" 2>nul
+    exit /b 1
+)
+move /y "!STAGED!" "!INSTALL_DIR!\!BIN_NAME!" >nul
+if !ERRORLEVEL! neq 0 (
+    echo Error: failed to install binary >&2
+    del "!STAGED!" 2>nul
+    del "!TEMP_ZIP!" 2>nul
+    rmdir /s /q "!TEMP_DIR!" 2>nul
+    exit /b 1
+)
+
+:: Cleanup temp files
+del "!TEMP_ZIP!" 2>nul
+rmdir /s /q "!TEMP_DIR!" 2>nul
+
+echo.
+echo v Installed at !INSTALL_DIR!\!BIN_NAME!
+echo.
+
+"!INSTALL_DIR!\!BIN_NAME!" --version
 
 :: Add to PATH if not present
 powershell -NoProfile -Command ^
     "$path = [Environment]::GetEnvironmentVariable('Path', 'User');" ^
-    "if ($path -notlike '*%INSTALL_DIR%*') {" ^
-    "  Write-Host 'Adding %INSTALL_DIR% to your PATH...';" ^
-    "  [Environment]::SetEnvironmentVariable('Path', \"$path;%INSTALL_DIR%\", 'User');" ^
+    "if ($path -notlike '*!INSTALL_DIR!*') {" ^
+    "  Write-Host 'Adding !INSTALL_DIR! to your PATH...';" ^
+    "  [Environment]::SetEnvironmentVariable('Path', \"$path;!INSTALL_DIR!\", 'User');" ^
     "  Write-Host 'You might need to restart your terminal for changes to take effect.';" ^
     "}"
 

--- a/install.ps1
+++ b/install.ps1
@@ -15,13 +15,45 @@
 #
 
 $ErrorActionPreference = "Stop"
+$ProgressPreference = "SilentlyContinue"
 
 $repo = "JetBrains/teamcity-cli"
 $binName = "teamcity.exe"
-$installDir = "$HOME\.local\bin"
+$Release = if ($env:TC_INSTALL_RELEASE) { $env:TC_INSTALL_RELEASE } else { "" }
+$OutDir = if ($env:TC_INSTALL_DIR) { $env:TC_INSTALL_DIR } else { "$HOME\.local\bin" }
+$tempZip = $null
+$tempExtract = $null
+$stagedBin = $null
 
-if (-not (Test-Path $installDir)) {
-    New-Item -ItemType Directory -Path $installDir | Out-Null
+function Cleanup {
+    if ($tempZip -and (Test-Path $tempZip)) {
+        Remove-Item $tempZip -Force -ErrorAction SilentlyContinue
+    }
+    if ($tempExtract -and (Test-Path $tempExtract)) {
+        Remove-Item -Recurse -Force $tempExtract -ErrorAction SilentlyContinue
+    }
+    if ($stagedBin -and (Test-Path $stagedBin)) {
+        Remove-Item $stagedBin -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Fail {
+    param([string]$Message)
+    Cleanup
+    Write-Error "Error: $Message"
+    exit 1
+}
+
+function Resolve-LatestRelease {
+    $location = & curl.exe -s -o NUL -w "%{redirect_url}" "https://github.com/$repo/releases/latest"
+    if (-not $location) {
+        Fail "failed to resolve latest TeamCity CLI release"
+    }
+    $tag = ($location -split '/')[-1]
+    if (-not $tag) {
+        Fail "failed to resolve latest TeamCity CLI release"
+    }
+    return $tag
 }
 
 Write-Host "
@@ -33,68 +65,71 @@ Write-Host "
     ╚═╝    ╚═════╝   https://jb.gg/tc/issues
 "
 
-Write-Host "This script will download TeamCity CLI to $installDir\$binName`n"
+Write-Host "This script will download TeamCity CLI to $OutDir\$binName`n"
+Write-Host "To install a specific version:"
+Write-Host "  `$env:TC_INSTALL_RELEASE='v0.7.0'; irm https://jb.gg/tc/install.ps1 | iex`n"
 
-$releasesUrl = "https://api.github.com/repos/$repo/releases/latest"
-$release = Invoke-RestMethod -Uri $releasesUrl
+try {
+    if (-not $Release) {
+        $Release = Resolve-LatestRelease
+    }
 
-$tag = $release.tag_name
-$version = $tag.TrimStart('v')
+    $version = $Release.TrimStart('v')
+    $arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x86_64" }
+    $assetName = "teamcity_$($version)_windows_$($arch).zip"
+    $downloadUrl = "https://github.com/$repo/releases/download/$Release/$assetName"
 
-$arch = if ($env:PROCESSOR_ARCHITECTURE -eq "ARM64") { "arm64" } else { "x86_64" }
-$os = "windows"
-$assetName = "teamcity_$($version)_$($os)_$($arch).zip"
+    Write-Host "Installing teamcity ($Release) from $downloadUrl`n"
 
-$asset = $release.assets | Where-Object { $_.name -eq $assetName }
-if (-not $asset) {
-    Write-Error "Could not find asset $assetName in release $tag"
-    exit 1
+    if (-not (Test-Path $OutDir)) {
+        New-Item -ItemType Directory -Path $OutDir | Out-Null
+    }
+    if (-not (Test-Path $OutDir -PathType Container)) {
+        Fail "output path is not a directory: $OutDir"
+    }
+
+    $tempZip = Join-Path $env:TEMP "teamcity_$([guid]::NewGuid().ToString('N')).zip"
+    $tempExtract = Join-Path $env:TEMP "teamcity_extract_$([guid]::NewGuid().ToString('N'))"
+
+    try {
+        Invoke-WebRequest -Uri $downloadUrl -OutFile $tempZip
+    } catch {
+        Fail "download failed for $assetName"
+    }
+
+    New-Item -ItemType Directory -Path $tempExtract | Out-Null
+    Expand-Archive -Path $tempZip -DestinationPath $tempExtract -Force
+
+    $exePath = Get-ChildItem -Path $tempExtract -Filter $binName -Recurse | Select-Object -First 1
+    if (-not $exePath) {
+        Fail "could not find $binName in the downloaded archive"
+    }
+
+    $stagedBin = Join-Path $OutDir ".teamcity_staged_$([guid]::NewGuid().ToString('N')).exe"
+    Copy-Item -Path $exePath.FullName -Destination $stagedBin -Force
+    Move-Item -Path $stagedBin -Destination "$OutDir\$binName" -Force
+    $stagedBin = $null
+
+    Write-Host "`n✓ Installed at $OutDir\$binName`n"
+    & "$OutDir\$binName" --version
+
+    $path = [Environment]::GetEnvironmentVariable("Path", "User")
+    if ($path -notlike "*$OutDir*") {
+        Write-Host "`nAdding $OutDir to your PATH..."
+        [Environment]::SetEnvironmentVariable("Path", "$path;$OutDir", "User")
+        $env:Path += ";$OutDir"
+        Write-Host "You might need to restart your terminal for changes to take effect."
+    }
+
+    Cleanup
+
+    Write-Host "`nNext steps:"
+    Write-Host "  Authenticate with TeamCity"
+    Write-Host "  teamcity auth login`n"
+    Write-Host "  List recent builds"
+    Write-Host "  teamcity run list`n"
+    Write-Host "  Get help"
+    Write-Host "  teamcity --help`n"
+} catch {
+    Fail $_.Exception.Message
 }
-
-$downloadUrl = $asset.browser_download_url
-$tempZip = Join-Path $env:TEMP "teamcity.zip"
-$tempExtract = Join-Path $env:TEMP "teamcity_extract"
-
-Write-Host "Downloading $assetName from $downloadUrl..."
-Invoke-WebRequest -Uri $downloadUrl -OutFile $tempZip
-
-if (Test-Path $tempExtract) {
-    Remove-Item -Recurse -Force $tempExtract
-}
-New-Item -ItemType Directory -Path $tempExtract | Out-Null
-
-Write-Host "Extracting..."
-Expand-Archive -Path $tempZip -DestinationPath $tempExtract -Force
-
-$exePath = Get-ChildItem -Path $tempExtract -Filter $binName -Recurse | Select-Object -First 1
-if (-not $exePath) {
-    Write-Error "Could not find $binName in the downloaded archive"
-    exit 1
-}
-
-Move-Item -Path $exePath.FullName -Destination "$installDir\$binName" -Force
-
-Write-Host "`n✓ Installed at $installDir\$binName"
-
-# Check if installDir is in PATH
-$path = [Environment]::GetEnvironmentVariable("Path", "User")
-if ($path -notlike "*$installDir*") {
-    Write-Host "`nAdding $installDir to your PATH..."
-    [Environment]::SetEnvironmentVariable("Path", "$path;$installDir", "User")
-    $env:Path += ";$installDir"
-    Write-Host "You might need to restart your terminal for changes to take effect."
-}
-
-& "$installDir\$binName" --version
-
-# Cleanup
-Remove-Item $tempZip -Force
-Remove-Item -Recurse -Force $tempExtract
-
-Write-Host "`nNext steps:"
-Write-Host "  Authenticate with TeamCity"
-Write-Host "  teamcity auth login`n"
-Write-Host "  List recent builds"
-Write-Host "  teamcity run list`n"
-Write-Host "  Get help"
-Write-Host "  teamcity --help`n"

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #
 # Copyright 2021-2026 JetBrains s.r.o.
@@ -16,10 +16,149 @@
 # limitations under the License.
 #
 
-RELEASE=${1}
-TMP_DIR="/tmp/tmpinstalldir"
-OUT_DIR=${2:-"/usr/local/bin"}
-check_mark="\033[1;32m✓\033[0m"
+set -Eeuo pipefail
+
+RELEASE="${1:-}"
+OUT_DIR="${2:-/usr/local/bin}"
+PROG="teamcity"
+CHECK_MARK=$'\033[1;32m✓\033[0m'
+TMP_DIR=""
+STAGED_BIN=""
+
+cleanup() {
+    if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+        rm -rf "$TMP_DIR"
+    fi
+    if [[ -n "${STAGED_BIN:-}" && -e "$STAGED_BIN" ]]; then
+        rm -f "$STAGED_BIN"
+    fi
+}
+
+header() {
+    printf '\n\033[1m%s\033[0m\n' "$1"
+}
+
+fail() {
+    local msg="${1:-unknown error}"
+    printf '============\n' >&2
+    printf 'Error: %s\n' "$msg" >&2
+    exit 1
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || fail "$1 is not installed"
+}
+
+detect_os() {
+    case "$(uname -s)" in
+        Darwin) printf 'darwin' ;;
+        Linux) printf 'linux' ;;
+        *) fail "unknown os: $(uname -s)" ;;
+    esac
+}
+
+detect_arch() {
+    case "$(uname -m)" in
+        x86_64|amd64) printf 'x86_64' ;;
+        aarch64|arm64) printf 'arm64' ;;
+        *) fail "unknown arch: $(uname -m)" ;;
+    esac
+}
+
+download_to_stdout() {
+    local url="$1"
+
+    if command -v curl >/dev/null 2>&1; then
+        curl --fail --location --silent --show-error "$url"
+        return
+    fi
+
+    if command -v wget >/dev/null 2>&1; then
+        wget -qO- "$url"
+        return
+    fi
+
+    fail "neither curl nor wget is installed"
+}
+
+resolve_latest_release() {
+    local location tag
+
+    if command -v curl >/dev/null 2>&1; then
+        location="$(curl -sI "https://github.com/JetBrains/teamcity-cli/releases/latest" 2>/dev/null \
+            | grep -i '^location:' | head -n 1 | tr -d '\r')"
+    elif command -v wget >/dev/null 2>&1; then
+        location="$(wget --spider -S "https://github.com/JetBrains/teamcity-cli/releases/latest" 2>&1 \
+            | grep -i '^\s*location:' | tail -n 1 | tr -d '\r' | sed 's/^\s*//')"
+    else
+        fail "neither curl nor wget is installed"
+    fi
+
+    tag="${location##*/}"
+    [[ -n "$tag" && "$tag" != "$location" ]] || fail "failed to resolve latest TeamCity CLI release"
+    printf '%s' "$tag"
+}
+
+install_teamcity() {
+    [[ -n "${BASH_VERSION:-}" ]] || fail "please use bash"
+
+    need_cmd tar
+    need_cmd find
+    need_cmd chmod
+    need_cmd mv
+    need_cmd mkdir
+    need_cmd mktemp
+    need_cmd uname
+    need_cmd cp
+
+    if [[ -z "$RELEASE" ]]; then
+        RELEASE="$(resolve_latest_release)"
+    fi
+
+    [[ "$RELEASE" =~ ^v?[0-9A-Za-z._-]+$ ]] || fail "invalid release: $RELEASE"
+
+    local os arch version url tmp_bin target
+    os="$(detect_os)"
+    arch="$(detect_arch)"
+    version="${RELEASE#v}"
+    url="https://github.com/JetBrains/teamcity-cli/releases/download/${RELEASE}/${PROG}_${version}_${os}_${arch}.tar.gz"
+    target="${OUT_DIR}/${PROG}"
+
+    echo -e "\033[0;90m\nInstalling $PROG ($RELEASE) from $url\033[0m\n"
+
+    mkdir -p "$OUT_DIR" || fail "failed to create output directory: $OUT_DIR"
+    [[ -d "$OUT_DIR" ]] || fail "output path is not a directory: $OUT_DIR"
+    [[ -w "$OUT_DIR" ]] || fail "output directory is not writable: $OUT_DIR"
+
+    TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/${PROG}.XXXXXX")" || fail "failed to create temp directory"
+    cd "$TMP_DIR"
+
+    download_to_stdout "$url" | tar -xzf - || fail "download or extract failed"
+
+    tmp_bin="$(find . -type f -name "$PROG" -print -quit)"
+    [[ -n "$tmp_bin" && -f "$tmp_bin" ]] || fail "could not find ${PROG} binary in archive"
+
+    STAGED_BIN="$(mktemp "${OUT_DIR}/.${PROG}.XXXXXX")" || fail "failed to create staged binary in $OUT_DIR"
+    cp "$tmp_bin" "$STAGED_BIN" || fail "failed to stage binary"
+    chmod 0755 "$STAGED_BIN" || fail "failed to set executable permissions"
+    mv -f "$STAGED_BIN" "$target" || fail "failed to move binary into place"
+    STAGED_BIN=""
+
+    echo -e "${CHECK_MARK} Installed at $target\n"
+    "$target" --version || fail "installed binary failed to run"
+
+    header "Next steps"
+    echo -e ""
+    echo -e "  \033[1mAuthenticate with TeamCity\033[0m"
+    echo -e "  \033[0;90mteamcity auth login\033[0m\n"
+    echo -e "  \033[1mList recent builds\033[0m"
+    echo -e "  \033[0;90mteamcity run list\033[0m\n"
+    echo -e "  \033[1mGet help\033[0m"
+    echo -e "  \033[0;90mteamcity --help\033[0m\n"
+}
+
+trap cleanup EXIT
+trap 'fail "interrupted"' INT TERM
 
 echo -e '
  ████████╗ ██████╗
@@ -37,105 +176,8 @@ If you get 'permission denied' error:
   - Specify other dir: \033[4mcurl -fsSL https://jb.gg/tc/install | bash -s -- \"\" \$HOME/.local/bin\033[0m
   - Or run with sudo
 
-If you get API rate limit exceeded error:
-  - Specify the version: \033[4mcurl -fsSL https://jb.gg/tc/install | bash -s -- v1.0.0\033[0m
-  - Or set GITHUB_TOKEN: \033[4mexport GITHUB_TOKEN=your_token\033[0m
+To install a specific version:
+  \033[4mcurl -fsSL https://jb.gg/tc/install | bash -s -- v0.7.0\033[0m
 "
-set -e
 
-function cleanup {
-    rm -rf $TMP_DIR > /dev/null 2>&1 || true
-}
-function header() {
-    echo -e "\n\033[1m$1\033[0m";
-}
-function fail {
-    cleanup
-    msg=$1
-    echo "============"
-    echo "Error: $msg" 1>&2
-    exit 1
-}
-function install {
-    set -e
-    if [ -z "$RELEASE" ]; then
-        GITHUB_AUTH=""
-        if [ -n "$GITHUB_TOKEN" ]; then
-            GITHUB_AUTH="-H 'Authorization: token $GITHUB_TOKEN'"
-        fi
-        LATEST=$(curl $GITHUB_AUTH --silent "https://api.github.com/repos/JetBrains/teamcity-cli/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
-        RELEASE=$LATEST
-    fi
-    USER="JetBrains"
-    PROG="teamcity"
-    INSECURE="false"
-    #bash check
-    [ ! "$BASH_VERSION" ] && fail "Please use bash instead"
-    [ ! -d $OUT_DIR ] && fail "output directory missing: $OUT_DIR"
-    #dependency check, assume we are a standard POSIX machine
-    which find > /dev/null || fail "find not installed"
-    which xargs > /dev/null || fail "xargs not installed"
-    which sort > /dev/null || fail "sort not installed"
-    which tail > /dev/null || fail "tail not installed"
-    which cut > /dev/null || fail "cut not installed"
-    which du > /dev/null || fail "du not installed"
-    GET=""
-    if which curl > /dev/null; then
-        GET="curl"
-        if [[ $INSECURE = "true" ]]; then GET="$GET --insecure"; fi
-        GET="$GET --fail -# -L"
-    elif which wget > /dev/null; then
-        GET="wget"
-        if [[ $INSECURE = "true" ]]; then GET="$GET --no-check-certificate"; fi
-        GET="$GET -qO-"
-    else
-        fail "neither wget/curl are installed"
-    fi
-    case $(uname -s) in
-    Darwin) OS="darwin";;
-    Linux) OS="linux";;
-    *) fail "unknown os: $(uname -s)";;
-    esac
-    #find ARCH
-    if [[ $(uname -m) == "x86_64" ]]; then
-        ARCH="x86_64"
-    elif [[ $(uname -m) == "aarch64" || $(uname -m) == "arm64" ]]; then
-        ARCH="arm64"
-    else
-        fail "unknown arch: $(uname -m)"
-    fi
-    URL="https://github.com/JetBrains/teamcity-cli/releases/download/$RELEASE/teamcity_${RELEASE#v}_${OS}_${ARCH}.tar.gz"
-    FTYPE=".tar.gz"
-
-    echo -e "\033[0;90m\nInstalling $PROG ($RELEASE) from $URL\033[0m\n"
-
-    #enter tempdir
-    mkdir -p $TMP_DIR
-    cd $TMP_DIR || exit
-    if [[ $FTYPE = ".tar.gz" ]] || [[ $FTYPE = ".tgz" ]]; then
-        which tar > /dev/null || fail "tar is not installed"
-        which gzip > /dev/null || fail "gzip is not installed"
-        bash -c "$GET $URL" | tar zxf - > /dev/null || fail "download failed"
-    else
-        fail "unknown file type: $FTYPE"
-    fi
-    TMP_BIN=$(find . -name "teamcity" -type f | head -1)
-    if [ ! -f "$TMP_BIN" ]; then
-        fail "could not find teamcity binary"
-    fi
-    chmod +x "$TMP_BIN" || fail "chmod +x failed"
-    mv "$TMP_BIN" "$OUT_DIR"/$PROG || fail "mv failed"
-    echo -e "${check_mark} Installed at $OUT_DIR/$PROG\n"
-    "$OUT_DIR/$PROG" --version
-    cleanup
-    header "Next steps"
-    echo -e ""
-    echo -e "  \033[1mAuthenticate with TeamCity\033[0m"
-    echo -e "  \033[0;90mteamcity auth login\033[0m\n"
-    echo -e "  \033[1mList recent builds\033[0m"
-    echo -e "  \033[0;90mteamcity run list\033[0m\n"
-    echo -e "  \033[1mGet help\033[0m"
-    echo -e "  \033[0;90mteamcity --help\033[0m\n"
-}
-
-install
+install_teamcity


### PR DESCRIPTION
## Summary
- **install.sh**: Refactored into clean functions with proper error handling (`set -Eeuo pipefail`, trap-based cleanup, atomic staged binary install via `mktemp`/`cp`/`mv`)
- **install.ps1**: Ported same patterns — cleanup on failure, atomic install, GUID-based temp paths, `$ProgressPreference = SilentlyContinue` for faster downloads
- **install.cmd**: Rewritten to use native `curl` + `tar` (Windows 10+) instead of inline PowerShell. Atomic install, proper cleanup on each error path
- **All scripts**: Resolve latest release via GitHub's 302 redirect (`curl -w %{redirect_url}`) instead of hitting the `/releases/latest` API — no rate limits, no `GITHUB_TOKEN` needed
- **CI**: Added install script verification steps to `test_linux` and `test_windows` pipelines

## Details
- Version pinning supported via first arg (sh/cmd) or `TC_INSTALL_RELEASE` env var (ps1)
- Custom install dir via second arg (sh/cmd) or `TC_INSTALL_DIR` env var (ps1)
- install.ps1 uses env vars instead of `param()` to stay compatible with `irm | iex`

## Test plan
- [x] `bash install.sh` on macOS
- [x] `irm .../install.ps1 | iex` on Windows (PS5)
- [x] `install.cmd` on Windows
- [x] CI `test_linux` pipeline passes
- [x] CI `test_windows` pipeline passes
