### PR TITLE
Quote API endpoint URLs to prevent shell interpretation

### DIFF
--- a/acceptance/testdata/api/api-endpoints.txtar
+++ b/acceptance/testdata/api/api-endpoints.txtar
@@ -1,27 +1,27 @@
 # Test various REST API endpoints.
 
 # Builds with field selection
-exec teamcity api /app/rest/builds?locator=count:2&fields=build(id,status,state) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:2&fields=build(id,status,state)' --raw --no-input
 stdout '"id"'
 stdout '"status"'
 ! stderr 'Error'
 
 # Projects
-exec teamcity api /app/rest/projects --no-input
+exec teamcity api '/app/rest/projects' --no-input
 stdout '"project"'
 ! stderr 'Error'
 
 # Build types
-exec teamcity api /app/rest/buildTypes --no-input
+exec teamcity api '/app/rest/buildTypes' --no-input
 stdout '"buildType"'
 ! stderr 'Error'
 
 # Agents
-exec teamcity api /app/rest/agents --no-input
+exec teamcity api '/app/rest/agents' --no-input
 stdout '"agent"'
 ! stderr 'Error'
 
 # Agent pools
-exec teamcity api /app/rest/agentPools --no-input
+exec teamcity api '/app/rest/agentPools' --no-input
 stdout '"agentPool"'
 ! stderr 'Error'

--- a/acceptance/testdata/api/api-errors.txtar
+++ b/acceptance/testdata/api/api-errors.txtar
@@ -1,9 +1,9 @@
 # Test API error handling.
 
 # Nonexistent endpoint
-! exec teamcity api /app/rest/nonexistent_endpoint_12345 --no-input
+! exec teamcity api '/app/rest/nonexistent_endpoint_12345' --no-input
 stderr '.'
 
 # --slurp without --paginate
-! exec teamcity api /app/rest/server --slurp --no-input
+! exec teamcity api '/app/rest/server' --slurp --no-input
 stderr 'requires --paginate'

--- a/acceptance/testdata/api/api-headers.txtar
+++ b/acceptance/testdata/api/api-headers.txtar
@@ -1,12 +1,12 @@
 # Test HTTP header flags.
 
 # --include shows response headers
-exec teamcity api /app/rest/server --include --no-input
+exec teamcity api '/app/rest/server' --include --no-input
 stdout 'HTTP/'
 stdout 'Content-Type'
 ! stderr 'Error'
 
 # --header sets custom request header
-exec teamcity api /app/rest/server --header Accept:application/json --no-input
+exec teamcity api '/app/rest/server' --header Accept:application/json --no-input
 stdout 'version'
 ! stderr 'Error'

--- a/acceptance/testdata/api/api-input-stdin.txtar
+++ b/acceptance/testdata/api/api-input-stdin.txtar
@@ -1,7 +1,7 @@
 # Test API with --input - reading body from stdin.
 
 stdin body.json
-exec teamcity api /app/rest/server --input - --raw --no-input
+exec teamcity api '/app/rest/server' --input - --raw --no-input
 stdout '"version"'
 ! stderr 'Error'
 

--- a/acceptance/testdata/api/api-methods.txtar
+++ b/acceptance/testdata/api/api-methods.txtar
@@ -1,16 +1,16 @@
 # Test HTTP methods beyond GET.
 
 # HEAD returns no body
-exec teamcity api /app/rest/server -X HEAD --no-input
+exec teamcity api '/app/rest/server' -X HEAD --no-input
 ! stdout .
 ! stderr 'Error'
 
 # DELETE to a read-only endpoint should fail gracefully
-! exec teamcity api /app/rest/server -X DELETE --no-input
+! exec teamcity api '/app/rest/server' -X DELETE --no-input
 stderr '.'
 
 # --input sends body with POST (invalid payload → server error, but proves input is read)
-! exec teamcity api /app/rest/buildQueue -X POST --input body.json --no-input
+! exec teamcity api '/app/rest/buildQueue' -X POST --input body.json --no-input
 stderr '.'
 
 -- body.json --

--- a/acceptance/testdata/api/api-paginate.txtar
+++ b/acceptance/testdata/api/api-paginate.txtar
@@ -1,10 +1,10 @@
 # Test API pagination.
 
-exec teamcity api /app/rest/projects --paginate --no-input
+exec teamcity api '/app/rest/projects' --paginate --no-input
 stdout '"project"'
 ! stderr 'Error'
 
 # --slurp collects all pages into a single JSON array
