### PR TITLE
feat(run): add experimental `run diff` command to compare two builds

### DIFF
--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -237,6 +237,39 @@ func (c *Client) GetBuildTests(buildID string, failedOnly bool, limit int) (*Tes
 	return &summary, nil
 }
 
+func (c *Client) GetBuildTestSummary(buildID string) (*TestOccurrences, error) {
+	id, err := c.ResolveBuildID(buildID)
+	if err != nil {
+		return nil, err
+	}
+
+	locator := fmt.Sprintf("build:(id:%s)", id)
+	fields := "count,passed,failed,ignored"
+	path := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(fields))
+
+	var summary TestOccurrences
+	if err := c.get(path, &summary); err != nil {
+		return nil, err
+	}
+	return &summary, nil
+}
+
+func (c *Client) GetBuildResultingProperties(buildID string) (*ParameterList, error) {
+	id, err := c.ResolveBuildID(buildID)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("/app/rest/builds/id:%s/resulting-properties", id)
+
+	var params ParameterList
+	if err := c.get(path, &params); err != nil {
+		return nil, err
+	}
+
+	return &params, nil
+}
+
 func (c *Client) GetBuildProblems(buildID string) (*ProblemOccurrences, error) {
 	id, err := c.ResolveBuildID(buildID)
 	if err != nil {

--- a/api/interface.go
+++ b/api/interface.go
@@ -66,7 +66,9 @@ type ClientInterface interface {
 	GetBuildSnapshotDependencies(buildID string) (*BuildList, error)
 	GetBuildChanges(buildID string) (*ChangeList, error)
 	GetBuildTests(buildID string, failedOnly bool, limit int) (*TestOccurrences, error)
+	GetBuildTestSummary(buildID string) (*TestOccurrences, error)
 	GetBuildProblems(buildID string) (*ProblemOccurrences, error)
+	GetBuildResultingProperties(buildID string) (*ParameterList, error)
 	UploadDiffChanges(patch []byte, description string) (string, error)
 
 	// Artifacts

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.21
 	github.com/moby/term v0.5.2
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/rogpeppe/go-internal v1.14.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
@@ -87,7 +88,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -1,0 +1,845 @@
+package run
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	tcerrors "github.com/JetBrains/teamcity-cli/internal/errors"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+type runDiffOptions struct {
+	json    bool
+	log     bool
+	web     bool
+	context int
+}
+
+func newRunDiffCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &runDiffOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "diff <run-id-1> [run-id-2]",
+		Short: "Compare two runs and show differences",
+		Long: `Compare two runs (builds) and highlight what changed between them.
+
+Shows differences in status, duration, agent, parameters, test results,
+and VCS changes. Useful for understanding why a build broke or what
+changed between a passing and failing run.
+
+Use --log to compare build logs with a colored unified diff, piped
+through a pager. Timestamps, temp paths, and git progress lines are
+normalized so the diff shows real content changes.
+
+Pipe to external diff tools for advanced views:
+  teamcity run diff 123 124 --log --no-color | delta
+  teamcity run diff 123 124 --log --no-color | diff-so-fancy
+
+If only one run ID is given, it is compared against the previous
+finished run of the same build configuration.`,
+		Args: cobra.RangeArgs(1, 2),
+		Example: `  teamcity run diff 123 124
+  teamcity run diff 456                # compare with previous run
+  teamcity run diff 123 124 --log      # compare build logs
+  teamcity run diff 123 124 --log -U5  # 5 lines context
+  teamcity run diff 123 124 --json
+  teamcity run diff 123 124 --web      # open both in browser`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRunDiff(f, args, opts)
+		},
+	}
+
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
+	cmd.Flags().BoolVar(&opts.log, "log", false, "Compare build logs with colored unified diff")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open both runs in browser")
+	cmd.Flags().IntVarP(&opts.context, "unified", "U", 3, "Number of context lines in log diff")
+
+	cmd.MarkFlagsMutuallyExclusive("json", "log")
+	cmd.MarkFlagsMutuallyExclusive("json", "web")
+	cmd.MarkFlagsMutuallyExclusive("log", "web")
+
+	cmdutil.MarkExperimental(f, cmd)
+	return cmd
+}
+
+type buildData struct {
+	build       *api.Build
+	tests       *api.TestOccurrences
+	testSummary *api.TestOccurrences
+	changes     *api.ChangeList
+	problems    *api.ProblemOccurrences
+	params      *api.ParameterList
+}
+
+func runRunDiff(f *cmdutil.Factory, args []string, opts *runDiffOptions) error {
+	p := f.Printer
+	client, err := f.Client()
+	if err != nil {
+		return err
+	}
+
+	id1, id2, err := resolveDiffBuildIDs(client, args)
+	if err != nil {
+		return err
+	}
+
+	if opts.web {
+		b1, err1 := client.GetBuild(id1)
+		b2, err2 := client.GetBuild(id2)
+		if err1 != nil {
+			return fmt.Errorf("resolving build %s: %w", id1, err1)
+		}
+		if err2 != nil {
+			return fmt.Errorf("resolving build %s: %w", id2, err2)
+		}
+		if b1.WebURL != "" {
+			_ = browser.OpenURL(b1.WebURL)
+		}
+		if b2.WebURL != "" {
+			_ = browser.OpenURL(b2.WebURL)
+		}
+		return nil
+	}
+
+	if opts.log {
+		return runLogDiff(f, client, id1, id2, opts.context)
+	}
+
+	d1, d2, err := fetchBothBuilds(client, id1, id2, p)
+	if err != nil {
+		return err
+	}
+
+	if opts.json {
+		return p.PrintJSON(buildDiffJSON(d1, d2))
+	}
+
+	renderDiff(p, d1, d2)
+	return nil
+}
+
+func resolveDiffBuildIDs(client api.ClientInterface, args []string) (string, string, error) {
+	if len(args) == 2 {
+		return args[0], args[1], nil
+	}
+
+	build, err := client.GetBuild(args[0])
+	if err != nil {
+		return "", "", fmt.Errorf("resolving build: %w", err)
+	}
+
+	builds, err := client.GetBuilds(api.BuildsOptions{
+		BuildTypeID: build.BuildTypeID,
+		Limit:       1,
+		State:       "finished",
+		UntilDate:   build.StartDate,
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("listing builds for %s: %w", build.BuildTypeID, err)
+	}
+
+	for _, b := range builds.Builds {
+		if b.ID != build.ID {
+			return fmt.Sprintf("%d", b.ID), args[0], nil
+		}
+	}
+
+	return "", "", tcerrors.WithSuggestion(
+		"no previous finished build found for "+build.BuildTypeID,
+		"provide two run IDs explicitly: teamcity run diff <id1> <id2>",
+	)
+}
+
+func fetchBuildData(client api.ClientInterface, id string, p *output.Printer) (buildData, error) {
+	b, err := client.GetBuild(id)
+	if err != nil {
+		return buildData{}, fmt.Errorf("build %s: %w", id, err)
+	}
+	d := buildData{build: b}
+	if d.tests, err = client.GetBuildTests(id, true, 0); err != nil {
+		p.Warn("Could not fetch tests for build %s: %v", id, err)
+	}
+	if d.testSummary, err = client.GetBuildTestSummary(id); err != nil {
+		p.Warn("Could not fetch test summary for build %s: %v", id, err)
+	}
+	if d.changes, err = client.GetBuildChanges(id); err != nil {
+		p.Warn("Could not fetch changes for build %s: %v", id, err)
+	}
+	if d.problems, err = client.GetBuildProblems(id); err != nil {
+		p.Warn("Could not fetch problems for build %s: %v", id, err)
+	}
+	if d.params, err = client.GetBuildResultingProperties(id); err != nil {
+		p.Warn("Could not fetch parameters for build %s: %v", id, err)
+	}
+	return d, nil
+}
+
+func fetchBothBuilds(client api.ClientInterface, id1, id2 string, p *output.Printer) (buildData, buildData, error) {
+	var d1, d2 buildData
+	var err1, err2 error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); d1, err1 = fetchBuildData(client, id1, p) }()
+	go func() { defer wg.Done(); d2, err2 = fetchBuildData(client, id2, p) }()
+	wg.Wait()
+	if err1 != nil {
+		return d1, d2, err1
+	}
+	return d1, d2, err2
+}
+
+// --- Log diff ---
+
+func runLogDiff(f *cmdutil.Factory, client api.ClientInterface, id1, id2 string, context int) error {
+	p := f.Printer
+
+	b1, err := client.GetBuild(id1)
+	if err != nil {
+		return err
+	}
+	b2, err := client.GetBuild(id2)
+	if err != nil {
+		return err
+	}
+
+	log1, err := client.GetBuildLog(id1)
+	if err != nil {
+		return fmt.Errorf("log for build %s: %w", id1, err)
+	}
+	log2, err := client.GetBuildLog(id2)
+	if err != nil {
+		return fmt.Errorf("log for build %s: %w", id2, err)
+	}
+
+	lines1 := output.NormalizeBuildLog(output.SplitLogLines(log1))
+	lines2 := output.NormalizeBuildLog(output.SplitLogLines(log2))
+
+	output.WithPager(p.Out, func(w io.Writer) {
+		hasDiff, err := output.UnifiedDiff(w, lines1, lines2,
+			fmt.Sprintf("Run #%s", b1.Number), fmt.Sprintf("Run #%s", b2.Number), context)
+		if err != nil {
+			_, _ = fmt.Fprintf(w, "Error: %v\n", err)
+			return
+		}
+		if !hasDiff {
+			_, _ = fmt.Fprintln(w, "Build logs are identical")
+		}
+	})
+
+	return nil
+}
+
+// --- Shared computation ---
+
+type paramDiff struct {
+	name     string
+	old, new string
+	kind     string // "changed", "added", "removed"
+}
+
+func computeParamDiffs(p1, p2 *api.ParameterList) []paramDiff {
+	if p1 == nil || p2 == nil {
+		return nil
+	}
+
+	m1 := paramMap(p1)
+	m2 := paramMap(p2)
+
+	var diffs []paramDiff
+	for name, v1 := range m1 {
+		if isAutoParam(name) {
+			continue
+		}
+		v2, ok := m2[name]
+		if !ok {
+			diffs = append(diffs, paramDiff{name, v1, "", "removed"})
+		} else if v1 != v2 {
+			diffs = append(diffs, paramDiff{name, v1, v2, "changed"})
+		}
+	}
+	for name, v2 := range m2 {
+		if isAutoParam(name) {
+			continue
+		}
+		if _, ok := m1[name]; !ok {
+			diffs = append(diffs, paramDiff{name, "", v2, "added"})
+		}
+	}
+
+	slices.SortFunc(diffs, func(a, b paramDiff) int { return cmp.Compare(a.name, b.name) })
+	return diffs
+}
+
+func computeTestDiffs(t1, t2, s1, s2 *api.TestOccurrences) (summaryChanged bool, newFailures []api.TestOccurrence, fixed []string) {
+	if t1 == nil || t2 == nil {
+		return false, nil, nil
+	}
+
+	if s1 != nil && s2 != nil {
+		summaryChanged = s1.Passed != s2.Passed || s1.Failed != s2.Failed || s1.Ignored != s2.Ignored
+	}
+
+	failed1 := testNamesByStatus(t1, "FAILURE")
+
+	for _, t := range t2.TestOccurrence {
+		if t.Status == "FAILURE" && !failed1[t.Name] {
+			newFailures = append(newFailures, t)
+		}
+	}
+	for name := range failed1 {
+		found := false
+		for _, t := range t2.TestOccurrence {
+			if t.Name == name && t.Status == "FAILURE" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			fixed = append(fixed, name)
+		}
+	}
+	slices.SortFunc(newFailures, func(a, b api.TestOccurrence) int { return cmp.Compare(a.Name, b.Name) })
+	slices.Sort(fixed)
+	return summaryChanged, newFailures, fixed
+}
+
+func computeChangeDiffs(c1, c2 *api.ChangeList) (onlyIn1, onlyIn2 []api.Change) {
+	set1 := changeVersionSet(c1)
+	set2 := changeVersionSet(c2)
+
+	if c1 != nil {
+		for _, c := range c1.Change {
+			if _, ok := set2[c.Version]; !ok {
+				onlyIn1 = append(onlyIn1, c)
+			}
+		}
+	}
+	if c2 != nil {
+		for _, c := range c2.Change {
+			if _, ok := set1[c.Version]; !ok {
+				onlyIn2 = append(onlyIn2, c)
+			}
+		}
+	}
+	return onlyIn1, onlyIn2
+}
+
+func computeProblemDiffs(pr1, pr2 *api.ProblemOccurrences) (newProblems, resolved []api.ProblemOccurrence) {
+	if pr1 == nil || pr2 == nil {
+		return nil, nil
+	}
+
+	set1 := problemIdentitySet(pr1)
+	set2 := problemIdentitySet(pr2)
+
+	for _, prob := range pr1.ProblemOccurrence {
+		if !set2[prob.Identity] {
+			resolved = append(resolved, prob)
+		}
+	}
+	for _, prob := range pr2.ProblemOccurrence {
+		if !set1[prob.Identity] {
+			newProblems = append(newProblems, prob)
+		}
+	}
+	return newProblems, resolved
+}
+
+// --- Rendering ---
+
+func renderDiff(p *output.Printer, d1, d2 buildData) {
+	b1, b2 := d1.build, d2.build
+
+	renderDiffHeader(p, b1, b2)
+
+	var sections []string
+	if renderStatusDiff(p, b1, b2) {
+		sections = append(sections, "status")
+	}
+	if renderProblemsDiff(p, d1.problems, d2.problems) {
+		sections = append(sections, "problems")
+	}
+	if renderTestsDiff(p, d1.tests, d2.tests, d1.testSummary, d2.testSummary) {
+		sections = append(sections, "tests")
+	}
+	if renderChangesDiff(p, d1.changes, d2.changes) {
+		sections = append(sections, "changes")
+	}
+	if renderParamsDiff(p, d1.params, d2.params) {
+		sections = append(sections, "parameters")
+	}
+	if renderAgentDiff(p, b1, b2) {
+		sections = append(sections, "agent")
+	}
+	if renderDurationDiff(p, b1, b2) {
+		sections = append(sections, "duration")
+	}
+
+	if len(sections) == 0 {
+		_, _ = fmt.Fprintf(p.Out, "\n%s\n", output.Faint("No differences found."))
+	}
+
+	renderDiffFooter(p, b1, b2, sections)
+}
+
+func renderDiffHeader(p *output.Printer, b1, b2 *api.Build) {
+	icon1 := output.StatusIcon(b1.Status, b1.State)
+	icon2 := output.StatusIcon(b2.Status, b2.State)
+
+	jobName := b1.BuildTypeID
+	if b1.BuildType != nil {
+		jobName = b1.BuildType.Name
+	}
+
+	_, _ = fmt.Fprintf(p.Out, "COMPARING  %s %d  #%s  →  %s %d  #%s\n",
+		icon1, b1.ID, b1.Number, icon2, b2.ID, b2.Number)
+
+	meta := output.Faint("Job: ") + output.Cyan(jobName)
+	if b1.BranchName != "" || b2.BranchName != "" {
+		branch := b1.BranchName
+		if b2.BranchName != "" && b2.BranchName != b1.BranchName {
+			branch = b1.BranchName + " → " + b2.BranchName
+		}
+		if branch != "" {
+			meta += output.Faint("  ·  Branch: ") + branch
+		}
+	}
+	_, _ = fmt.Fprintln(p.Out, meta)
+}
+
+func renderDiffFooter(p *output.Printer, b1, b2 *api.Build, sections []string) {
+	_, _ = fmt.Fprintln(p.Out)
+	if len(sections) > 0 {
+		_, _ = fmt.Fprintf(p.Out, "%s %s\n",
+			output.Faint("Changed:"), strings.Join(sections, ", "))
+	}
+	if b1.WebURL != "" {
+		_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("View -"), b1.WebURL)
+	}
+	if b2.WebURL != "" {
+		_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("View +"), b2.WebURL)
+	}
+}
+
+func sectionHeader(p *output.Printer, name string) {
+	_, _ = fmt.Fprintf(p.Out, "\n%s\n", output.Bold(name))
+}
+
+func diffLine(p *output.Printer, prefix, color string, format string, args ...any) {
+	output.DiffLine(p.Out, prefix, color, format, args...)
+}
+
+func renderStatusDiff(p *output.Printer, b1, b2 *api.Build) bool {
+	if b1.Status == b2.Status && b1.State == b2.State {
+		return false
+	}
+
+	sectionHeader(p, "STATUS")
+
+	statusLine1 := output.StatusText(b1.Status, b1.State)
+	if b1.StatusText != "" && b1.StatusText != b1.Status {
+		statusLine1 += output.Faint("  " + truncate(b1.StatusText, 80))
+	}
+	statusLine2 := output.StatusText(b2.Status, b2.State)
+	if b2.StatusText != "" && b2.StatusText != b2.Status {
+		statusLine2 += output.Faint("  " + truncate(b2.StatusText, 80))
+	}
+
+	diffLine(p, "-", "red", "%s", statusLine1)
+	diffLine(p, "+", "green", "%s", statusLine2)
+	return true
+}
+
+func renderDurationDiff(p *output.Printer, b1, b2 *api.Build) bool {
+	if b1.FinishDate == "" || b2.FinishDate == "" {
+		return false
+	}
+	dur1 := buildDuration(b1)
+	dur2 := buildDuration(b2)
+
+	if dur1 == dur2 {
+		return false
+	}
+
+	sectionHeader(p, "DURATION")
+
+	diffLine(p, "-", "red", "%s", output.FormatDuration(dur1))
+
+	delta := dur2 - dur1
+	sign := "+"
+	if delta < 0 {
+		sign = "-"
+		delta = -delta
+	}
+	diffLine(p, "+", "green", "%s  %s", output.FormatDuration(dur2),
+		output.Faint(fmt.Sprintf("(%s%s)", sign, output.FormatDuration(delta))))
+	return true
+}
+
+func renderAgentDiff(p *output.Printer, b1, b2 *api.Build) bool {
+	a1, a2 := agentName(b1), agentName(b2)
+	if a1 == a2 {
+		return false
+	}
+
+	sectionHeader(p, "AGENT")
+	diffLine(p, "-", "red", "%s", a1)
+	diffLine(p, "+", "green", "%s", a2)
+	return true
+}
+
+func renderParamsDiff(p *output.Printer, params1, params2 *api.ParameterList) bool {
+	diffs := computeParamDiffs(params1, params2)
+	if len(diffs) == 0 {
+		return false
+	}
+
+	sectionHeader(p, "PARAMETERS")
+
+	for _, c := range diffs {
+		switch c.kind {
+		case "changed":
+			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s → %s\n",
+				output.Yellow("~"), c.name, output.Red(c.old), output.Green(c.new))
+		case "added":
+			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s\n",
+				output.Green("+"), c.name, output.Green(c.new))
+		case "removed":
+			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s\n",
+				output.Red("-"), c.name, output.Red(c.old))
+		}
+	}
+
+	return true
+}
+
+func renderChangesDiff(p *output.Printer, c1, c2 *api.ChangeList) bool {
+	onlyIn1, onlyIn2 := computeChangeDiffs(c1, c2)
+	if len(onlyIn1) == 0 && len(onlyIn2) == 0 {
+		return false
+	}
+
+	sectionHeader(p, "CHANGES")
+
+	for _, c := range onlyIn1 {
+		_, _ = fmt.Fprintf(p.Out, "  %s %s  %s  %s\n",
+			output.Red("-"), output.Yellow(shortSHA(c.Version)), output.Faint(shortUsername(c.Username)), firstLine(c.Comment))
+	}
+	for _, c := range onlyIn2 {
+		_, _ = fmt.Fprintf(p.Out, "  %s %s  %s  %s\n",
+			output.Green("+"), output.Yellow(shortSHA(c.Version)), output.Faint(shortUsername(c.Username)), firstLine(c.Comment))
+	}
+
+	return true
+}
+
+func renderTestsDiff(p *output.Printer, t1, t2, s1, s2 *api.TestOccurrences) bool {
+	summaryChanged, newFailures, fixed := computeTestDiffs(t1, t2, s1, s2)
+	if !summaryChanged && len(newFailures) == 0 && len(fixed) == 0 {
+		return false
+	}
+
+	sectionHeader(p, "TESTS")
+
+	if summaryChanged {
+		diffLine(p, "-", "red", "%s", testSummaryStr(s1))
+		diffLine(p, "+", "green", "%s", testSummaryStr(s2))
+	}
+
+	if len(newFailures) > 0 {
+		_, _ = fmt.Fprintf(p.Out, "  %s\n", output.Red("New failures:"))
+		for _, t := range newFailures {
+			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red("✗"), t.Name)
+			if t.Details != "" {
+				_, _ = fmt.Fprintf(p.Out, "      %s\n", output.Faint(truncate(t.Details, 120)))
+			}
+		}
+	}
+
+	if len(fixed) > 0 {
+		_, _ = fmt.Fprintf(p.Out, "  %s\n", output.Green("Fixed:"))
+		for _, name := range fixed {
+			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Green("✓"), name)
+		}
+	}
+
+	return true
+}
+
+func renderProblemsDiff(p *output.Printer, pr1, pr2 *api.ProblemOccurrences) bool {
+	newProblems, resolved := computeProblemDiffs(pr1, pr2)
+	if len(newProblems) == 0 && len(resolved) == 0 {
+		return false
+	}
+
+	sectionHeader(p, "PROBLEMS")
+
+	for _, prob := range resolved {
+		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Red("-"), firstLine(prob.Details))
+	}
+	for _, prob := range newProblems {
+		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Green("+"), firstLine(prob.Details))
+	}
+
+	return true
+}
+
+// --- JSON output ---
+
+func buildDiffJSON(d1, d2 buildData) map[string]any {
+	b1, b2 := d1.build, d2.build
+
+	jsonBuild := func(b *api.Build) map[string]any {
+		m := map[string]any{"id": b.ID, "number": b.Number, "status": b.Status, "state": b.State}
+		if a := agentName(b); a != "" {
+			m["agent"] = a
+		}
+		return m
+	}
+
+	diff := map[string]any{}
+
+	if b1.Status != b2.Status || b1.State != b2.State {
+		diff["status"] = map[string]any{"from": statusString(b1), "to": statusString(b2)}
+	}
+	if b1.FinishDate != "" && b2.FinishDate != "" {
+		if dur1, dur2 := buildDuration(b1), buildDuration(b2); dur1 != dur2 {
+			diff["duration"] = map[string]any{"from": dur1.String(), "to": dur2.String()}
+		}
+	}
+	if a1, a2 := agentName(b1), agentName(b2); a1 != a2 {
+		diff["agent"] = map[string]any{"from": a1, "to": a2}
+	}
+
+	if diffs := computeParamDiffs(d1.params, d2.params); len(diffs) > 0 {
+		params := make([]map[string]any, len(diffs))
+		for i, d := range diffs {
+			params[i] = map[string]any{"name": d.name, "from": d.old, "to": d.new, "type": d.kind}
+		}
+		diff["parameters"] = params
+	}
+
+	if summaryChanged, newFail, fixed := computeTestDiffs(d1.tests, d2.tests, d1.testSummary, d2.testSummary); summaryChanged || len(newFail) > 0 || len(fixed) > 0 {
+		tests := map[string]any{
+			"from": testSummaryJSON(d1.testSummary),
+			"to":   testSummaryJSON(d2.testSummary),
+		}
+		if len(newFail) > 0 {
+			failures := make([]map[string]string, len(newFail))
+			for i, t := range newFail {
+				failures[i] = map[string]string{"name": t.Name, "details": firstLine(t.Details)}
+			}
+			tests["newFailures"] = failures
+		}
+		if len(fixed) > 0 {
+			tests["fixed"] = fixed
+		}
+		diff["tests"] = tests
+	}
+
+	if only1, only2 := computeChangeDiffs(d1.changes, d2.changes); len(only1) > 0 || len(only2) > 0 {
+		jsonChange := func(c api.Change) map[string]string {
+			return map[string]string{"sha": c.Version, "author": c.Username, "message": firstLine(c.Comment)}
+		}
+		changes := map[string]any{}
+		if len(only1) > 0 {
+			c := make([]map[string]string, len(only1))
+			for i, v := range only1 {
+				c[i] = jsonChange(v)
+			}
+			changes["onlyInRun1"] = c
+		}
+		if len(only2) > 0 {
+			c := make([]map[string]string, len(only2))
+			for i, v := range only2 {
+				c[i] = jsonChange(v)
+			}
+			changes["onlyInRun2"] = c
+		}
+		diff["changes"] = changes
+	}
+
+	if newProbs, resolved := computeProblemDiffs(d1.problems, d2.problems); len(newProbs) > 0 || len(resolved) > 0 {
+		problems := map[string]any{}
+		if len(newProbs) > 0 {
+			p := make([]string, len(newProbs))
+			for i, v := range newProbs {
+				p[i] = firstLine(v.Details)
+			}
+			problems["new"] = p
+		}
+		if len(resolved) > 0 {
+			p := make([]string, len(resolved))
+			for i, v := range resolved {
+				p[i] = firstLine(v.Details)
+			}
+			problems["resolved"] = p
+		}
+		diff["problems"] = problems
+	}
+
+	return map[string]any{"run1": jsonBuild(b1), "run2": jsonBuild(b2), "diff": diff}
+}
+
+// --- Helpers ---
+
+func buildDuration(b *api.Build) time.Duration {
+	if b.StartDate == "" || b.FinishDate == "" {
+		return 0
+	}
+	start, err1 := api.ParseTeamCityTime(b.StartDate)
+	finish, err2 := api.ParseTeamCityTime(b.FinishDate)
+	if err1 != nil || err2 != nil {
+		return 0
+	}
+	return finish.Sub(start)
+}
+
+func agentName(b *api.Build) string {
+	if b.Agent != nil {
+		return b.Agent.Name
+	}
+	return ""
+}
+
+func statusString(b *api.Build) string {
+	if b.State == "running" {
+		return "running"
+	}
+	if b.State == "queued" {
+		return "queued"
+	}
+	return strings.ToLower(b.Status)
+}
+
+func paramMap(pl *api.ParameterList) map[string]string {
+	m := make(map[string]string, len(pl.Property))
+	for _, p := range pl.Property {
+		if p.Type != nil && p.Type.RawValue == "password" {
+			continue
+		}
+		m[p.Name] = p.Value
+	}
+	return m
+}
+
+var autoParamPrefixes = []string{
+	"teamcity.",
+	"system.teamcity.",
+	"system.build.",
+	"system.agent.",
+	"system.ec2.",
+	"system.cloud.",
+	"build.number",
+	"build.vcs.number",
+	"build.counter",
+	"env.BUILD_NUMBER",
+	"env.BUILD_URL",
+	"env.BUILD_VCS_NUMBER",
+	"env.SSH_AUTH_SOCK",
+	"env.INVOCATION_ID",
+	"env.JOURNAL_STREAM",
+	"env.SYSTEMD_EXEC_PID",
+}
+
+func isAutoParam(name string) bool {
+	for _, prefix := range autoParamPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func changeVersionSet(cl *api.ChangeList) map[string]struct{} {
+	m := make(map[string]struct{})
+	if cl != nil {
+		for _, c := range cl.Change {
+			m[c.Version] = struct{}{}
+		}
+	}
+	return m
+}
+
+func testNamesByStatus(tests *api.TestOccurrences, status string) map[string]bool {
+	m := make(map[string]bool)
+	for _, t := range tests.TestOccurrence {
+		if t.Status == status {
+			m[t.Name] = true
+		}
+	}
+	return m
+}
+
+func testSummaryJSON(t *api.TestOccurrences) map[string]int {
+	if t == nil {
+		return map[string]int{"passed": 0, "failed": 0, "ignored": 0}
+	}
+	return map[string]int{"passed": t.Passed, "failed": t.Failed, "ignored": t.Ignored}
+}
+
+func testSummaryStr(t *api.TestOccurrences) string {
+	if t == nil {
+		return "no tests"
+	}
+	var parts []string
+	if t.Passed > 0 {
+		parts = append(parts, fmt.Sprintf("%d passed", t.Passed))
+	}
+	if t.Failed > 0 {
+		parts = append(parts, fmt.Sprintf("%d failed", t.Failed))
+	}
+	if t.Ignored > 0 {
+		parts = append(parts, fmt.Sprintf("%d ignored", t.Ignored))
+	}
+	if len(parts) == 0 {
+		return "no tests"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func problemIdentitySet(pr *api.ProblemOccurrences) map[string]bool {
+	m := make(map[string]bool)
+	if pr != nil {
+		for _, p := range pr.ProblemOccurrence {
+			m[p.Identity] = true
+		}
+	}
+	return m
+}
+
+func truncate(s string, maxLen int) string {
+	s = firstLine(s)
+	return output.Truncate(s, maxLen)
+}
+
+func shortUsername(username string) string {
+	if idx := strings.IndexByte(username, '@'); idx > 0 {
+		return username[:idx]
+	}
+	return username
+}
+
+func shortSHA(sha string) string {
+	if len(sha) > 7 {
+		return sha[:7]
+	}
+	return sha
+}
+
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if idx := strings.IndexByte(s, '\n'); idx > 0 {
+		return s[:idx]
+	}
+	return s
+}

--- a/internal/cmd/run/diff_test.go
+++ b/internal/cmd/run/diff_test.go
@@ -1,0 +1,323 @@
+package run_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/config"
+)
+
+func setupDiffServer(t *testing.T) *cmdtest.TestServer {
+	t.Helper()
+	ts := cmdtest.NewTestServer(t)
+
+	ts.Handle("GET /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Server{VersionMajor: 2025, VersionMinor: 7, BuildNumber: "197398"})
+	})
+	ts.Handle("HEAD /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ts.Handle("GET /app/rest/builds/id:1", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/resulting-properties") {
+			cmdtest.JSON(w, api.ParameterList{
+				Count: 2,
+				Property: []api.Parameter{
+					{Name: "version", Value: "1.0.0"},
+					{Name: "env.JAVA_HOME", Value: "/usr/lib/jvm/java-11"},
+				},
+			})
+			return
+		}
+		cmdtest.JSON(w, api.Build{
+			ID:          1,
+			Number:      "1",
+			Status:      "SUCCESS",
+			State:       "finished",
+			BuildTypeID: "TestProject_Build",
+			BuildType:   &api.BuildType{ID: "TestProject_Build", Name: "Build"},
+			BranchName:  "main",
+			StartDate:   "20240101T120000+0000",
+			FinishDate:  "20240101T120230+0000",
+			WebURL:      ts.URL + "/viewLog.html?buildId=1",
+			Agent:       &api.Agent{ID: 1, Name: "Agent-Linux-01"},
+		})
+	})
+
+	ts.Handle("GET /app/rest/builds/id:2", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/resulting-properties") {
+			cmdtest.JSON(w, api.ParameterList{
+				Count: 3,
+				Property: []api.Parameter{
+					{Name: "version", Value: "1.0.1"},
+					{Name: "env.JAVA_HOME", Value: "/usr/lib/jvm/java-17"},
+					{Name: "new.feature", Value: "enabled"},
+				},
+			})
+			return
+		}
+		cmdtest.JSON(w, api.Build{
+			ID:          2,
+			Number:      "2",
+			Status:      "FAILURE",
+			State:       "finished",
+			BuildTypeID: "TestProject_Build",
+			BuildType:   &api.BuildType{ID: "TestProject_Build", Name: "Build"},
+			BranchName:  "main",
+			StartDate:   "20240101T130000+0000",
+			FinishDate:  "20240101T130315+0000",
+			StatusText:  "Tests failed: 2",
+			WebURL:      ts.URL + "/viewLog.html?buildId=2",
+			Agent:       &api.Agent{ID: 2, Name: "Agent-Linux-02"},
+		})
+	})
+
+	ts.Handle("GET /app/rest/changes", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.RawQuery
+		if strings.Contains(q, "id%3A1") || strings.Contains(q, "id:1") {
+			cmdtest.JSON(w, api.ChangeList{
+				Count: 1,
+				Change: []api.Change{
+					{ID: 1, Version: "aaa1111", Username: "alice", Comment: "Initial commit"},
+				},
+			})
+			return
+		}
+		if strings.Contains(q, "id%3A2") || strings.Contains(q, "id:2") {
+			cmdtest.JSON(w, api.ChangeList{
+				Count: 2,
+				Change: []api.Change{
+					{ID: 1, Version: "aaa1111", Username: "alice", Comment: "Initial commit"},
+					{ID: 2, Version: "bbb2222", Username: "bob", Comment: "Break the tests"},
+				},
+			})
+			return
+		}
+		cmdtest.JSON(w, api.ChangeList{Count: 0})
+	})
+
+	ts.Handle("GET /app/rest/testOccurrences", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.RawQuery
+		if strings.Contains(q, "id%3A1") || strings.Contains(q, "id:1") {
+			cmdtest.JSON(w, api.TestOccurrences{
+				Count:  3,
+				Passed: 3,
+				Failed: 0,
+				TestOccurrence: []api.TestOccurrence{
+					{ID: "t1", Name: "TestLogin", Status: "SUCCESS"},
+					{ID: "t2", Name: "TestPayment", Status: "SUCCESS"},
+					{ID: "t3", Name: "TestSearch", Status: "SUCCESS"},
+				},
+			})
+			return
+		}
+		if strings.Contains(q, "id%3A2") || strings.Contains(q, "id:2") {
+			cmdtest.JSON(w, api.TestOccurrences{
+				Count:  3,
+				Passed: 1,
+				Failed: 2,
+				TestOccurrence: []api.TestOccurrence{
+					{ID: "t1", Name: "TestLogin", Status: "FAILURE"},
+					{ID: "t2", Name: "TestPayment", Status: "FAILURE"},
+					{ID: "t3", Name: "TestSearch", Status: "SUCCESS"},
+				},
+			})
+			return
+		}
+		cmdtest.JSON(w, api.TestOccurrences{Count: 0})
+	})
+
+	ts.Handle("GET /app/rest/problemOccurrences", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.RawQuery
+		if strings.Contains(q, "id%3A1") || strings.Contains(q, "id:1") {
+			cmdtest.JSON(w, api.ProblemOccurrences{Count: 0, ProblemOccurrence: []api.ProblemOccurrence{}})
+			return
+		}
+		if strings.Contains(q, "id%3A2") || strings.Contains(q, "id:2") {
+			cmdtest.JSON(w, api.ProblemOccurrences{
+				Count: 1,
+				ProblemOccurrence: []api.ProblemOccurrence{
+					{ID: "p1", Type: "TC_FAILED_TESTS", Identity: "failedTests", Details: "2 tests failed"},
+				},
+			})
+			return
+		}
+		cmdtest.JSON(w, api.ProblemOccurrences{Count: 0, ProblemOccurrence: []api.ProblemOccurrence{}})
+	})
+
+	ts.Handle("GET /downloadBuildLog.html", func(w http.ResponseWriter, r *http.Request) {
+		buildID := r.URL.Query().Get("buildId")
+		header := "Build #1 header\nTriggered\nStarted on agent\nFinished\nVCS rev\nTeamCity URL\nServer version\nServer timezone\n"
+		switch buildID {
+		case "1":
+			cmdtest.Text(w, header+"[12:00:01] Compiling...\n[12:00:05] Running tests...\n[12:00:08] TestLogin passed\n[12:00:09] TestPayment passed\n[12:00:10] All tests passed\n[12:00:10] Build finished")
+		case "2":
+			cmdtest.Text(w, header+"[13:00:01] Compiling...\n[13:00:05] Running tests...\n[13:00:08]E: TestLogin FAILED\n[13:00:09]E: TestPayment FAILED\n[13:00:10] 2 tests failed\n[13:00:10] Build finished with errors")
+		default:
+			cmdtest.Text(w, "")
+		}
+	})
+
+	config.SetUserForServer(ts.URL, "admin")
+	return ts
+}
+
+func TestRunDiffLog(t *testing.T) {
+	ts := setupDiffServer(t)
+
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "diff", "1", "2", "--log")
+
+	assert.Contains(t, got, "#1")
+	assert.Contains(t, got, "#2")
+	assert.Contains(t, got, "@@")
+	assert.Contains(t, got, "-")
+	assert.Contains(t, got, "All tests passed")
+	assert.Contains(t, got, "+")
+	assert.Contains(t, got, "TestLogin FAILED")
+	assert.Contains(t, got, "TestPayment FAILED")
+}
+
+func TestRunDiffLogIdentical(t *testing.T) {
+	ts := cmdtest.NewTestServer(t)
+	ts.Handle("GET /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Server{VersionMajor: 2025, VersionMinor: 7, BuildNumber: "197398"})
+	})
+	ts.Handle("HEAD /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	ts.Handle("GET /app/rest/builds/id:", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Build{ID: 1, Number: "1", Status: "SUCCESS", State: "finished"})
+	})
+	ts.Handle("GET /downloadBuildLog.html", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.Text(w, "h1\nh2\nh3\nh4\nh5\nh6\nh7\nh8\n[12:00:00] Build started\n[12:00:10] Build finished")
+	})
+	config.SetUserForServer(ts.URL, "admin")
+
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "diff", "1", "1", "--log")
+	assert.Contains(t, got, "identical")
+}
+
+func TestRunDiff(t *testing.T) {
+	ts := setupDiffServer(t)
+
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "diff", "1", "2")
+
+	assert.Contains(t, got, "COMPARING")
+	assert.Contains(t, got, "#1")
+	assert.Contains(t, got, "#2")
+
+	assert.Contains(t, got, "STATUS")
+	assert.Contains(t, got, "Success")
+	assert.Contains(t, got, "Failed")
+
+	assert.Contains(t, got, "DURATION")
+
+	assert.Contains(t, got, "AGENT")
+	assert.Contains(t, got, "Agent-Linux-01")
+	assert.Contains(t, got, "Agent-Linux-02")
+
+	assert.Contains(t, got, "PARAMETERS")
+	assert.Contains(t, got, "version")
+	assert.Contains(t, got, "1.0.0")
+	assert.Contains(t, got, "1.0.1")
+	assert.Contains(t, got, "new.feature")
+
+	assert.Contains(t, got, "CHANGES")
+	assert.Contains(t, got, "bbb2222")
+	assert.Contains(t, got, "bob")
+
+	assert.Contains(t, got, "TESTS")
+	assert.Contains(t, got, "TestLogin")
+	assert.Contains(t, got, "TestPayment")
+	assert.Contains(t, got, "New failures")
+
+	assert.Contains(t, got, "PROBLEMS")
+	assert.Contains(t, got, "2 tests failed")
+
+	assert.Contains(t, got, "Changed:")
+	assert.Contains(t, got, "View -")
+	assert.Contains(t, got, "View +")
+}
+
+func TestRunDiffJSON(t *testing.T) {
+	ts := setupDiffServer(t)
+
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "diff", "1", "2", "--json")
+
+	assert.Contains(t, got, `"run1"`)
+	assert.Contains(t, got, `"run2"`)
+	assert.Contains(t, got, `"diff"`)
+	assert.Contains(t, got, `"status"`)
+	assert.Contains(t, got, `"parameters"`)
+	assert.Contains(t, got, `"tests"`)
+	assert.Contains(t, got, `"newFailures"`)
+}
+
+func TestRunDiffSingleArg(t *testing.T) {
+	ts := setupDiffServer(t)
+
+	ts.Handle("GET /app/rest/builds", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.BuildList{
+			Count: 2,
+			Builds: []api.Build{
+				{ID: 2, Number: "2", Status: "FAILURE", State: "finished", BuildTypeID: "TestProject_Build"},
+				{ID: 1, Number: "1", Status: "SUCCESS", State: "finished", BuildTypeID: "TestProject_Build"},
+			},
+		})
+	})
+
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "diff", "2")
+
+	assert.Contains(t, got, "COMPARING")
+	assert.Contains(t, got, "#1")
+	assert.Contains(t, got, "#2")
+}
+
+func TestRunDiffIdenticalBuilds(t *testing.T) {
+	ts := cmdtest.NewTestServer(t)
+
+	ts.Handle("GET /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Server{VersionMajor: 2025, VersionMinor: 7, BuildNumber: "197398"})
+	})
+	ts.Handle("HEAD /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	build := api.Build{
+		ID: 1, Number: "1", Status: "SUCCESS", State: "finished",
+		BuildTypeID: "TestProject_Build",
+		BuildType:   &api.BuildType{ID: "TestProject_Build", Name: "Build"},
+		StartDate:   "20240101T120000+0000",
+		FinishDate:  "20240101T120100+0000",
+		Agent:       &api.Agent{ID: 1, Name: "Agent-01"},
+	}
+
+	ts.Handle("GET /app/rest/builds/id:", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/resulting-properties") {
+			cmdtest.JSON(w, api.ParameterList{Count: 0})
+			return
+		}
+		cmdtest.JSON(w, build)
+	})
+	ts.Handle("GET /app/rest/testOccurrences", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.TestOccurrences{Count: 1, Passed: 1, TestOccurrence: []api.TestOccurrence{
+			{ID: "t1", Name: "Test1", Status: "SUCCESS"},
+		}})
+	})
+	ts.Handle("GET /app/rest/changes", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.ChangeList{Count: 0})
+	})
+	ts.Handle("GET /app/rest/problemOccurrences", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.ProblemOccurrences{Count: 0, ProblemOccurrence: []api.ProblemOccurrence{}})
+	})
+
+	config.SetUserForServer(ts.URL, "admin")
+
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "diff", "1", "1")
+	assert.Contains(t, got, "No differences found")
+}

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -126,6 +126,7 @@ func formatLogLine(line string) string {
 	} else if len(rest) >= 3 && rest[0] == ' ' && rest[1] == ':' {
 		content = rest[2:]
 	}
