### PR TITLE
feat(run): add --reuse-deps to pin existing builds as snapshot dependencies

### DIFF
--- a/acceptance/testdata/run/run-start.txtar
+++ b/acceptance/testdata/run/run-start.txtar
@@ -37,3 +37,9 @@ stdout '"id"'
 
 extract '"id":\s*(\d+)' BUILD_ID
 exec teamcity run cancel $BUILD_ID --force --no-input
+
+# --reuse-deps (dry-run, non-existent id surfaces as "not found")
+exec teamcity run start $JOB_ID --reuse-deps 999999999 --dry-run --no-input
+stdout 'Snapshot dependencies:'
+stdout '999999999'
+stdout 'not found'

--- a/api/builds.go
+++ b/api/builds.go
@@ -217,6 +217,7 @@ type RunBuildOptions struct {
 	Tags                      []string
 	PersonalChangeID          string
 	Revision                  string
+	SnapshotDependencies      []int
 }
 
 // RunBuild runs a new build with full options
@@ -276,6 +277,14 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 				{ID: opts.PersonalChangeID, Personal: true},
 			},
 		}
+	}
+
+	if len(opts.SnapshotDependencies) > 0 {
+		refs := make([]BuildRef, len(opts.SnapshotDependencies))
+		for i, id := range opts.SnapshotDependencies {
+			refs[i] = BuildRef{ID: id}
+		}
+		req.SnapshotDependencies = &SnapshotDepBuilds{Build: refs}
 	}
 
 	if opts.Revision != "" {

--- a/api/builds_test.go
+++ b/api/builds_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -87,4 +88,45 @@ func TestGetBuildsUsesFavoritesLocator(T *testing.T) {
 
 	assert.Contains(T, capturedQuery, BuildsOptions{Favorites: true}.Locator().Encode())
 	assert.Contains(T, capturedQuery, "count%3A5")
+}
+
+func TestRunBuildSendsSnapshotDependencies(T *testing.T) {
+	T.Parallel()
+
+	var captured TriggerBuildRequest
+	client := setupTestServer(T, func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(T, err)
+		require.NoError(T, json.Unmarshal(body, &captured))
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Build{ID: 1})
+	})
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{
+		SnapshotDependencies: []int{6946, 6917, 6922},
+	})
+	require.NoError(T, err)
+
+	require.NotNil(T, captured.SnapshotDependencies)
+	require.Len(T, captured.SnapshotDependencies.Build, 3)
+	assert.Equal(T, 6946, captured.SnapshotDependencies.Build[0].ID)
+	assert.Equal(T, 6917, captured.SnapshotDependencies.Build[1].ID)
+	assert.Equal(T, 6922, captured.SnapshotDependencies.Build[2].ID)
+}
+
+func TestRunBuildOmitsEmptySnapshotDependencies(T *testing.T) {
+	T.Parallel()
+
+	var rawBody []byte
+	client := setupTestServer(T, func(w http.ResponseWriter, r *http.Request) {
+		b, err := io.ReadAll(r.Body)
+		require.NoError(T, err)
+		rawBody = b
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(Build{ID: 1})
+	})
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{})
+	require.NoError(T, err)
+	assert.NotContains(T, string(rawBody), "snapshot-dependencies")
 }