-exec teamcity api /app/rest/projects --paginate --slurp --no-input
+exec teamcity api '/app/rest/projects' --paginate --slurp --no-input
 stdout '\['
 ! stderr 'Error'

--- a/acceptance/testdata/api/api-post-field.txtar
+++ b/acceptance/testdata/api/api-post-field.txtar
@@ -1,9 +1,9 @@
 # Trigger a build via raw API POST with -f field syntax.
 [!has_token] skip 'requires authentication token'
 
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
-exec teamcity api /app/rest/buildQueue -X POST -f buildType=id:$JOB_ID --no-input
+exec teamcity api '/app/rest/buildQueue' -X POST -f buildType=id:$JOB_ID --no-input
 stdout '"id"'
 ! stderr 'Error'

--- a/acceptance/testdata/api/api-server.txtar
+++ b/acceptance/testdata/api/api-server.txtar
@@ -1,21 +1,21 @@
 # Test API server endpoint with various output flags.
 
-exec teamcity api /app/rest/server --no-input
+exec teamcity api '/app/rest/server' --no-input
 stdout 'version'
 stdout 'buildNumber'
 ! stderr .
 
 # --raw: unformatted JSON
-exec teamcity api /app/rest/server --raw --no-input
+exec teamcity api '/app/rest/server' --raw --no-input
 stdout '"version"'
 ! stderr .
 
 # -X HEAD: no body
-exec teamcity api /app/rest/server -X HEAD --no-input
+exec teamcity api '/app/rest/server' -X HEAD --no-input
 ! stdout .
 ! stderr 'Error'
 
 # --silent: suppress output
-exec teamcity api /app/rest/server --silent --no-input
+exec teamcity api '/app/rest/server' --silent --no-input
 ! stdout .
 ! stderr 'Error'

--- a/acceptance/testdata/config/readonly.txtar
+++ b/acceptance/testdata/config/readonly.txtar
@@ -18,10 +18,10 @@ env TEAMCITY_RO=1
 
 # ---- Discover real IDs for GET-first command tests ----
 
-exec teamcity api /app/rest/agents?locator=count:1&fields=agent(id) --raw --no-input
+exec teamcity api '/app/rest/agents?locator=count:1&fields=agent(id)' --raw --no-input
 extract '"id":(\d+)' AGENT_ID
 
-exec teamcity api /app/rest/builds?locator=count:1&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 # ---- Read commands still work ----
@@ -44,21 +44,21 @@ exec teamcity pool list --no-input
 exec teamcity queue list --no-input
 ! stderr 'read-only'
 
-exec teamcity api /app/rest/server --no-input
+exec teamcity api '/app/rest/server' --no-input
 ! stderr 'read-only'
 
 # ---- API: non-GET methods blocked ----
 
-! exec teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:Fake' --no-input
+! exec teamcity api '/app/rest/buildQueue' -X POST -f 'buildType=id:Fake' --no-input
 stderr 'read-only mode'
 
-! exec teamcity api /app/rest/builds/1/comment -X PUT --no-input
+! exec teamcity api '/app/rest/builds/1/comment' -X PUT --no-input
 stderr 'read-only mode'
 
-! exec teamcity api /app/rest/builds/1/tags/foo -X DELETE --no-input
+! exec teamcity api '/app/rest/builds/1/tags/foo' -X DELETE --no-input
 stderr 'read-only mode'
 
-! exec teamcity api /app/rest/builds/1/pin -X PATCH --no-input
+! exec teamcity api '/app/rest/builds/1/pin' -X PATCH --no-input
 stderr 'read-only mode'
 
 # ---- run: direct-write subcommands ----
@@ -154,5 +154,5 @@ stderr 'read-only mode'
 
 env TEAMCITY_RO=
 
-exec teamcity api /app/rest/server -X HEAD --no-input
+exec teamcity api '/app/rest/server' -X HEAD --no-input
 ! stderr 'read-only'

--- a/acceptance/testdata/job/job-authenticated.txtar
+++ b/acceptance/testdata/job/job-authenticated.txtar
@@ -1,7 +1,7 @@
 # Job commands requiring authentication.
 [!has_token] skip 'requires authentication token'
 
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 # param list

--- a/acceptance/testdata/job/job-list.txtar
+++ b/acceptance/testdata/job/job-list.txtar
@@ -29,7 +29,7 @@ stdout '"projectId"'
 stderr 'must be a positive number'
 
 # --project filter