+	content = output.RestoreAnsi(content)
 	content = strings.TrimPrefix(content, " ")
 
 	switch msgType {

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -31,6 +31,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(newRunChangesCmd(f))
 	cmd.AddCommand(newRunTestsCmd(f))
 	cmd.AddCommand(newRunTreeCmd(f))
+	cmd.AddCommand(newRunDiffCmd(f))
 
 	return cmd
 }

--- a/internal/cmd/run/tui/tui.go
+++ b/internal/cmd/run/tui/tui.go
@@ -169,7 +169,7 @@ func formatWatchLogLine(line string) string {
 		return ""
 	}
 
-	return fmt.Sprintf("[%s] %s", timestamp, rest)
+	return fmt.Sprintf("[%s] %s", timestamp, output.RestoreAnsi(rest))
 }
 
 func (m watchModel) View() string {

--- a/internal/cmdtest/mock_handlers.go
+++ b/internal/cmdtest/mock_handlers.go
@@ -573,6 +573,28 @@ func SetupMockClient(t *testing.T) *TestServer {
 		})
 	})
 
+	// Resulting properties (for run diff)
+	ts.Handle("GET /app/rest/builds/id:1/resulting-properties", func(w http.ResponseWriter, r *http.Request) {
+		JSON(w, api.ParameterList{
+			Count: 2,
+			Property: []api.Parameter{
+				{Name: "version", Value: "1.0.0"},
+				{Name: "env.JAVA_HOME", Value: "/usr/lib/jvm/java-11"},
+			},
+		})
+	})
+
+	ts.Handle("GET /app/rest/builds/id:2/resulting-properties", func(w http.ResponseWriter, r *http.Request) {
+		JSON(w, api.ParameterList{
+			Count: 3,
+			Property: []api.Parameter{
+				{Name: "version", Value: "1.0.1"},
+				{Name: "env.JAVA_HOME", Value: "/usr/lib/jvm/java-17"},
+				{Name: "new.feature", Value: "enabled"},
+			},
+		})
+	})
+
 	ts.Handle("GET /app/rest/cloud/images/", func(w http.ResponseWriter, r *http.Request) {
 		JSON(w, api.CloudImage{
 			ID: "id:img-1,profileId:aws-prod", Name: "ubuntu-22-large",

--- a/internal/cmdutil/experimental.go
+++ b/internal/cmdutil/experimental.go
@@ -1,0 +1,35 @@
+package cmdutil
+
+import "github.com/spf13/cobra"
+
+// MarkExperimental tags a command as experimental and warns on each invocation.
+func MarkExperimental(f *Factory, cmd *cobra.Command) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations["experimental"] = "true"
+	cmd.Short = "[experimental] " + cmd.Short
+
+	inner := cmd.RunE
+	if inner == nil {
+		return
+	}
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		f.Printer.Warn("%q is experimental: flags, output, and JSON schema may change or the command may be removed without notice. It is intentionally undocumented — do not rely on it in scripts.", cmd.CommandPath())
+		return inner(cmd, args)
+	}
+}
+
+// IsExperimental reports whether the command (or any of its parents) is marked experimental.
+func IsExperimental(cmd *cobra.Command) bool {
+	if cmd.Annotations["experimental"] == "true" {
+		return true
+	}
+	found := false
+	cmd.VisitParents(func(p *cobra.Command) {
+		if p.Annotations["experimental"] == "true" {
+			found = true
+		}
+	})
+	return found
+}

--- a/internal/cmdutil/experimental_test.go
+++ b/internal/cmdutil/experimental_test.go
@@ -1,0 +1,84 @@
+package cmdutil
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarkExperimental(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	f := &Factory{
+		Printer: &output.Printer{
+			Out:    &bytes.Buffer{},
+			ErrOut: &stderr,
+		},
+	}
+
+	ran := false
+	cmd := &cobra.Command{
+		Use:   "frobnicate",
+		Short: "Do the thing",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ran = true
+			return nil
+		},
+	}
+
+	MarkExperimental(f, cmd)
+
+	assert.Equal(t, "[experimental] Do the thing", cmd.Short)
+	assert.Equal(t, "true", cmd.Annotations["experimental"])
+	assert.True(t, IsExperimental(cmd))
+
+	// Execute and verify the notice is printed
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+	assert.True(t, ran)
+	assert.Contains(t, stderr.String(), "experimental")
+	assert.Contains(t, stderr.String(), "frobnicate")
+}
+
+func TestMarkExperimental_Quiet(t *testing.T) {
+	t.Parallel()
+
+	var stderr bytes.Buffer
+	f := &Factory{
+		Quiet: true,
+		Printer: &output.Printer{
+			Out:    &bytes.Buffer{},
+			ErrOut: &stderr,
+			Quiet:  true,
+		},
+	}
+
+	cmd := &cobra.Command{
+		Use:   "frobnicate",
+		Short: "Do the thing",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	MarkExperimental(f, cmd)
+	cmd.SetArgs([]string{})
+	require.NoError(t, cmd.Execute())
+	assert.Empty(t, stderr.String())
+}
+
+func TestIsExperimental_Parent(t *testing.T) {
+	t.Parallel()
+
+	parent := &cobra.Command{Use: "parent", Annotations: map[string]string{"experimental": "true"}}
+	child := &cobra.Command{Use: "child", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+	parent.AddCommand(child)
+
+	assert.True(t, IsExperimental(child))
+	assert.False(t, IsExperimental(&cobra.Command{Use: "standalone"}))
+}

--- a/internal/output/color.go
+++ b/internal/output/color.go
@@ -1,6 +1,10 @@
 package output
 
-import "github.com/fatih/color"
+import (
+	"regexp"
+
+	"github.com/fatih/color"
+)
 
 var (
 	Green  = color.New(color.FgGreen).SprintFunc()
@@ -10,3 +14,20 @@ var (
 	Bold   = color.New(color.Bold).SprintFunc()
 	Faint  = color.New(color.Faint).SprintFunc()
 )
+
+// TCAnsiRe matches real ESC sequences and TC's space-prefixed ANSI codes (` [33m` instead of `\x1b[33m`).
+var TCAnsiRe = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]| \[[0-9;]*m`)
+
+// RestoreAnsi converts TC's space-prefixed ANSI codes to real terminal escape sequences.
+// When color.NoColor is true (non-TTY or --no-color), all ANSI sequences are stripped instead.
+func RestoreAnsi(s string) string {
+	if color.NoColor {
+		return TCAnsiRe.ReplaceAllString(s, "")
+	}
+	return TCAnsiRe.ReplaceAllStringFunc(s, func(match string) string {
+		if match[0] == '\x1b' {
+			return match // already real ANSI
+		}
+		return "\x1b" + match[1:] // replace leading space with ESC
+	})
+}

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -1,0 +1,112 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+// UnifiedDiff writes a colored unified diff between two line slices, returns true if they differ.
+func UnifiedDiff(w io.Writer, a, b []string, fromLabel, toLabel string, context int) (bool, error) {
+	diff := difflib.UnifiedDiff{
+		A:        a,
+		B:        b,
+		FromFile: fromLabel,
+		ToFile:   toLabel,
+		Context:  context,
+	}
+
+	text, err := difflib.GetUnifiedDiffString(diff)
+	if err != nil {
+		return false, fmt.Errorf("computing diff: %w", err)
+	}
+
+	if text == "" {
+		return false, nil
+	}
+
+	for line := range strings.SplitSeq(text, "\n") {
+		_, _ = fmt.Fprintln(w, ColorDiffLine(line))
+	}
+
+	return true, nil
+}
+
+var (
+	tcTimestampRe = regexp.MustCompile(`\[\d{2}:\d{2}:\d{2}\]`)
+	tcTempPathRe  = regexp.MustCompile(`/(opt|mnt)/buildAgent/temp/\S+`)
+	tcAgentNameRe = regexp.MustCompile(`i-[0-9a-f]{10,}-VM-\d+`)
+	gitProgressRe = regexp.MustCompile(`(remote: )?(Counting|Compressing|Enumerating|Receiving|Resolving) (objects|deltas):\s+\d+%`)
+)
+
+// NormalizeBuildLog strips per-run noise (header, ANSI, timestamps, temp paths, agent IDs, git progress).
+func NormalizeBuildLog(lines []string) []string {
+	start := 0
+	for i := 0; i < min(15, len(lines)); i++ {
+		if tcTimestampRe.MatchString(lines[i]) {
+			start = i
+			break
+		}
+	}
+
+	out := make([]string, 0, len(lines)-start)
+	for i := start; i < len(lines); i++ {
+		line := lines[i]
+		if gitProgressRe.MatchString(line) {
+			continue
+		}
+		line = TCAnsiRe.ReplaceAllString(line, "")
+		line = tcTimestampRe.ReplaceAllString(line, "[]")
+		line = tcTempPathRe.ReplaceAllString(line, "<tmp>")
+		line = tcAgentNameRe.ReplaceAllString(line, "<agent>")
+		out = append(out, line)
+	}
+	return out
+}
+
+// SplitLogLines splits a log string into \n-terminated lines for difflib.
+func SplitLogLines(log string) []string {
+	lines := strings.Split(log, "\n")
+	result := make([]string, len(lines))
+	for i, line := range lines {
+		result[i] = strings.TrimSuffix(line, "\r") + "\n"
+	}
+	return result
+}
+
+// ColorDiffLine applies git-style coloring to a single diff line.
+func ColorDiffLine(line string) string {
+	switch {
+	case strings.HasPrefix(line, "---"), strings.HasPrefix(line, "+++"):
+		return Bold(line)
+	case strings.HasPrefix(line, "@@"):
+		return Cyan(line)
+	case strings.HasPrefix(line, "-"):
+		return Red(line)
+	case strings.HasPrefix(line, "+"):
+		return Green(line)
+	default:
+		return line
+	}
+}
+
+// DiffLine prints a single line with a colored prefix (used for structured diffs).
+func DiffLine(w io.Writer, prefix, color string, format string, args ...any) {
+	text := fmt.Sprintf(format, args...)
+	var colorFn func(...any) string
+	switch color {
+	case "red":
+		colorFn = Red
+	case "green":
+		colorFn = Green
+	case "yellow":
+		colorFn = Yellow
+	default:
+		_, _ = fmt.Fprintf(w, "    %s\n", text)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "  %s %s\n", colorFn(prefix), text)
+}


### PR DESCRIPTION
## Summary

Add `teamcity run diff` to compare two runs and highlight what changed — status, problems, tests, VCS changes, parameters, agent, duration. Supports structured output, JSON, log diff, and `--web`.

## Changes

- **`internal/cmd/run/diff.go`** — new command with structured metadata diff, log diff (`--log`), JSON output (`--json`), `--web` flag, single-arg auto-resolution (finds previous finished build)
- **`internal/output/diff.go`** — `UnifiedDiff` (colored unified diff via go-difflib), `NormalizeBuildLog` (strips timestamps, temp paths, agent IDs, ANSI codes, git progress), `SplitLogLines`, `ColorDiffLine`, `DiffLine`
- **`internal/output/color.go`** — `TCAnsiRe` (shared regex for TC's space-prefixed ANSI codes), `RestoreAnsi` (converts ` [33m` → `\x1b[33m` for terminal rendering)
- **`internal/cmd/run/log.go`** — call `RestoreAnsi` in `formatLogLine` so embedded ANSI codes from build tools (Terraform, etc.) render as terminal colors
- **`api/interface.go`** + **`api/builds_metadata.go`** — add `GetBuildResultingProperties` for parameter comparison
- **`go.mod`** — promote `pmezard/go-difflib` from indirect to direct dependency

## Design Decisions

- **Two modes**: default structured diff (status → problems → tests → changes → params → agent → duration) and `--log` for normalized unified diff of build logs. Sections ordered most-actionable-first.
- **Log normalization strips, doesn't filter**: timestamps → `[]`, temp paths → `<tmp>`, agent IDs → `<agent>`, ANSI codes removed, git progress dropped. No language-specific filtering — for advanced views, pipe to `delta`/`diff-so-fancy`.
- **TC ANSI handling**: TeamCity stores ANSI codes with space prefix instead of ESC byte (` [33m` not `\x1b[33m`). `RestoreAnsi` converts them back for `run log`; `NormalizeBuildLog` strips them for `run diff --log`. Regex derived from TC's own `AnsiText.tsx` component.
- **Shared compute functions** (`computeParamDiffs`, `computeTestDiffs`, etc.) eliminate duplication between render and JSON output paths.
- **Auto-param filtering**: prefixes like `teamcity.*`, `system.build.*`, `env.BUILD_NUMBER` etc. are excluded from parameter diffs since they always differ between runs.

## Example

```
$ teamcity run diff 875850923 917387409
COMPARING  ✓ Run #447  →  ✗ Run #448
Job: Common

STATUS
  - Success  Success
  + Failed  Gradle exception (new); exit code 1 (Step: Gradle) (new)

PROBLEMS
  + Execution failed for task ':tflint_download'. org.gradle.api.UncheckedIOException: ...
  + Process exited with code 1 (Step: Gradle)

CHANGES
  - 9438e1b  stanislav.sandalnikov  aws/ecs/service/default: support multiple target groups
  + 70fe0e2  stanislav.sandalnikov  aws/elastic/vpc: support UltraWarm parameters

AGENT
  - default-linux-aws-C-i-016a7ef36f502135c
  + default-linux-aws-C-i-085276d6b4c1a5ed9

DURATION
  - 13m 21s
  + 1m 21s  (-12m 0s)

Changed: status, problems, changes, agent, duration
View: https://buildserver.labs.intellij.net/.../875850923  https://buildserver.labs.intellij.net/.../917387409
```

## Test Plan

- [x] Unit tests pass (`just unit`) — 6 tests: structured diff, JSON, log diff, identical builds, single-arg, identical logs
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`