--- a/api/types.go
+++ b/api/types.go
@@ -171,16 +171,21 @@ type BuildQueue struct {
 
 // TriggerBuildRequest represents a request to trigger a build
 type TriggerBuildRequest struct {
-	BuildType         BuildTypeRef       `json:"buildType"`
-	BranchName        string             `json:"branchName,omitempty"`
-	Properties        *PropertyList      `json:"properties,omitempty"`
-	Comment           *BuildComment      `json:"comment,omitempty"`
-	Personal          bool               `json:"personal,omitempty"`
-	TriggeringOptions *TriggeringOptions `json:"triggeringOptions,omitempty"`
-	Agent             *AgentRef          `json:"agent,omitempty"`
-	Tags              *TagList           `json:"tags,omitempty"`
-	LastChanges       *LastChanges       `json:"lastChanges,omitempty"`
-	Revisions         *Revisions         `json:"revisions,omitempty"`
+	BuildType            BuildTypeRef       `json:"buildType"`
+	BranchName           string             `json:"branchName,omitempty"`
+	Properties           *PropertyList      `json:"properties,omitempty"`
+	Comment              *BuildComment      `json:"comment,omitempty"`
+	Personal             bool               `json:"personal,omitempty"`
+	TriggeringOptions    *TriggeringOptions `json:"triggeringOptions,omitempty"`
+	Agent                *AgentRef          `json:"agent,omitempty"`
+	Tags                 *TagList           `json:"tags,omitempty"`
+	LastChanges          *LastChanges       `json:"lastChanges,omitempty"`
+	Revisions            *Revisions         `json:"revisions,omitempty"`
+	SnapshotDependencies *SnapshotDepBuilds `json:"snapshot-dependencies,omitempty"`
+}
+
+type SnapshotDepBuilds struct {
+	Build []BuildRef `json:"build"`
 }
 
 type Revisions struct {

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -342,6 +342,9 @@ teamcity run start MyProject_Build --rebuild-deps
 # Rebuild only failed dependencies
 teamcity run start MyProject_Build --rebuild-failed-deps
 
+# Reuse existing builds as snapshot dependencies (pin by build ID)
+teamcity run start MyProject_Build --reuse-deps 6946,6917
+
 # Add to the top of the queue
 teamcity run start MyProject_Build --top
 
@@ -569,6 +572,18 @@ Rebuild all dependencies
 <td>
 
 Rebuild failed or incomplete dependencies only
+
+</td>
+</tr>
+<tr>
+<td>
+
+`--reuse-deps`
+
+</td>
+<td>
+
+Reuse existing builds as snapshot dependencies. Accepts a comma-separated list of build IDs or can be repeated. TeamCity resolves which dependency slot each build fills by its build configuration.
 
 </td>
 </tr>

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -2,6 +2,8 @@ package run_test
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -73,6 +75,41 @@ func TestRunStartDryRun(T *testing.T) {
 	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "start", testJob, "--dry-run")
 	assert.Contains(T, got, "Would trigger run for")
 	assert.Contains(T, got, testJob)
+}
+
+func TestRunStartReuseDepsDryRun(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	ts.Handle("GET /app/rest/builds/id:6946", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Build{ID: 6946, Number: "42", Status: "SUCCESS", BuildTypeID: "Dep_A"})
+	})
+	ts.Handle("GET /app/rest/builds/id:6917", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Build{ID: 6917, Number: "41", Status: "SUCCESS", BuildTypeID: "Dep_B"})
+	})
+	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "start", testJob,
+		"--reuse-deps", "6946,6917", "--dry-run")
+	assert.Contains(T, got, "Snapshot dependencies:")
+	assert.Contains(T, got, "6946")
+	assert.Contains(T, got, "#42")
+	assert.Contains(T, got, "Dep_A")
+	assert.Contains(T, got, "6917")
+}
+
+func TestRunStartReuseDepsSendsIDs(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+
+	var captured api.TriggerBuildRequest
+	ts.Handle("POST /app/rest/buildQueue", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(T, json.Unmarshal(body, &captured))
+		cmdtest.JSON(w, api.Build{ID: 999, BuildTypeID: testJob, WebURL: "https://example/build/999"})
+	})
+
+	cmdtest.RunCmdWithFactory(T, ts.Factory, "run", "start", testJob, "--reuse-deps", "6946,6917")
+
+	require.NotNil(T, captured.SnapshotDependencies)
+	require.Len(T, captured.SnapshotDependencies.Build, 2)
+	assert.Equal(T, 6946, captured.SnapshotDependencies.Build[0].ID)
+	assert.Equal(T, 6917, captured.SnapshotDependencies.Build[1].ID)
 }
 
 func TestRunStartDryRunNonExistentJob(T *testing.T) {

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -1,8 +1,12 @@
 package run
 
 import (
+	"cmp"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -44,6 +48,63 @@ func (w *watchFlags) watchOpts(logs, json bool) *runWatchOptions {
 	}
 }
 
+type reuseDep struct {
+	id    int
+	build *api.Build
+	err   error
+}
+
+func fetchReuseDeps(client api.ClientInterface, ids []int) []reuseDep {
+	out := make([]reuseDep, len(ids))
+	var wg sync.WaitGroup
+	for i, id := range ids {
+		wg.Go(func() {
+			b, err := client.GetBuild(strconv.Itoa(id))
+			out[i] = reuseDep{id: id, build: b, err: err}
+		})
+	}
+	wg.Wait()
+	return out
+}
+
+func printReuseDeps(p *output.Printer, deps []reuseDep) {
+	if len(deps) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintln(p.Out, "  Snapshot dependencies:")
+	idW := 0
+	for _, d := range deps {
+		idW = max(idW, len(strconv.Itoa(d.id)))
+	}
+	for _, d := range deps {
+		icon, summary := reuseDepRow(d)
+		_, _ = fmt.Fprintf(p.Out, "    %s %-*d  %s\n", icon, idW, d.id, summary)
+	}
+}
+
+func reuseDepRow(d reuseDep) (icon, summary string) {
+	if d.build == nil {
+		if _, ok := errors.AsType[*api.NotFoundError](d.err); ok || d.err == nil {
+			return output.Faint("?"), output.Red("(not found)")
+		}
+		return output.Faint("?"), output.Yellow(fmt.Sprintf("(lookup failed: %v)", d.err))
+	}
+	b := d.build
+	var btName string
+	if b.BuildType != nil {
+		btName = b.BuildType.Name
+	}
+	parts := make([]string, 0, 3)
+	if b.Number != "" {
+		parts = append(parts, output.Cyan("#"+b.Number))
+	}
+	parts = append(parts, cmp.Or(btName, b.BuildTypeID))
+	if (b.State != "" && b.State != "finished") || (b.Status != "" && !strings.EqualFold(b.Status, "SUCCESS")) {
+		parts = append(parts, output.StatusText(b.Status, b.State))
+	}
+	return output.StatusIcon(b.Status, b.State), strings.Join(parts, "  ")
+}
+
 func printQueuedRun(p *output.Printer, build *api.Build, context string) {
 	ref := fmt.Sprintf("%d  #%s", build.ID, build.Number)
 	if build.Number == "" {
@@ -79,6 +140,7 @@ type runStartOptions struct {
 	queueAtTop        bool
 	agent             int
 	tags              []string
+	reuseDeps         []int
 	watchFlags
 	web    bool
 	dryRun bool
@@ -101,6 +163,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
   teamcity run start Falcon_Build --comment "Release build" --tag release --tag v1.0
   teamcity run start Falcon_Build --clean --rebuild-deps --top
+  teamcity run start Falcon_Build --reuse-deps 6946,6917  # pin existing builds as snapshot deps
   teamcity run start Falcon_Build --local-changes # personal build with uncommitted Git changes
   teamcity run start Falcon_Build --local-changes changes.patch  # from file
   teamcity run start Falcon_Build --revision abc123def --branch main
@@ -124,6 +187,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.cleanSources, "clean", false, "Clean sources before run")
 	cmd.Flags().BoolVar(&opts.rebuildDeps, "rebuild-deps", false, "Rebuild all dependencies")
 	cmd.Flags().BoolVar(&opts.rebuildFailedDeps, "rebuild-failed-deps", false, "Rebuild failed/incomplete dependencies")
+	cmd.Flags().IntSliceVar(&opts.reuseDeps, "reuse-deps", nil, "Reuse existing builds as snapshot deps (build IDs, comma-separated or repeated)")
 	cmd.Flags().BoolVar(&opts.queueAtTop, "top", false, "Add to top of queue")
 	cmd.Flags().IntVar(&opts.agent, "agent", 0, "Run on specific agent (by ID)")
 	opts.addToCmd(cmd)
@@ -190,6 +254,9 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		}
 		if opts.rebuildDeps {
 			_, _ = fmt.Fprintln(p.Out, "  Rebuild dependencies: yes")
+		}
+		if len(opts.reuseDeps) > 0 {
+			printReuseDeps(p, fetchReuseDeps(client, opts.reuseDeps))
 		}
 		if opts.queueAtTop {
 			_, _ = fmt.Fprintln(p.Out, "  Queue at top: yes")
@@ -268,6 +335,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		Tags:                      opts.tags,
 		PersonalChangeID:          personalChangeID,
 		Revision:                  opts.revision,
+		SnapshotDependencies:      opts.reuseDeps,
 	})
 	if err != nil {
 		return err
@@ -299,6 +367,9 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 	}
 	if len(opts.tags) > 0 {
 		p.Info("  Tags: %s", strings.Join(opts.tags, ", "))
+	}
+	if len(opts.reuseDeps) > 0 {
+		printReuseDeps(p, fetchReuseDeps(client, opts.reuseDeps))
 	}
 	p.Info("  URL: %s", build.WebURL)
 	if opts.agent > 0 {


### PR DESCRIPTION
## Summary

Closes #221.

Adds `--reuse-deps` to `teamcity run start`, letting users pin existing builds as snapshot dependencies of the new run instead of letting TeamCity re-trigger the whole chain:

```bash
teamcity run start MyJob --reuse-deps 6946,6917
```

TeamCity resolves each build into the correct dependency slot via its `buildTypeId` — no slot key needed in the flag.

## Changes

- **API** (`api/types.go`, `api/builds.go`): new `SnapshotDepBuilds` payload type; `RunBuildOptions.SnapshotDependencies []int` + serialization on `RunBuild`.
- **CLI** (`internal/cmd/run/start.go`): `--reuse-deps` flag (`IntSliceVar` — comma-separated or repeated). Parallel per-ID lookup renders a pretty block with status icon, ID, `#number`, config name, and a `Failed` / `Running` / `Queued` marker when non-default. Unknown IDs render as `? ID (not found)`.
- **Tests**: unit (API POST body + CLI dry-run), acceptance (`run-start.txtar`).
- **Docs**: new example and flag-table row in `teamcity-cli-managing-runs.md`.

## Design Decisions

- **Flag name `--reuse-deps`** mirrors the existing `--rebuild-deps` / `--rebuild-failed-deps` family. Symmetry, no new mental model.
- **Bare build-IDs, not `BuildTypeID=buildID`.** The `BT=id` form the issue proposes is redundant on the wire — verified against buildserver that `{snapshot-dependencies:{build:[{id:N}]}}` is sufficient; the server resolves the dep slot from the referenced build's `buildTypeId`. Dropping the key keeps the flag scriptable (`jq -r '.build[].id' | paste -sd,`).
- **Parallel resolution** via `sync.WaitGroup.Go` so displaying 14+ pinned deps isn't sequential.

## Example

```
$ teamcity run start ijplatform_master_QodanaJvmNightly --reuse-deps 921541200,902234295,999999999 --dry-run
[dry-run] Would trigger run for ijplatform_master_QodanaJvmNightly
  Snapshot dependencies:
    ✓ 921541200  #2026.2.560  Snapshot 2026.2 CLI
    ✗ 902234295  #2026.2.524  Snapshot 2026.2 CLI  Failed
    ? 999999999  (not found)
```

End-to-end verified against a real composite on `buildserver.labs.intellij.net` (queued build `924874808`, server-side `snapshot-dependencies` confirmed attached).

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — new `run-start.txtar` case added; run in CI
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [x] If adding a data-producing command: includes `--json` support (the queued `Build` is already returned via existing `--json` path)
- [x] If modifying `--json` output: no field removals/renames (additive only — new `snapshot-dependencies` field in trigger payload)
- [x] If changing docs-visible behavior: updated `docs/` (README is a placeholder stub, nothing to update there)