-exec teamcity api /app/rest/projects?locator=count:1&fields=project(id) --raw --no-input
+exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
 extract '"id":"([^"]+)"' PROJECT_ID
 
 exec teamcity job list --project $PROJECT_ID --limit 3 --no-input

--- a/acceptance/testdata/job/job-tree.txtar
+++ b/acceptance/testdata/job/job-tree.txtar
@@ -1,6 +1,6 @@
 # Display snapshot dependency tree for a job.
 
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 exec teamcity job tree $JOB_ID --no-input

--- a/acceptance/testdata/job/job-view.txtar
+++ b/acceptance/testdata/job/job-view.txtar
@@ -1,6 +1,6 @@
 # Test job view subcommand.
 
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 exec teamcity job view $JOB_ID --no-input

--- a/acceptance/testdata/pool/pool-link-unlink.txtar
+++ b/acceptance/testdata/pool/pool-link-unlink.txtar
@@ -2,7 +2,7 @@
 [!has_token] skip 'requires authentication token'
 
 # Use default pool (0) and discover a project
-exec teamcity api /app/rest/projects?locator=count:1&fields=project(id) --raw --no-input
+exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
 extract '"id":"([^"]+)"' PROJECT_ID
 
 # Link project to pool 0

--- a/acceptance/testdata/project/project-authenticated.txtar
+++ b/acceptance/testdata/project/project-authenticated.txtar
@@ -1,7 +1,7 @@
 # Project commands requiring authentication.
 [!has_token] skip 'requires authentication token'
 
-exec teamcity api /app/rest/projects?locator=count:1&fields=project(id) --raw --no-input
+exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
 extract '"id":"([^"]+)"' PROJECT_ID
 
 # param set → get → list → delete

--- a/acceptance/testdata/project/project-settings-status.txtar
+++ b/acceptance/testdata/project/project-settings-status.txtar
@@ -1,6 +1,6 @@
 # View versioned settings status of a project.
 
-exec teamcity api /app/rest/projects?locator=count:1&fields=project(id) --raw --no-input
+exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
 extract '"id":"([^"]+)"' PROJECT_ID
 
 exec teamcity project settings status $PROJECT_ID --no-input

--- a/acceptance/testdata/project/project-view.txtar
+++ b/acceptance/testdata/project/project-view.txtar
@@ -16,7 +16,7 @@ stdout '"name"'
 stderr '.'
 
 # discovered via API
-exec teamcity api /app/rest/projects?locator=count:1&fields=project(id) --raw --no-input
+exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
 extract '"id":"([^"]+)"' PROJECT_ID
 
 exec teamcity project view $PROJECT_ID --no-input

--- a/acceptance/testdata/queue/queue-authenticated.txtar
+++ b/acceptance/testdata/queue/queue-authenticated.txtar
@@ -6,7 +6,7 @@
 stderr '.'
 
 # remove: start a build and try to remove from queue (may already be running)
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 exec teamcity run start $JOB_ID --json --no-input

--- a/acceptance/testdata/queue/queue-list.txtar
+++ b/acceptance/testdata/queue/queue-list.txtar
@@ -19,7 +19,7 @@ exec teamcity queue list --limit 10 --no-input
 ! stderr 'Error'
 
 # --job filter (discover job first)
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 exec teamcity queue list --job $JOB_ID --limit 5 --no-input

--- a/acceptance/testdata/run/run-artifacts.txtar
+++ b/acceptance/testdata/run/run-artifacts.txtar
@@ -1,6 +1,6 @@
 # Test run artifacts and download subcommands.
 
-exec teamcity api /app/rest/builds?locator=count:1&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 exec teamcity run artifacts $BUILD_ID --no-input
@@ -22,7 +22,7 @@ stdout '(downloaded|No artifacts)'
 ! stderr 'Error'
 
 # --job (by job ID)
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 exec teamcity run artifacts --job $JOB_ID --no-input

--- a/acceptance/testdata/run/run-changes.txtar
+++ b/acceptance/testdata/run/run-changes.txtar
@@ -1,6 +1,6 @@
 # Test run changes subcommand.
 
-exec teamcity api /app/rest/builds?locator=count:1&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 exec teamcity run changes $BUILD_ID --no-input

--- a/acceptance/testdata/run/run-list-filters.txtar
+++ b/acceptance/testdata/run/run-list-filters.txtar
@@ -20,7 +20,7 @@ exec teamcity run list --since 2024-01-01 --until 2025-12-31 --limit 5 --no-inpu
 ! stderr 'Error'
 
 # --project (discover first)
-exec teamcity api /app/rest/projects?locator=count:1&fields=project(id) --raw --no-input
+exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
 extract '"id":"([^"]+)"' PROJECT_ID
 
 exec teamcity run list --project $PROJECT_ID --limit 3 --no-input

--- a/acceptance/testdata/run/run-log.txtar
+++ b/acceptance/testdata/run/run-log.txtar
@@ -1,6 +1,6 @@
 # Test run log subcommand.
 
-exec teamcity api /app/rest/builds?locator=count:1&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 exec teamcity run log $BUILD_ID --no-input

--- a/acceptance/testdata/run/run-metadata.txtar
+++ b/acceptance/testdata/run/run-metadata.txtar
@@ -1,7 +1,7 @@
 # Test run metadata commands: pin/unpin, tag/untag, comment.
 [!has_token] skip 'requires authentication token'
 
-exec teamcity api /app/rest/builds?locator=count:1&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 # Pin and unpin

--- a/acceptance/testdata/run/run-restart.txtar
+++ b/acceptance/testdata/run/run-restart.txtar
@@ -2,7 +2,7 @@
 [!has_token] skip 'requires authentication token'
 
 # Find a completed build from Sandbox (stable, not affected by parallel tests)
-exec teamcity api /app/rest/builds?locator=buildType:Sandbox_Build,count:1,status:SUCCESS&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=buildType:Sandbox_Build,count:1,status:SUCCESS&fields=build(id)' --raw --no-input
 extract '"id":\s*(\d+)' BUILD_ID
 
 exec teamcity run restart $BUILD_ID --no-input

--- a/acceptance/testdata/run/run-start.txtar
+++ b/acceptance/testdata/run/run-start.txtar
@@ -1,7 +1,7 @@
 # Test run start subcommand.
 [!has_token] skip 'requires authentication token'
 
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 # Start and cancel

--- a/acceptance/testdata/run/run-tests.txtar
+++ b/acceptance/testdata/run/run-tests.txtar
@@ -1,6 +1,6 @@
 # Test run tests subcommand.
 
-exec teamcity api /app/rest/builds?locator=count:1&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 exec teamcity run tests $BUILD_ID --no-input
@@ -21,7 +21,7 @@ exec teamcity run tests $BUILD_ID --limit 5 --no-input
 ! stderr 'Error'
 
 # --job (by job ID instead of build ID)
-exec teamcity api /app/rest/buildTypes?locator=count:1&fields=buildType(id) --raw --no-input
+exec teamcity api '/app/rest/buildTypes?locator=count:1&fields=buildType(id)' --raw --no-input
 extract '"id":"([^"]+)"' JOB_ID
 
 exec teamcity run tests --job $JOB_ID --no-input

--- a/acceptance/testdata/run/run-view.txtar
+++ b/acceptance/testdata/run/run-view.txtar
@@ -1,6 +1,6 @@
 # Test run view subcommand.
 
-exec teamcity api /app/rest/builds?locator=count:1&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 exec teamcity run view $BUILD_ID --no-input

--- a/acceptance/testdata/run/run-watch.txtar
+++ b/acceptance/testdata/run/run-watch.txtar
@@ -1,6 +1,6 @@
 # Watch a completed run (should return immediately since already finished).
 
-exec teamcity api /app/rest/builds?locator=count:1,status:SUCCESS,state:finished&fields=build(id) --raw --no-input
+exec teamcity api '/app/rest/builds?locator=count:1,status:SUCCESS,state:finished&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 # Watching a finished successful build should return quickly

--- a/docs/topics/teamcity-cli-aliases.md
+++ b/docs/topics/teamcity-cli-aliases.md
@@ -105,7 +105,7 @@ teamcity alias set unmaint  'agent enable $1'
 ### API shortcuts
 
 ```Shell
-teamcity alias set whoami   'api /app/rest/users/current'
+teamcity alias set whoami   "api '/app/rest/users/current'"
 ```
 
 ### Shell aliases with external tools

--- a/docs/topics/teamcity-cli-rest-api-access.md
+++ b/docs/topics/teamcity-cli-rest-api-access.md
@@ -9,7 +9,7 @@ The `teamcity api` command lets you make authenticated HTTP requests to the [Tea
 The endpoint argument is the path portion of the URL, starting with `/app/rest/`:
 
 ```Shell
-teamcity api /app/rest/server
+teamcity api '/app/rest/server'
 ```
 
 The CLI automatically adds the base URL and authentication headers based on your current authentication context.
@@ -20,16 +20,16 @@ By default, requests use the GET method. Specify a different method with `-X`:
 
 ```Shell
 # GET (default)
-teamcity api /app/rest/projects
+teamcity api '/app/rest/projects'
 
 # POST
-teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
+teamcity api '/app/rest/buildQueue' -X POST -f 'buildType=id:MyBuild'
 
 # PUT
-teamcity api /app/rest/builds/12345/comment -X PUT --input comment.txt
+teamcity api '/app/rest/builds/12345/comment' -X PUT --input comment.txt
 
 # DELETE
-teamcity api /app/rest/builds/12345/tags/obsolete -X DELETE
+teamcity api '/app/rest/builds/12345/tags/obsolete' -X DELETE
 ```
 
 > When [read-only mode](teamcity-cli-scripting.md#Read-only+mode) is enabled (`TEAMCITY_RO=1` or `ro: true` in config), non-GET requests are blocked.
@@ -43,8 +43,8 @@ teamcity api /app/rest/builds/12345/tags/obsolete -X DELETE
 Use `-f` to build a JSON request body from key-value pairs:
 
 ```Shell
-teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
-teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild' -f 'branchName=main'
+teamcity api '/app/rest/buildQueue' -X POST -f 'buildType=id:MyBuild'
+teamcity api '/app/rest/buildQueue' -X POST -f 'buildType=id:MyBuild' -f 'branchName=main'
 ```
 
 ### Request body from a file
@@ -52,13 +52,13 @@ teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild' -f 'branchNa
 Use `--input` to read the request body from a file:
 
 ```Shell
-teamcity api /app/rest/projects -X POST --input project.json
+teamcity api '/app/rest/projects' -X POST --input project.json
 ```
 
 Read from stdin with `--input -`:
 
 ```Shell
-echo '{"name": "New Project"}' | teamcity api /app/rest/projects -X POST --input -
+echo '{"name": "New Project"}' | teamcity api '/app/rest/projects' -X POST --input -
 ```
 
 ## Custom headers
@@ -66,7 +66,7 @@ echo '{"name": "New Project"}' | teamcity api /app/rest/projects -X POST --input
 Add custom headers with `-H`:
 
 ```Shell
-teamcity api /app/rest/builds -H "Accept: application/xml"
+teamcity api '/app/rest/builds' -H "Accept: application/xml"
 ```
 
 ## Response handling
@@ -74,7 +74,7 @@ teamcity api /app/rest/builds -H "Accept: application/xml"
 ### Include response headers
 
 ```Shell
-teamcity api /app/rest/server -i
+teamcity api '/app/rest/server' -i
 ```
 
 ### Raw output
@@ -82,7 +82,7 @@ teamcity api /app/rest/server -i
 Output the response without formatting:
 
 ```Shell
-teamcity api /app/rest/server --raw
+teamcity api '/app/rest/server' --raw
 ```
 
 ### Silent mode
@@ -90,7 +90,7 @@ teamcity api /app/rest/server --raw
 Suppress output on success (useful in scripts where you only care about the exit code):
 
 ```Shell
-teamcity api /app/rest/builds/12345/tags/release -X POST --silent
+teamcity api '/app/rest/builds/12345/tags/release' -X POST --silent
 ```
 
 ## Pagination
@@ -98,13 +98,13 @@ teamcity api /app/rest/builds/12345/tags/release -X POST --silent
 The TeamCity REST API returns paginated results for large collections. Use `--paginate` to automatically fetch all pages:
 
 ```Shell
-teamcity api /app/rest/builds --paginate
+teamcity api '/app/rest/builds' --paginate
 ```
 
 Combine paginated results into a single JSON array with `--slurp`:
 
 ```Shell
-teamcity api /app/rest/builds --paginate --slurp
+teamcity api '/app/rest/builds' --paginate --slurp
 ```
 
 > The `--slurp` flag requires `--paginate`. It collects items from all pages and outputs them as a single JSON array.
@@ -115,20 +115,20 @@ teamcity api /app/rest/builds --paginate --slurp
 
 ```Shell
 # Get current user info
-teamcity api /app/rest/users/current
+teamcity api '/app/rest/users/current'
 
 # List all VCS roots
-teamcity api /app/rest/vcs-roots
+teamcity api '/app/rest/vcs-roots'
 
 # Get build statistics
-teamcity api /app/rest/builds/12345/statistics
+teamcity api '/app/rest/builds/12345/statistics'
 
 # Trigger a build with parameters
-teamcity api /app/rest/buildQueue -X POST \
+teamcity api '/app/rest/buildQueue' -X POST \
   --input <(echo '{"buildType":{"id":"MyBuild"},"properties":{"property":[{"name":"version","value":"1.0"}]}}')
 
 # Download a specific artifact
-teamcity api /app/rest/builds/12345/artifacts/content/report.html --raw > report.html
+teamcity api '/app/rest/builds/12345/artifacts/content/report.html' --raw > report.html
 ```
 
 ## api flags

--- a/docs/topics/teamcity-cli-scripting.md
+++ b/docs/topics/teamcity-cli-scripting.md
@@ -291,8 +291,8 @@ esac
 For operations not covered by dedicated commands, use `teamcity api` to make direct REST API requests:
 
 ```Shell
-teamcity api /app/rest/server
-teamcity api /app/rest/builds --paginate --slurp
+teamcity api '/app/rest/server'
+teamcity api '/app/rest/builds' --paginate --slurp
 ```
 
 See [REST API access](teamcity-cli-rest-api-access.md) for details.

--- a/internal/cmd/api.go
+++ b/internal/cmd/api.go
@@ -51,16 +51,16 @@ This command is useful for:
 - Debugging and exploration`,
 		Args: cobra.ExactArgs(1),
 		Example: `  # Get server info
-  teamcity api /app/rest/server
+  teamcity api '/app/rest/server'
 
   # List projects
-  teamcity api /app/rest/projects
+  teamcity api '/app/rest/projects'
 
   # Create a resource with POST
-  teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
+  teamcity api '/app/rest/buildQueue' -X POST -f 'buildType=id:MyBuild'
 
   # Fetch all pages and combine into array
-  teamcity api /app/rest/builds --paginate --slurp`,
+  teamcity api '/app/rest/builds' --paginate --slurp`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAPI(args[0], opts)
 		},

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -15,7 +15,7 @@ teamcity run list --status failure      # Find failed builds
 teamcity run log <id> --failed          # Full failure diagnostics
 ```
 
-**Do not guess flags or syntax.** Use the [Command Reference](references/commands.md) or `teamcity <command> --help`. Fall back to `teamcity api /app/rest/...` when needed. Builds are **runs** (`teamcity run`), build configurations are **jobs** (`teamcity job`).
+**Do not guess flags or syntax.** Use the [Command Reference](references/commands.md) or `teamcity <command> --help`. Fall back to `teamcity api '/app/rest/...'` when needed. Builds are **runs** (`teamcity run`), build configurations are **jobs** (`teamcity job`).
 
 ## Core Commands
 

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -318,16 +318,16 @@ For features not covered by specific commands. Endpoints always start with `/app
 
 ```bash
 # GET request
-teamcity api /app/rest/server
+teamcity api '/app/rest/server'
 
 # POST request
-teamcity api /app/rest/buildQueue -X POST -f 'buildType=id:MyBuild'
+teamcity api '/app/rest/buildQueue' -X POST -f 'buildType=id:MyBuild'
 
 # With pagination
-teamcity api /app/rest/builds --paginate --slurp
+teamcity api '/app/rest/builds' --paginate --slurp
 
 # Browse artifact subdirectory
-teamcity api /app/rest/builds/id:BUILD_ID/artifacts/children/SUBPATH
+teamcity api '/app/rest/builds/id:BUILD_ID/artifacts/children/SUBPATH'
 ```
 
 ### Flags


### PR DESCRIPTION
## Summary
- Single-quote all `/app/rest/...` endpoint arguments in `teamcity api` examples across help text, documentation, skills, and acceptance tests
- Prevents shell interpretation of `?`, `&`, `(`, `)` and other special characters commonly found in TeamCity REST API URLs with locators and field selectors
- Especially important for AI agents that copy examples verbatim without adding quotes

Fixes #131

## Test plan
- [x] `go build ./...` compiles successfully
- [x] Acceptance tests pass with quoted URLs (testscript `exec` supports single-quoted arguments)
- [x] `teamcity api -h` shows quoted examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)