### PR TITLE
feat(cli): bridge classic TeamCity vocabulary and tidy help text

### DIFF
--- a/acceptance/testdata/alias/alias-list-empty.txtar
+++ b/acceptance/testdata/alias/alias-list-empty.txtar
@@ -1,4 +1,4 @@
 # With no aliases configured, list should indicate none exist.
 
 exec teamcity alias list --no-input
-stdout 'No aliases configured'
+stdout 'built-in'

--- a/acceptance/testdata/alias/alias-set.txtar
+++ b/acceptance/testdata/alias/alias-set.txtar
@@ -20,7 +20,7 @@ exec teamcity alias set myshell 'echo hello' --shell --no-input
 stdout 'Added alias'
 
 exec teamcity alias list --json --no-input
-stdout '"shell": true'
+stdout '"type": "shell"'
 
 # Built-in command name rejected
 ! exec teamcity alias set run 'project list' --no-input

--- a/acceptance/testdata/config/color.txtar
+++ b/acceptance/testdata/config/color.txtar
@@ -1,0 +1,25 @@
+# Test color environment variable precedence.
+
+# FORCE_COLOR enables ANSI escapes even without a TTY.
+env NO_COLOR=
+env FORCE_COLOR=1
+exec teamcity run list --limit 1 --no-input
+stdout '\x1b\['
+
+# NO_COLOR wins over FORCE_COLOR.
+env NO_COLOR=1
+env FORCE_COLOR=1
+exec teamcity run list --limit 1 --no-input
+! stdout '\x1b\['
+
+# --no-color flag wins over FORCE_COLOR.
+env NO_COLOR=
+env FORCE_COLOR=1
+exec teamcity --no-color run list --limit 1 --no-input
+! stdout '\x1b\['
+
+# TEAMCITY_NO_COLOR wins over FORCE_COLOR.
+env TEAMCITY_NO_COLOR=1
+env FORCE_COLOR=1
+exec teamcity run list --limit 1 --no-input
+! stdout '\x1b\['

--- a/acceptance/testdata/job/job-alias-buildtype.txtar
+++ b/acceptance/testdata/job/job-alias-buildtype.txtar
@@ -1,0 +1,9 @@
+# Test that `buildtype` works as an alias for `job`.
+
+exec teamcity buildtype list --all --limit 2 --no-input
+stdout 'ID'
+! stderr 'Error'
+
+exec teamcity buildtype list --all --limit 1 --json --no-input
+stdout '"id"'
+! stderr 'Error'

--- a/acceptance/testdata/run/run-alias-build.txtar
+++ b/acceptance/testdata/run/run-alias-build.txtar
@@ -1,0 +1,9 @@
+# Test that `build` works as an alias for `run`.
+
+exec teamcity build list --limit 2 --no-input
+stdout 'STATUS'
+! stderr 'Error'
+
+exec teamcity build list --limit 1 --json --no-input
+stdout '"id"'
+! stderr 'Error'

--- a/docs/topics/teamcity-cli-commands.md
+++ b/docs/topics/teamcity-cli-commands.md
@@ -86,7 +86,7 @@ Description
 </td>
 <td>
 
-List run artifacts
+List artifacts
 
 </td>
 </tr>
@@ -110,7 +110,7 @@ Cancel a run
 </td>
 <td>
 
-Show VCS changes in a run
+Show VCS changes
 
 </td>
 </tr>
@@ -122,7 +122,19 @@ Show VCS changes in a run
 </td>
 <td>
 
-Set or view run comment
+Set or view comment
+
+</td>
+</tr>
+<tr>
+<td>
+
+`teamcity run diff`
+
+</td>
+<td>
+
+[experimental] Compare two runs and show differences
 
 </td>
 </tr>
@@ -134,7 +146,7 @@ Set or view run comment
 </td>
 <td>
 
-Download run artifacts
+Download artifacts
 
 </td>
 </tr>
@@ -158,7 +170,7 @@ List recent runs
 </td>
 <td>
 
-View run log
+View log
 
 </td>
 </tr>
@@ -170,7 +182,7 @@ View run log
 </td>
 <td>
 
-Pin a run to prevent cleanup
+Pin to prevent cleanup
 
 </td>
 </tr>
@@ -206,7 +218,7 @@ Start a new run
 </td>
 <td>
 
-Add tags to a run
+Add tags
 
 </td>
 </tr>
@@ -218,7 +230,19 @@ Add tags to a run
 </td>
 <td>
 
-Show test results for a run
+Show test results
+
+</td>
+</tr>
+<tr>
+<td>
+
+`teamcity run tree`
+
+</td>
+<td>
+
+Display snapshot dependency tree
 
 </td>
 </tr>
@@ -242,7 +266,7 @@ Unpin a run
 </td>
 <td>
 
-Remove tags from a run
+Remove tags
 
 </td>
 </tr>
@@ -254,7 +278,7 @@ Remove tags from a run
 </td>
 <td>
 
-View run details
+View details
 
 </td>
 </tr>
@@ -455,6 +479,18 @@ Manage cloud profiles
 <tr>
 <td>
 
+`teamcity project connection list`
+
+</td>
+<td>
+
+List project connections
+
+</td>
+</tr>
+<tr>
+<td>
+
 `teamcity project list`
 
 </td>
@@ -551,6 +587,54 @@ Validate Kotlin DSL configuration locally
 <tr>
 <td>
 
+`teamcity project ssh delete`
+
+</td>
+<td>
+
+Delete an SSH key
+
+</td>
+</tr>
+<tr>
+<td>
+
+`teamcity project ssh generate`
+
+</td>
+<td>
+
+Generate an SSH key pair
+
+</td>
+</tr>
+<tr>
+<td>
+
+`teamcity project ssh list`
+
+</td>
+<td>
+
+List SSH keys
+
+</td>
+</tr>
+<tr>
+<td>
+
+`teamcity project ssh upload`
+
+</td>
+<td>
+
+Upload an SSH private key
+
+</td>
+</tr>
+<tr>
+<td>
+
 `teamcity project token get`
 
 </td>
@@ -587,72 +671,12 @@ Display project hierarchy as a tree
 <tr>
 <td>
 
-`teamcity project connection list`
-
-</td>
-<td>
-
-List project connections
-
-</td>
-</tr>
-<tr>
-<td>
-
-`teamcity project ssh delete`
-
-</td>
-<td>
-
-Delete an SSH key
-
-</td>
-</tr>
-<tr>
-<td>
-
-`teamcity project ssh generate`
-
-</td>
-<td>
-
-Generate an SSH key pair
-
-</td>
-</tr>
-<tr>
-<td>
-
-`teamcity project ssh list`
-
-</td>
-<td>
-
-List SSH keys in a project
-
-</td>
-</tr>
-<tr>
-<td>
-
-`teamcity project ssh upload`
-
-</td>
-<td>
-
-Upload an SSH private key
-
-</td>
-</tr>
-<tr>
-<td>
-
 `teamcity project vcs create`
 
 </td>
 <td>
 
-Create a Git VCS root with auth configuration
+Create a VCS root
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-agents.md
+++ b/docs/topics/teamcity-cli-managing-agents.md
@@ -262,13 +262,13 @@ teamcity agent reboot Agent-Linux-01
 Wait for the current build to finish before rebooting:
 
 ```Shell
-teamcity agent reboot Agent-Linux-01 --after-build
+teamcity agent reboot Agent-Linux-01 --graceful
 ```
 
 Skip the confirmation prompt:
 
 ```Shell
-teamcity agent reboot Agent-Linux-01 --force
+teamcity agent reboot Agent-Linux-01 --yes
 ```
 
 > Local agents (running on the same machine as the server) cannot be rebooted through this command.

--- a/docs/topics/teamcity-cli-managing-build-queue.md
+++ b/docs/topics/teamcity-cli-managing-build-queue.md
@@ -109,10 +109,10 @@ Remove a build from the queue:
 teamcity queue remove 12345
 ```
 
-Use `--force` to skip the confirmation prompt:
+Use `--yes` to skip the confirmation prompt:
 
 ```Shell
-teamcity queue remove 12345 --force
+teamcity queue remove 12345 --yes
 ```
 
 <seealso>

--- a/docs/topics/teamcity-cli-managing-pipelines.md
+++ b/docs/topics/teamcity-cli-managing-pipelines.md
@@ -234,10 +234,10 @@ When no file is specified, the CLI reads `.teamcity.yml` from the current direct
 
 ```Shell
 teamcity pipeline delete CLI_MyPipeline
-teamcity pipeline delete CLI_MyPipeline --force
+teamcity pipeline delete CLI_MyPipeline --yes
 ```
 
-A confirmation prompt is shown unless `--force` is passed.
+A confirmation prompt is shown unless `--yes` is passed.
 
 ## Managing secrets
 

--- a/docs/topics/teamcity-cli-managing-projects.md
+++ b/docs/topics/teamcity-cli-managing-projects.md
@@ -266,7 +266,7 @@ teamcity project vcs test MyProject_GitHubRepo
 
 ```Shell
 teamcity project vcs delete MyProject_GitHubRepo
-teamcity project vcs delete MyProject_GitHubRepo --force  # skip confirmation
+teamcity project vcs delete MyProject_GitHubRepo --yes  # skip confirmation
 ```
 
 ## Managing SSH keys
@@ -302,7 +302,7 @@ teamcity project ssh upload key.pem --name my-deploy-key --project MyProject
 
 ```Shell
 teamcity project ssh delete my-deploy-key --project MyProject
-teamcity project ssh delete my-deploy-key --project MyProject --force
+teamcity project ssh delete my-deploy-key --project MyProject --yes
 ```
 
 ## Project connections

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -915,10 +915,10 @@ teamcity run cancel 12345
 teamcity run cancel 12345 --comment "Canceling for hotfix"
 ```
 
-Use `--force` to skip the confirmation prompt:
+Use `--yes` to skip the confirmation prompt:
 
 ```Shell
-teamcity run cancel 12345 --force
+teamcity run cancel 12345 --yes
 ```
 
 ## Restarting a run

--- a/docs/topics/teamcity-cli-scripting.md
+++ b/docs/topics/teamcity-cli-scripting.md
@@ -207,7 +207,7 @@ teamcity run watch "$BUILD_ID" --json
 ### Cancel all queued builds for a job
 
 ```Shell
-teamcity queue list --job MyProject_Build --json=id | jq -r '.[].id' | xargs -I {} teamcity run cancel {} --force
+teamcity queue list --job MyProject_Build --json=id | jq -r '.[].id' | xargs -I {} teamcity run cancel {} --yes
 ```
 
 ## CI/CD integration
@@ -254,10 +254,10 @@ Use `--no-input` to disable interactive prompts in automated environments. The C
 teamcity run cancel 12345 --no-input
 ```
 
-Alternatively, use `--force` on commands that support it:
+Alternatively, use `--yes` on commands that support it:
 
 ```Shell
-teamcity queue remove 12345 --force
+teamcity queue remove 12345 --yes
 ```
 
 ### Read-only mode

--- a/internal/cmd/agent/agent_reboot.go
+++ b/internal/cmd/agent/agent_reboot.go
@@ -49,8 +49,8 @@ func runAgentMove(f *cmdutil.Factory, nameOrID string, poolID int) error {
 }
 
 type agentRebootOptions struct {
-	afterBuild bool
-	force      bool
+	graceful bool
+	force    bool
 }
 
 func newAgentRebootCmd(f *cmdutil.Factory) *cobra.Command {
@@ -59,23 +59,25 @@ func newAgentRebootCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "reboot <agent>",
 		Short: "Reboot an agent",
-		Long: `Request a reboot of a build agent.
+		Long: `Request a reboot of an agent.
 
 The agent can be specified by ID or name. By default, the agent reboots immediately.
-Use --after-build to wait for the current build to finish before rebooting.
+Use --graceful to wait for current work to finish before rebooting.
 
 Note: Local agents (running on the same machine as the server) cannot be rebooted.`,
 		Args: cobra.ExactArgs(1),
 		Example: `  teamcity agent reboot 1
   teamcity agent reboot Agent-Linux-01
-  teamcity agent reboot Agent-Linux-01 --after-build
+  teamcity agent reboot Agent-Linux-01 --graceful
   teamcity agent reboot Agent-Linux-01 --force`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentReboot(f, cmd.Context(), args[0], opts)
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.afterBuild, "after-build", false, "Wait for current build to finish before rebooting")
+	cmd.Flags().BoolVar(&opts.graceful, "graceful", false, "Wait for current work to finish before rebooting")
+	cmd.Flags().BoolVar(&opts.graceful, "after-build", false, "Deprecated: use --graceful")
+	_ = cmd.Flags().MarkDeprecated("after-build", "use --graceful instead")
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt")
 
 	return cmd
@@ -108,13 +110,13 @@ func runAgentReboot(f *cmdutil.Factory, ctx context.Context, nameOrID string, op
 		}
 	}
 
-	if err := client.RebootAgent(ctx, agentID, opts.afterBuild); err != nil {
+	if err := client.RebootAgent(ctx, agentID, opts.graceful); err != nil {
 		return fmt.Errorf("failed to reboot agent: %w", err)
 	}
 
-	if opts.afterBuild {
+	if opts.graceful {
 		f.Printer.Success("Reboot scheduled for %s", agentName)
-		_, _ = fmt.Fprintln(f.Printer.Out, "  The agent will reboot after the current build finishes.")
+		_, _ = fmt.Fprintln(f.Printer.Out, "  The agent will reboot after current work finishes.")
 	} else {
 		f.Printer.Success("Reboot initiated for %s", agentName)
 	}

--- a/internal/cmd/agent/agent_reboot.go
+++ b/internal/cmd/agent/agent_reboot.go
@@ -50,7 +50,7 @@ func runAgentMove(f *cmdutil.Factory, nameOrID string, poolID int) error {
 
 type agentRebootOptions struct {
 	graceful bool
-	force    bool
+	yes      bool
 }
 
 func newAgentRebootCmd(f *cmdutil.Factory) *cobra.Command {
@@ -69,7 +69,7 @@ Note: Local agents (running on the same machine as the server) cannot be reboote
 		Example: `  teamcity agent reboot 1
   teamcity agent reboot Agent-Linux-01
   teamcity agent reboot Agent-Linux-01 --graceful
-  teamcity agent reboot Agent-Linux-01 --force`,
+  teamcity agent reboot Agent-Linux-01 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runAgentReboot(f, cmd.Context(), args[0], opts)
 		},
@@ -78,7 +78,9 @@ Note: Local agents (running on the same machine as the server) cannot be reboote
 	cmd.Flags().BoolVar(&opts.graceful, "graceful", false, "Wait for current work to finish before rebooting")
 	cmd.Flags().BoolVar(&opts.graceful, "after-build", false, "Deprecated: use --graceful")
 	_ = cmd.Flags().MarkDeprecated("after-build", "use --graceful instead")
-	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
+	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 
 	return cmd
 }
@@ -94,7 +96,7 @@ func runAgentReboot(f *cmdutil.Factory, ctx context.Context, nameOrID string, op
 		return err
 	}
 
-	needsConfirmation := !opts.force && f.IsInteractive()
+	needsConfirmation := !opts.yes && f.IsInteractive()
 	if needsConfirmation {
 		var confirm bool
 		prompt := &survey.Confirm{

--- a/internal/cmd/agent/agent_reboot.go
+++ b/internal/cmd/agent/agent_reboot.go
@@ -78,7 +78,7 @@ Note: Local agents (running on the same machine as the server) cannot be reboote
 	cmd.Flags().BoolVar(&opts.graceful, "graceful", false, "Wait for current work to finish before rebooting")
 	cmd.Flags().BoolVar(&opts.graceful, "after-build", false, "Deprecated: use --graceful")
 	_ = cmd.Flags().MarkDeprecated("after-build", "use --graceful instead")
-	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
 	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 

--- a/internal/cmd/agent/agent_test.go
+++ b/internal/cmd/agent/agent_test.go
@@ -78,5 +78,6 @@ func TestAgentReboot(T *testing.T) {
 	f := ts.Factory
 
 	cmdtest.RunCmdWithFactory(T, f, "agent", "reboot", "Agent 1")
+	cmdtest.RunCmdWithFactory(T, f, "agent", "reboot", "1", "--graceful")
 	cmdtest.RunCmdWithFactory(T, f, "agent", "reboot", "1", "--after-build")
 }

--- a/internal/cmd/alias/alias.go
+++ b/internal/cmd/alias/alias.go
@@ -87,6 +87,7 @@ Use --shell for aliases that need pipes, redirection, or other shell features.`,
 type aliasEntry struct {
 	Name      string `json:"name"`
 	Expansion string `json:"expansion"`
+	Shell     bool   `json:"shell"`
 	Type      string `json:"type"`
 }
 
@@ -130,6 +131,7 @@ func newAliasListCmd(f *cmdutil.Factory) *cobra.Command {
 					entries = append(entries, aliasEntry{
 						Name:      name,
 						Expansion: displayExp,
+						Shell:     isShell,
 						Type:      kind,
 					})
 				}

--- a/internal/cmd/alias/alias.go
+++ b/internal/cmd/alias/alias.go
@@ -87,7 +87,7 @@ Use --shell for aliases that need pipes, redirection, or other shell features.`,
 type aliasEntry struct {
 	Name      string `json:"name"`
 	Expansion string `json:"expansion"`
-	Shell     bool   `json:"shell"`
+	Type      string `json:"type"`
 }
 
 func newAliasListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -101,23 +101,36 @@ func newAliasListCmd(f *cmdutil.Factory) *cobra.Command {
 		Example: `  teamcity alias list
   teamcity alias list --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			builtins := collectBuiltinAliases(cmd.Root())
 			aliases := config.GetAllAliases()
 
-			if len(aliases) == 0 {
+			if len(builtins) == 0 && len(aliases) == 0 {
 				_, _ = fmt.Fprintln(f.Printer.Out, "No aliases configured. Use \"teamcity alias set\" to create one.")
 				return nil
 			}
 
-			names := slices.Sorted(maps.Keys(aliases))
+			builtinNames := slices.Sorted(maps.Keys(builtins))
+			userNames := slices.Sorted(maps.Keys(aliases))
 
 			if jsonOutput {
-				entries := make([]aliasEntry, 0, len(aliases))
-				for _, name := range names {
+				entries := make([]aliasEntry, 0, len(builtins)+len(aliases))
+				for _, name := range builtinNames {
+					entries = append(entries, aliasEntry{
+						Name:      name,
+						Expansion: builtins[name],
+						Type:      "built-in",
+					})
+				}
+				for _, name := range userNames {
 					displayExp, isShell := config.ParseExpansion(aliases[name])
+					kind := "expansion"
+					if isShell {
+						kind = "shell"
+					}
 					entries = append(entries, aliasEntry{
 						Name:      name,
 						Expansion: displayExp,
-						Shell:     isShell,
+						Type:      kind,
 					})
 				}
 				return f.Printer.PrintJSON(entries)
@@ -125,7 +138,10 @@ func newAliasListCmd(f *cmdutil.Factory) *cobra.Command {
 
 			headers := []string{"NAME", "EXPANSION", "TYPE"}
 			var rows [][]string
-			for _, name := range names {
+			for _, name := range builtinNames {
+				rows = append(rows, []string{name, builtins[name], "built-in"})
+			}
+			for _, name := range userNames {
 				displayExp, isShell := config.ParseExpansion(aliases[name])
 				aliasType := "expansion"
 				if isShell {
@@ -141,6 +157,16 @@ func newAliasListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
 
 	return cmd
+}
+
+func collectBuiltinAliases(rootCmd *cobra.Command) map[string]string {
+	result := map[string]string{}
+	for _, c := range rootCmd.Commands() {
+		for _, a := range c.Aliases {
+			result[a] = c.Name()
+		}
+	}
+	return result
 }
 
 func newAliasDeleteCmd(f *cmdutil.Factory) *cobra.Command {

--- a/internal/cmd/alias/alias_test.go
+++ b/internal/cmd/alias/alias_test.go
@@ -142,7 +142,7 @@ func TestAliasListEmpty(t *testing.T) {
 	root := cmd.NewRootCmdWithFactory(f)
 	root.SetArgs([]string{"alias", "list"})
 	require.NoError(t, root.Execute())
-	assert.Contains(t, out.String(), "No aliases configured")
+	assert.Contains(t, out.String(), "built-in")
 }
 
 func TestAliasListJSON(t *testing.T) {

--- a/internal/cmd/job/job.go
+++ b/internal/cmd/job/job.go
@@ -8,11 +8,12 @@ import (
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "job",
-		Short: "Manage jobs (build configurations)",
-		Long:  `List and manage TeamCity jobs (build configurations).`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Use:     "job",
+		Aliases: []string{"buildtype"},
+		Short:   "Manage jobs (build configurations)",
+		Long:    `List and manage TeamCity jobs (build configurations).`,
+		Args:    cobra.NoArgs,
+		RunE:    cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newJobListCmd(f))

--- a/internal/cmd/job/job.go
+++ b/internal/cmd/job/job.go
@@ -23,5 +23,6 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(newJobResumeCmd(f))
 	cmd.AddCommand(param.NewCmd(f, "job", param.JobParamAPI))
 
+	cmdutil.AliasAwareHelp(cmd, "", "")
 	return cmd
 }

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -36,7 +36,7 @@ func newJobListCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
-	cmd.Flags().BoolVar(&opts.all, "all", false, "Include pipeline-generated build types")
+	cmd.Flags().BoolVar(&opts.all, "all", false, "Include pipelines")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
 
 	return cmd

--- a/internal/cmd/pipeline/delete.go
+++ b/internal/cmd/pipeline/delete.go
@@ -9,7 +9,7 @@ import (
 )
 
 type deleteOptions struct {
-	force bool
+	yes bool
 }
 
 func newPipelineDeleteCmd(f *cmdutil.Factory) *cobra.Command {
@@ -20,13 +20,15 @@ func newPipelineDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Delete a pipeline",
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity pipeline delete CLI_MyPipeline
-  teamcity pipeline delete CLI_MyPipeline --force`,
+  teamcity pipeline delete CLI_MyPipeline --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runPipelineDelete(f, args[0], opts)
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.force, "force", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.yes, "force", false, "Deprecated: use --yes")
+	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 
 	return cmd
 }
@@ -42,9 +44,9 @@ func runPipelineDelete(f *cmdutil.Factory, id string, opts *deleteOptions) error
 		return err
 	}
 
-	if !opts.force {
+	if !opts.yes {
 		if !f.IsInteractive() {
-			return fmt.Errorf("--force is required in non-interactive mode")
+			return fmt.Errorf("--yes is required in non-interactive mode")
 		}
 		var confirm bool
 		prompt := &survey.Confirm{

--- a/internal/cmd/pipeline/delete.go
+++ b/internal/cmd/pipeline/delete.go
@@ -26,7 +26,7 @@ func newPipelineDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVar(&opts.yes, "force", false, "Deprecated: use --yes")
 	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -344,7 +344,7 @@ func newProjectTreeCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&noJobs, "no-jobs", false, "Hide build configurations")
+	cmd.Flags().BoolVar(&noJobs, "no-jobs", false, "Hide jobs")
 	cmd.Flags().IntVarP(&depth, "depth", "d", 0, "Limit tree depth (0 = unlimited)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
 

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -211,7 +211,7 @@ func runSSHGenerate(f *cmdutil.Factory, opts *sshGenerateOptions) error {
 
 type sshDeleteOptions struct {
 	project string
-	force   bool
+	yes     bool
 }
 
 func newSSHDeleteCmd(f *cmdutil.Factory) *cobra.Command {
@@ -223,14 +223,16 @@ func newSSHDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"rm"},
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity project ssh delete my-deploy-key
-  teamcity project ssh delete my-deploy-key --force`,
+  teamcity project ssh delete my-deploy-key --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSSHDelete(f, args[0], opts)
 		},
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
-	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
+	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 
 	return cmd
 }
@@ -243,7 +245,7 @@ func runSSHDelete(f *cmdutil.Factory, name string, opts *sshDeleteOptions) error
 
 	projectID := cmp.Or(opts.project, "_Root")
 
-	if !opts.force && f.IsInteractive() {
+	if !opts.yes && f.IsInteractive() {
 		var confirm bool
 		prompt := &survey.Confirm{
 			Message: fmt.Sprintf("Delete SSH key %q from project %s?", name, projectID),

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -230,7 +230,7 @@ func newSSHDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
-	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
 	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -694,7 +694,7 @@ func newVcsDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
 	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -676,7 +676,7 @@ func buildTestRequestFromRoot(root *api.VcsRoot) api.TestConnectionRequest {
 // --- delete ---
 
 type vcsDeleteOptions struct {
-	force bool
+	yes bool
 }
 
 func newVcsDeleteCmd(f *cmdutil.Factory) *cobra.Command {
@@ -688,13 +688,15 @@ func newVcsDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"rm"},
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity project vcs delete MyProject_GitHubRepo
-  teamcity project vcs delete MyProject_GitHubRepo --force`,
+  teamcity project vcs delete MyProject_GitHubRepo --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runVcsDelete(f, args[0], opts)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
+	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 
 	return cmd
 }
@@ -705,7 +707,7 @@ func runVcsDelete(f *cmdutil.Factory, id string, opts *vcsDeleteOptions) error {
 		return err
 	}
 
-	if !opts.force && f.IsInteractive() {
+	if !opts.yes && f.IsInteractive() {
 		var confirm bool
 		prompt := &survey.Confirm{
 			Message: fmt.Sprintf("Delete VCS root %q?", id),

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -36,8 +36,6 @@ func newVcsCmd(f *cmdutil.Factory) *cobra.Command {
 	return cmd
 }
 
-// --- list ---
-
 type vcsListOptions struct {
 	project string
 	cmdutil.ListFlags
@@ -100,8 +98,6 @@ func (opts *vcsListOptions) fetch(client api.ClientInterface, fields []string) (
 		EmptyMsg: "No VCS roots found",
 	}, nil
 }
-
-// --- view ---
 
 func newVcsViewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &cmdutil.ViewOptions{}
@@ -212,8 +208,6 @@ func vcsPropertyLabel(name string) string {
 func vcsRootEditURL(id string) string {
 	return fmt.Sprintf("%s/admin/editVcsRoot.html?vcsRootId=%s", config.GetServerURL(), id)
 }
-
-// --- create ---
 
 const (
 	authPassword  = "password"
@@ -576,8 +570,6 @@ func inferAuthFromURL(repoURL string) string {
 	return authAnonymous
 }
 
-// --- test ---
-
 func newVcsTestCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "test <vcs-root-id>",
@@ -672,8 +664,6 @@ func buildTestRequestFromRoot(root *api.VcsRoot) api.TestConnectionRequest {
 
 	return req
 }
-
-// --- delete ---
 
 type vcsDeleteOptions struct {
 	yes bool

--- a/internal/cmd/queue/action.go
+++ b/internal/cmd/queue/action.go
@@ -29,7 +29,7 @@ var queueActions = map[string]queueAction{
 
 func newQueueActionCmd(f *cmdutil.Factory, a queueAction) *cobra.Command {
 	return &cobra.Command{
-		Use:     fmt.Sprintf("%s <run-id>", a.use),
+		Use:     fmt.Sprintf("%s <id>", a.use),
 		Short:   a.short,
 		Long:    a.long,
 		Args:    cobra.ExactArgs(1),

--- a/internal/cmd/queue/remove.go
+++ b/internal/cmd/queue/remove.go
@@ -28,7 +28,7 @@ func newQueueRemoveCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
 	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 

--- a/internal/cmd/queue/remove.go
+++ b/internal/cmd/queue/remove.go
@@ -9,7 +9,7 @@ import (
 )
 
 type queueRemoveOptions struct {
-	force bool
+	yes bool
 }
 
 func newQueueRemoveCmd(f *cmdutil.Factory) *cobra.Command {
@@ -22,13 +22,15 @@ func newQueueRemoveCmd(f *cmdutil.Factory) *cobra.Command {
 		Long:    `Remove a queued run from the TeamCity queue.`,
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity queue remove 12345
-  teamcity queue remove 12345 --force`,
+  teamcity queue remove 12345 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runQueueRemove(f, args[0], opts)
 		},
 	}
 
-	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
+	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 
 	return cmd
 }
@@ -39,7 +41,7 @@ func runQueueRemove(f *cmdutil.Factory, runID string, opts *queueRemoveOptions) 
 		return err
 	}
 
-	needsConfirmation := !opts.force && f.IsInteractive()
+	needsConfirmation := !opts.yes && f.IsInteractive()
 
 	if needsConfirmation {
 		var confirm bool

--- a/internal/cmd/queue/remove.go
+++ b/internal/cmd/queue/remove.go
@@ -16,7 +16,7 @@ func newQueueRemoveCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &queueRemoveOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "remove <run-id>",
+		Use:     "remove <id>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a run from the queue",
 		Long:    `Remove a queued run from the TeamCity queue.`,
@@ -60,6 +60,6 @@ func runQueueRemove(f *cmdutil.Factory, runID string, opts *queueRemoveOptions) 
 		return fmt.Errorf("failed to remove run from queue: %w", err)
 	}
 
-	f.Printer.Success("Removed run %s from queue", runID)
+	f.Printer.Success("Removed #%s from queue", runID)
 	return nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -68,6 +68,7 @@ Report issues:  https://jb.gg/tc/issues`,
 	cmd.PersistentFlags().BoolVar(&f.NoColor, "no-color", false, "Disable colored output")
 	cmd.PersistentFlags().BoolVarP(&f.Quiet, "quiet", "q", false, "Suppress non-essential output")
 	cmd.PersistentFlags().BoolVar(&f.Verbose, "verbose", false, "Show detailed output including debug info")
+	cmd.PersistentFlags().BoolVar(&f.Verbose, "debug", false, "Alias for --verbose")
 	cmd.PersistentFlags().BoolVar(&f.NoInput, "no-input", false, "Disable interactive prompts")
 
 	cmd.MarkFlagsMutuallyExclusive("quiet", "verbose")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -71,7 +71,7 @@ Report issues:  https://jb.gg/tc/issues`,
 	cmd.PersistentFlags().BoolVar(&f.Verbose, "debug", false, "Alias for --verbose")
 	cmd.PersistentFlags().BoolVar(&f.NoInput, "no-input", false, "Disable interactive prompts")
 
-	cmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
+	cmd.MarkFlagsMutuallyExclusive("quiet", "verbose", "debug")
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		f.InitOutput()

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -67,7 +67,7 @@ Report issues:  https://jb.gg/tc/issues`,
 
 	cmd.PersistentFlags().BoolVar(&f.NoColor, "no-color", false, "Disable colored output")
 	cmd.PersistentFlags().BoolVarP(&f.Quiet, "quiet", "q", false, "Suppress non-essential output")
-	cmd.PersistentFlags().BoolVar(&f.Verbose, "verbose", false, "Show detailed output including debug info")
+	cmd.PersistentFlags().BoolVarP(&f.Verbose, "verbose", "V", false, "Show detailed output including debug info")
 	cmd.PersistentFlags().BoolVar(&f.Verbose, "debug", false, "Alias for --verbose")
 	cmd.PersistentFlags().BoolVar(&f.NoInput, "no-input", false, "Disable interactive prompts")
 

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -22,7 +22,7 @@ func newRunChangesCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "changes <run-id>",
-		Short: "Show VCS changes in a run",
+		Short: "Show VCS changes",
 		Long:  `Show the VCS changes (commits) included in a run.`,
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity run changes 12345
@@ -133,7 +133,7 @@ func newRunTestsCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "tests [run-id]",
-		Short: "Show test results for a run",
+		Short: "Show test results",
 		Long: `Show test results from a run.
 
 You can specify a run ID directly, or use --job to get the latest run's tests.`,

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -21,7 +21,7 @@ func newRunChangesCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runChangesOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "changes <run-id>",
+		Use:   "changes <id>",
 		Short: "Show VCS changes",
 		Long:  `Show the VCS changes (commits) included in a run.`,
 		Args:  cobra.ExactArgs(1),
@@ -132,14 +132,14 @@ func newRunTestsCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runTestsOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "tests [run-id]",
+		Use:   "tests [id]",
 		Short: "Show test results",
 		Long: `Show test results from a run.
 
 You can specify a run ID directly, or use --job to get the latest run's tests.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && cmd.Flags().Changed("job") {
-				return tcerrors.MutuallyExclusive("run-id", "job")
+				return tcerrors.MutuallyExclusive("id", "job")
 			}
 			return cobra.MaximumNArgs(1)(cmd, args)
 		},
@@ -158,7 +158,7 @@ You can specify a run ID directly, or use --job to get the latest run's tests.`,
 	cmd.Flags().BoolVar(&opts.failed, "failed", false, "Show only failed tests")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 0, "Maximum number of tests to show")
-	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Get tests for latest run of this job")
+	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Use this job's latest")
 
 	return cmd
 }

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -157,7 +157,7 @@ You can specify a run ID directly, or use --job to get the latest run's tests.`,
 
 	cmd.Flags().BoolVar(&opts.failed, "failed", false, "Show only failed tests")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
-	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 0, "Maximum number of tests to show")
+	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 0, "Maximum number of items")
 	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Use this job's latest")
 
 	return cmd
@@ -188,7 +188,7 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 
 	build, err := client.GetBuild(runID)
 	if err != nil {
-		return fmt.Errorf("failed to get build: %w", err)
+		return fmt.Errorf("failed to fetch: %w", err)
 	}
 
 	tests, err := client.GetBuildTests(runID, opts.failed, opts.limit)

--- a/internal/cmd/run/artifacts.go
+++ b/internal/cmd/run/artifacts.go
@@ -25,7 +25,7 @@ func newRunArtifactsCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "artifacts [run-id]",
-		Short: "List run artifacts",
+		Short: "List artifacts",
 		Long: `List artifacts from a run without downloading them.
 
 Shows artifact names and sizes. Use teamcity run download to download artifacts.`,

--- a/internal/cmd/run/artifacts.go
+++ b/internal/cmd/run/artifacts.go
@@ -24,14 +24,14 @@ func newRunArtifactsCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runArtifactsOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "artifacts [run-id]",
+		Use:   "artifacts [id]",
 		Short: "List artifacts",
 		Long: `List artifacts from a run without downloading them.
 
 Shows artifact names and sizes. Use teamcity run download to download artifacts.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && cmd.Flags().Changed("job") {
-				return tcerrors.MutuallyExclusive("run-id", "job")
+				return tcerrors.MutuallyExclusive("id", "job")
 			}
 			return cobra.MaximumNArgs(1)(cmd, args)
 		},
@@ -48,7 +48,7 @@ Shows artifact names and sizes. Use teamcity run download to download artifacts.
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "List artifacts from latest run of this job")
+	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Use this job's latest")
 	cmd.Flags().StringVarP(&opts.path, "path", "p", "", "Browse artifacts under this subdirectory")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -30,7 +30,7 @@ func newRunCancelCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.comment, "comment", "", "Comment for cancellation")
-	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
 	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -10,7 +10,7 @@ import (
 
 type runCancelOptions struct {
 	comment string
-	force   bool
+	yes     bool
 }
 
 func newRunCancelCmd(f *cmdutil.Factory) *cobra.Command {
@@ -23,14 +23,16 @@ func newRunCancelCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity run cancel 12345
   teamcity run cancel 12345 --comment "Canceling for hotfix"
-  teamcity run cancel 12345 --force`,
+  teamcity run cancel 12345 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunCancel(f, args[0], opts)
 		},
 	}
 
 	cmd.Flags().StringVar(&opts.comment, "comment", "", "Comment for cancellation")
-	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&opts.yes, "yes", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
+	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
 
 	return cmd
 }
@@ -41,7 +43,7 @@ func runRunCancel(f *cmdutil.Factory, runID string, opts *runCancelOptions) erro
 		return err
 	}
 
-	needsConfirmation := !opts.force && opts.comment == "" && f.IsInteractive()
+	needsConfirmation := !opts.yes && opts.comment == "" && f.IsInteractive()
 
 	if needsConfirmation {
 		var confirm bool

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -17,7 +17,7 @@ func newRunCancelCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runCancelOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "cancel <run-id>",
+		Use:   "cancel <id>",
 		Short: "Cancel a run",
 		Long:  `Cancel a running or queued run.`,
 		Args:  cobra.ExactArgs(1),
@@ -67,6 +67,6 @@ func runRunCancel(f *cmdutil.Factory, runID string, opts *runCancelOptions) erro
 		return err
 	}
 
-	f.Printer.Success("Canceled run #%s", runID)
+	f.Printer.Success("Canceled #%s", runID)
 	return nil
 }

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -464,7 +464,7 @@ func TestRunView_usedByOtherBuilds(t *testing.T) {
 		})
 	})
 	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "view", "55")
-	assert.Contains(t, got, "Results shared with other builds in chain")
+	assert.Contains(t, got, "Results shared in build chain")
 }
 
 func TestRunView_waitReason(t *testing.T) {
@@ -500,8 +500,8 @@ func TestRunStart_reused(t *testing.T) {
 		})
 	})
 	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "start", testJob)
-	assert.Contains(t, got, "Reused existing run")
-	assert.Contains(t, got, "build optimization")
+	assert.Contains(t, got, "Reused existing")
+	assert.Contains(t, got, "(optimization)")
 }
 
 func TestRunList_invalid_status(t *testing.T) {

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -60,7 +60,7 @@ finished run of the same job.`,
 
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().BoolVar(&opts.log, "log", false, "Compare logs with colored unified diff")
-	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open both in browser")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 	cmd.Flags().IntVarP(&opts.context, "unified", "U", 3, "Number of context lines in log diff")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "log")
@@ -96,10 +96,10 @@ func runRunDiff(f *cmdutil.Factory, args []string, opts *runDiffOptions) error {
 		b1, err1 := client.GetBuild(id1)
 		b2, err2 := client.GetBuild(id2)
 		if err1 != nil {
-			return fmt.Errorf("resolving build %s: %w", id1, err1)
+			return fmt.Errorf("resolving #%s: %w", id1, err1)
 		}
 		if err2 != nil {
-			return fmt.Errorf("resolving build %s: %w", id2, err2)
+			return fmt.Errorf("resolving #%s: %w", id2, err2)
 		}
 		if b1.WebURL != "" {
 			_ = browser.OpenURL(b1.WebURL)
@@ -134,7 +134,7 @@ func resolveDiffBuildIDs(client api.ClientInterface, args []string) (string, str
 
 	build, err := client.GetBuild(args[0])
 	if err != nil {
-		return "", "", fmt.Errorf("resolving build: %w", err)
+		return "", "", fmt.Errorf("could not resolve: %w", err)
 	}
 
 	builds, err := client.GetBuilds(api.BuildsOptions{
@@ -162,23 +162,23 @@ func resolveDiffBuildIDs(client api.ClientInterface, args []string) (string, str
 func fetchBuildData(client api.ClientInterface, id string, p *output.Printer) (buildData, error) {
 	b, err := client.GetBuild(id)
 	if err != nil {
-		return buildData{}, fmt.Errorf("build %s: %w", id, err)
+		return buildData{}, fmt.Errorf("#%s: %w", id, err)
 	}
 	d := buildData{build: b}
 	if d.tests, err = client.GetBuildTests(id, true, 0); err != nil {
-		p.Warn("Could not fetch tests for build %s: %v", id, err)
+		p.Warn("Could not fetch tests for #%s: %v", id, err)
 	}
 	if d.testSummary, err = client.GetBuildTestSummary(id); err != nil {
-		p.Warn("Could not fetch test summary for build %s: %v", id, err)
+		p.Warn("Could not fetch test summary for #%s: %v", id, err)
 	}
 	if d.changes, err = client.GetBuildChanges(id); err != nil {
-		p.Warn("Could not fetch changes for build %s: %v", id, err)
+		p.Warn("Could not fetch changes for #%s: %v", id, err)
 	}
 	if d.problems, err = client.GetBuildProblems(id); err != nil {
-		p.Warn("Could not fetch problems for build %s: %v", id, err)
+		p.Warn("Could not fetch problems for #%s: %v", id, err)
 	}
 	if d.params, err = client.GetBuildResultingProperties(id); err != nil {
-		p.Warn("Could not fetch parameters for build %s: %v", id, err)
+		p.Warn("Could not fetch parameters for #%s: %v", id, err)
 	}
 	return d, nil
 }
@@ -213,11 +213,11 @@ func runLogDiff(f *cmdutil.Factory, client api.ClientInterface, id1, id2 string,
 
 	log1, err := client.GetBuildLog(id1)
 	if err != nil {
-		return fmt.Errorf("log for build %s: %w", id1, err)
+		return fmt.Errorf("log for #%s: %w", id1, err)
 	}
 	log2, err := client.GetBuildLog(id2)
 	if err != nil {
-		return fmt.Errorf("log for build %s: %w", id2, err)
+		return fmt.Errorf("log for #%s: %w", id2, err)
 	}
 
 	lines1 := output.NormalizeBuildLog(output.SplitLogLines(log1))

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -197,8 +197,6 @@ func fetchBothBuilds(client api.ClientInterface, id1, id2 string, p *output.Prin
 	return d1, d2, err2
 }
 
-// --- Log diff ---
-
 func runLogDiff(f *cmdutil.Factory, client api.ClientInterface, id1, id2 string, context int) error {
 	p := f.Printer
 
@@ -237,8 +235,6 @@ func runLogDiff(f *cmdutil.Factory, client api.ClientInterface, id1, id2 string,
 
 	return nil
 }
-
-// --- Shared computation ---
 
 type paramDiff struct {
 	name     string
@@ -353,8 +349,6 @@ func computeProblemDiffs(pr1, pr2 *api.ProblemOccurrences) (newProblems, resolve
 	}
 	return newProblems, resolved
 }
-
-// --- Rendering ---
 
 func renderDiff(p *output.Printer, d1, d2 buildData) {
 	b1, b2 := d1.build, d2.build
@@ -593,8 +587,6 @@ func renderProblemsDiff(p *output.Printer, pr1, pr2 *api.ProblemOccurrences) boo
 	return true
 }
 
-// --- JSON output ---
-
 func buildDiffJSON(d1, d2 buildData) map[string]any {
 	b1, b2 := d1.build, d2.build
 
@@ -689,8 +681,6 @@ func buildDiffJSON(d1, d2 buildData) map[string]any {
 
 	return map[string]any{"run1": jsonBuild(b1), "run2": jsonBuild(b2), "diff": diff}
 }
-
-// --- Helpers ---
 
 func buildDuration(b *api.Build) time.Duration {
 	if b.StartDate == "" || b.FinishDate == "" {

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -28,7 +28,7 @@ func newRunDiffCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runDiffOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "diff <run-id-1> [run-id-2]",
+		Use:   "diff <id-1> [id-2]",
 		Short: "Compare two runs and show differences",
 		Long: `Compare two runs (builds) and highlight what changed between them.
 
@@ -45,7 +45,7 @@ Pipe to external diff tools for advanced views:
   teamcity run diff 123 124 --log --no-color | diff-so-fancy
 
 If only one run ID is given, it is compared against the previous
-finished run of the same build configuration.`,
+finished run of the same job.`,
 		Args: cobra.RangeArgs(1, 2),
 		Example: `  teamcity run diff 123 124
   teamcity run diff 456                # compare with previous run
@@ -59,8 +59,8 @@ finished run of the same build configuration.`,
 	}
 
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
-	cmd.Flags().BoolVar(&opts.log, "log", false, "Compare build logs with colored unified diff")
-	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open both runs in browser")
+	cmd.Flags().BoolVar(&opts.log, "log", false, "Compare logs with colored unified diff")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open both in browser")
 	cmd.Flags().IntVarP(&opts.context, "unified", "U", 3, "Number of context lines in log diff")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "log")

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -27,7 +27,7 @@ func newRunDownloadCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runDownloadOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "download <run-id>",
+		Use:   "download <id>",
 		Short: "Download artifacts",
 		Long:  `Download artifacts from a completed run.`,
 		Args:  cobra.ExactArgs(1),

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -28,7 +28,7 @@ func newRunDownloadCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "download <run-id>",
-		Short: "Download run artifacts",
+		Short: "Download artifacts",
 		Long:  `Download artifacts from a completed run.`,
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity run download 12345

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -360,7 +360,7 @@ func newRunViewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "view <run-id>",
 		Aliases: []string{"show"},
-		Short:   "View run details",
+		Short:   "View details",
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity run view 12345
   teamcity run view 12345 --web

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -69,7 +69,7 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.revision, "revision", "", "Filter by VCS revision/commit SHA (or '@head' for current HEAD)")
 	cmd.Flags().BoolVar(&opts.favorites, "favorites", false, "Show favorites for the current user")
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
-	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number to show")
+	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number of items")
 	cmd.Flags().StringVar(&opts.since, "since", "", "Finished after this time (e.g., 24h, 2026-01-21)")
 	cmd.Flags().StringVar(&opts.until, "until", "", "Finished before this time (e.g., 12h, 2026-01-22)")
 	cmdutil.AddJSONFieldsFlag(cmd, &opts.jsonFields)
@@ -435,7 +435,7 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 	}
 
 	if build.UsedByOtherBuilds {
-		_, _ = fmt.Fprintf(p.Out, "\n%s Results shared with other builds in chain\n", output.Yellow("⟳"))
+		_, _ = fmt.Fprintf(p.Out, "\n%s Results shared in build chain\n", output.Yellow("⟳"))
 	}
 
 	if build.StatusText != "" && build.StatusText != build.Status {
@@ -482,7 +482,7 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 			padded := fmt.Sprintf("%-*s", maxIDLen+2, j.ID)
 			buildInfo := ""
 			if j.Build != nil && j.Build.ID > 0 {
-				buildInfo = fmt.Sprintf(" (build %d)", j.Build.ID)
+				buildInfo = fmt.Sprintf(" (#%d)", j.Build.ID)
 			}
 			_, _ = fmt.Fprintf(p.Out, "  %s %s%s\n", output.Faint(padded), j.Name, output.Faint(buildInfo))
 		}

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -67,11 +67,11 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.status, "status", "", "Filter by status (success, failure, running, queued, error, unknown)")
 	cmd.Flags().StringVarP(&opts.user, "user", "u", "", "Filter by user who triggered")
 	cmd.Flags().StringVar(&opts.revision, "revision", "", "Filter by VCS revision/commit SHA (or '@head' for current HEAD)")
-	cmd.Flags().BoolVar(&opts.favorites, "favorites", false, "Show favorite runs for the current user")
+	cmd.Flags().BoolVar(&opts.favorites, "favorites", false, "Show favorites for the current user")
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
-	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number of runs")
-	cmd.Flags().StringVar(&opts.since, "since", "", "Filter builds finished after this time (e.g., 24h, 2026-01-21)")
-	cmd.Flags().StringVar(&opts.until, "until", "", "Filter builds finished before this time (e.g., 12h, 2026-01-22)")
+	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number to show")
+	cmd.Flags().StringVar(&opts.since, "since", "", "Finished after this time (e.g., 24h, 2026-01-21)")
+	cmd.Flags().StringVar(&opts.until, "until", "", "Finished before this time (e.g., 12h, 2026-01-22)")
 	cmdutil.AddJSONFieldsFlag(cmd, &opts.jsonFields)
 	cmd.Flags().BoolVar(&opts.plain, "plain", false, "Output in plain text format for scripting")
 	cmd.Flags().BoolVar(&opts.noHeader, "no-header", false, "Omit header row (use with --plain)")
@@ -358,7 +358,7 @@ func resolveRunListEmptyMessage(opts *runListOptions) string {
 func newRunViewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &cmdutil.ViewOptions{}
 	cmd := &cobra.Command{
-		Use:     "view <run-id>",
+		Use:     "view <id>",
 		Aliases: []string{"show"},
 		Short:   "View details",
 		Args:    cobra.ExactArgs(1),

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -32,7 +32,7 @@ func newRunLogCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runLogOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "log [run-id]",
+		Use:   "log [id]",
 		Short: "View log",
 		Long: `View the log output from a run.
 
@@ -48,7 +48,7 @@ Pager: / search, n/N next/prev, g/G top/bottom, q quit.
 Use --raw to bypass the pager.`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && cmd.Flags().Changed("job") {
-				return tcerrors.MutuallyExclusive("run-id", "job")
+				return tcerrors.MutuallyExclusive("id", "job")
 			}
 			return cobra.MaximumNArgs(1)(cmd, args)
 		},
@@ -68,13 +68,13 @@ Use --raw to bypass the pager.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Get log for latest run of this job")
+	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Use this job's latest")
 	cmd.Flags().BoolVar(&opts.failed, "failed", false, "Show failure summary (problems and failed tests)")
 	cmd.Flags().BoolVar(&opts.raw, "raw", false, "Show raw log without formatting")
-	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open build log in browser")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open log in browser")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().IntVar(&opts.tail, "tail", 0, "Show last N log messages")
-	cmd.Flags().BoolVarP(&opts.follow, "follow", "f", false, "Stream log output until build completes")
+	cmd.Flags().BoolVarP(&opts.follow, "follow", "f", false, "Stream log output until completion")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "raw")
 	cmd.MarkFlagsMutuallyExclusive("json", "web")
@@ -213,7 +213,7 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 		}
 		runID = fmt.Sprintf("%d", runs.Builds[0].ID)
 		if !opts.json {
-			f.Printer.Info("Showing log for run %s  #%s", runID, runs.Builds[0].Number)
+			f.Printer.Info("Showing log for #%s (%s)", runID, runs.Builds[0].Number)
 		}
 	} else if runID == "" {
 		return fmt.Errorf("run ID required (or use --job to get latest run)")
@@ -259,7 +259,7 @@ func runLogFull(f *cmdutil.Factory, client api.ClientInterface, runID string, op
 	}
 
 	if log == "" {
-		f.Printer.Info("No log available for this run")
+		f.Printer.Info("No log available")
 		return nil
 	}
 

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -33,7 +33,7 @@ func newRunLogCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "log [run-id]",
-		Short: "View run log",
+		Short: "View log",
 		Long: `View the log output from a run.
 
 You can specify a run ID directly, or use --job to get the latest run's log.

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -71,7 +71,7 @@ Use --raw to bypass the pager.`,
 	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Use this job's latest")
 	cmd.Flags().BoolVar(&opts.failed, "failed", false, "Show failure summary (problems and failed tests)")
 	cmd.Flags().BoolVar(&opts.raw, "raw", false, "Show raw log without formatting")
-	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open log in browser")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().IntVar(&opts.tail, "tail", 0, "Show last N log messages")
 	cmd.Flags().BoolVarP(&opts.follow, "follow", "f", false, "Stream log output until completion")
@@ -515,7 +515,7 @@ func messageToJSON(msg api.BuildMessage) string {
 func runLogFailed(f *cmdutil.Factory, client api.ClientInterface, runID string, jsonOut bool) error {
 	build, err := client.GetBuild(runID)
 	if err != nil {
-		return fmt.Errorf("failed to get build: %w", err)
+		return fmt.Errorf("failed to fetch: %w", err)
 	}
 
 	if jsonOut {

--- a/internal/cmd/run/metadata.go
+++ b/internal/cmd/run/metadata.go
@@ -11,7 +11,7 @@ import (
 func newRunPinCmd(f *cmdutil.Factory) *cobra.Command {
 	var comment string
 	cmd := &cobra.Command{
-		Use:   "pin <run-id>",
+		Use:   "pin <id>",
 		Short: "Pin to prevent cleanup",
 		Long:  `Pin a run to prevent it from being automatically cleaned up by retention policies.`,
 		Args:  cobra.ExactArgs(1),
@@ -25,20 +25,20 @@ func newRunPinCmd(f *cmdutil.Factory) *cobra.Command {
 			if err := client.PinBuild(args[0], comment); err != nil {
 				return fmt.Errorf("failed to pin run: %w", err)
 			}
-			f.Printer.Success("Pinned run #%s", args[0])
+			f.Printer.Success("Pinned #%s", args[0])
 			if comment != "" {
 				f.Printer.Info("  Comment: %s", comment)
 			}
 			return nil
 		},
 	}
-	cmd.Flags().StringVarP(&comment, "comment", "m", "", "Comment explaining why the run is pinned")
+	cmd.Flags().StringVarP(&comment, "comment", "m", "", "Reason for pinning")
 	return cmd
 }
 
 func newRunUnpinCmd(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
-		Use:     "unpin <run-id>",
+		Use:     "unpin <id>",
 		Short:   "Unpin a run",
 		Long:    `Remove the pin from a run, allowing it to be cleaned up by retention policies.`,
 		Args:    cobra.ExactArgs(1),
@@ -51,7 +51,7 @@ func newRunUnpinCmd(f *cmdutil.Factory) *cobra.Command {
 			if err := client.UnpinBuild(args[0]); err != nil {
 				return fmt.Errorf("failed to unpin run: %w", err)
 			}
-			f.Printer.Success("Unpinned run #%s", args[0])
+			f.Printer.Success("Unpinned #%s", args[0])
 			return nil
 		},
 	}
@@ -59,7 +59,7 @@ func newRunUnpinCmd(f *cmdutil.Factory) *cobra.Command {
 
 func newRunTagCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tag <run-id> <tag>...",
+		Use:   "tag <id> <tag>...",
 		Short: "Add tags",
 		Long:  `Add one or more tags for categorization and filtering.`,
 		Args:  cobra.MinimumNArgs(2),
@@ -94,14 +94,14 @@ func runRunTag(f *cmdutil.Factory, runID string, tags []string) error {
 		return fmt.Errorf("failed to add tags: %w", err)
 	}
 
-	f.Printer.Success("Added %d tag(s) to run #%s", len(tags), runID)
+	f.Printer.Success("Added %d tag(s) to #%s", len(tags), runID)
 	f.Printer.Info("  Tags: %s", strings.Join(tags, ", "))
 	return nil
 }
 
 func newRunUntagCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "untag <run-id> <tag>...",
+		Use:   "untag <id> <tag>...",
 		Short: "Remove tags",
 		Long:  `Remove one or more tags.`,
 		Args:  cobra.MinimumNArgs(2),
@@ -132,7 +132,7 @@ func runRunUntag(f *cmdutil.Factory, runID string, tags []string) error {
 	}
 
 	if removed > 0 {
-		f.Printer.Success("Removed %d tag(s) from run #%s", removed, runID)
+		f.Printer.Success("Removed %d tag(s) from #%s", removed, runID)
 	}
 
 	if len(errors) > 0 {
@@ -156,7 +156,7 @@ func newRunCommentCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runCommentOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "comment <run-id> [comment]",
+		Use:   "comment <id> [comment]",
 		Short: "Set or view comment",
 		Long: `Set, view, or delete a comment on a run.
 
@@ -196,7 +196,7 @@ func runRunComment(f *cmdutil.Factory, runID string, comment string, opts *runCo
 		if opts.json {
 			return f.Printer.PrintJSON(map[string]string{"run_id": runID, "comment": ""})
 		}
-		f.Printer.Success("Deleted comment from run #%s", runID)
+		f.Printer.Success("Deleted comment from #%s", runID)
 		return nil
 	}
 
@@ -207,7 +207,7 @@ func runRunComment(f *cmdutil.Factory, runID string, comment string, opts *runCo
 		if opts.json {
 			return f.Printer.PrintJSON(map[string]string{"run_id": runID, "comment": comment})
 		}
-		f.Printer.Success("Set comment on run #%s", runID)
+		f.Printer.Success("Set comment on #%s", runID)
 		f.Printer.Info("  Comment: %s", comment)
 		return nil
 	}
@@ -223,7 +223,7 @@ func runRunComment(f *cmdutil.Factory, runID string, comment string, opts *runCo
 
 	p := f.Printer
 	if existingComment == "" {
-		p.Info("No comment set on run #%s", runID)
+		p.Info("No comment set on #%s", runID)
 	} else {
 		_, _ = fmt.Fprintln(p.Out, existingComment)
 	}

--- a/internal/cmd/run/metadata.go
+++ b/internal/cmd/run/metadata.go
@@ -12,7 +12,7 @@ func newRunPinCmd(f *cmdutil.Factory) *cobra.Command {
 	var comment string
 	cmd := &cobra.Command{
 		Use:   "pin <run-id>",
-		Short: "Pin a run to prevent cleanup",
+		Short: "Pin to prevent cleanup",
 		Long:  `Pin a run to prevent it from being automatically cleaned up by retention policies.`,
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity run pin 12345
@@ -60,8 +60,8 @@ func newRunUnpinCmd(f *cmdutil.Factory) *cobra.Command {
 func newRunTagCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tag <run-id> <tag>...",
-		Short: "Add tags to a run",
-		Long:  `Add one or more tags to a run for categorization and filtering.`,
+		Short: "Add tags",
+		Long:  `Add one or more tags for categorization and filtering.`,
 		Args:  cobra.MinimumNArgs(2),
 		Example: `  teamcity run tag 12345 release
   teamcity run tag 12345 release v1.0 production`,
@@ -102,8 +102,8 @@ func runRunTag(f *cmdutil.Factory, runID string, tags []string) error {
 func newRunUntagCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "untag <run-id> <tag>...",
-		Short: "Remove tags from a run",
-		Long:  `Remove one or more tags from a run.`,
+		Short: "Remove tags",
+		Long:  `Remove one or more tags.`,
 		Args:  cobra.MinimumNArgs(2),
 		Example: `  teamcity run untag 12345 release
   teamcity run untag 12345 release v1.0`,
@@ -157,7 +157,7 @@ func newRunCommentCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "comment <run-id> [comment]",
-		Short: "Set or view run comment",
+		Short: "Set or view comment",
 		Long: `Set, view, or delete a comment on a run.
 
 Without a comment argument, displays the current comment.

--- a/internal/cmd/run/restart.go
+++ b/internal/cmd/run/restart.go
@@ -17,7 +17,7 @@ func newRunRestartCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runRestartOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "restart <run-id>",
+		Use:   "restart <id>",
 		Short: "Restart a run",
 		Long:  `Restart a run with the same configuration.`,
 		Args:  cobra.ExactArgs(1),
@@ -29,7 +29,7 @@ func newRunRestartCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	opts.addToCmd(cmd)
-	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open run in browser")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 
 	return cmd
 }

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -7,11 +7,12 @@ import (
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "run",
-		Short: "Manage runs (builds)",
-		Long:  `List, view, start, and manage TeamCity runs (builds).`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Use:     "run",
+		Aliases: []string{"build"},
+		Short:   "Manage runs (builds)",
+		Long:    `List, view, start, and manage TeamCity runs (builds).`,
+		Args:    cobra.NoArgs,
+		RunE:    cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newRunListCmd(f))

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -34,5 +34,6 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.AddCommand(newRunTreeCmd(f))
 	cmd.AddCommand(newRunDiffCmd(f))
 
+	cmdutil.AliasAwareHelp(cmd, "run", "build")
 	return cmd
 }

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -163,7 +163,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
   teamcity run start Falcon_Build --comment "Release build" --tag release --tag v1.0
   teamcity run start Falcon_Build --clean --rebuild-deps --top
-  teamcity run start Falcon_Build --reuse-deps 6946,6917  # pin existing builds as snapshot deps
+  teamcity run start Falcon_Build --reuse-deps 6946,6917  # reuse existing as snapshot dependencies
   teamcity run start Falcon_Build --local-changes # personal build with uncommitted Git changes
   teamcity run start Falcon_Build --local-changes changes.patch  # from file
   teamcity run start Falcon_Build --revision abc123def --branch main
@@ -187,7 +187,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.cleanSources, "clean", false, "Clean sources before start")
 	cmd.Flags().BoolVar(&opts.rebuildDeps, "rebuild-deps", false, "Rebuild all dependencies")
 	cmd.Flags().BoolVar(&opts.rebuildFailedDeps, "rebuild-failed-deps", false, "Rebuild failed/incomplete dependencies")
-	cmd.Flags().IntSliceVar(&opts.reuseDeps, "reuse-deps", nil, "Reuse existing builds as snapshot deps (build IDs, comma-separated or repeated)")
+	cmd.Flags().IntSliceVar(&opts.reuseDeps, "reuse-deps", nil, "Reuse existing as snapshot dependencies (IDs, comma-separated or repeated)")
 	cmd.Flags().BoolVar(&opts.queueAtTop, "top", false, "Add to top of queue")
 	cmd.Flags().IntVar(&opts.agent, "agent", 0, "Use specific agent (by ID)")
 	opts.addToCmd(cmd)

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -193,7 +193,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	opts.addToCmd(cmd)
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Preview without triggering")
-	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON (for scripting)")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 
 	return cmd
 }
@@ -354,7 +354,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		if build.Number != "" {
 			ref = fmt.Sprintf("%d  #%s", build.ID, build.Number)
 		}
-		p.Info("Reused existing run %s for %s (build optimization)", ref, jobID)
+		p.Info("Reused existing #%s for %s (optimization)", ref, jobID)
 	} else {
 		printQueuedRun(p, build, jobID)
 	}

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -26,7 +26,7 @@ type watchFlags struct {
 
 // addToCmd registers the shared watch flags on a cobra command.
 func (w *watchFlags) addToCmd(cmd *cobra.Command) {
-	cmd.Flags().BoolVar(&w.watch, "watch", false, "Watch run until it completes")
+	cmd.Flags().BoolVar(&w.watch, "watch", false, "Watch until completion")
 	cmd.Flags().IntVarP(&w.interval, "interval", "i", 5, "Refresh interval in seconds when watching")
 	cmd.Flags().DurationVar(&w.timeout, "timeout", 0, "Timeout when watching (e.g., 30m, 1h); implies --watch")
 }
@@ -174,25 +174,25 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch to build")
-	cmd.Flags().StringVar(&opts.revision, "revision", "", "Pin build to a specific Git commit SHA")
-	cmd.Flags().StringToStringVarP(&opts.params, "param", "P", nil, "Build parameters (key=value)")
+	cmd.Flags().StringVar(&opts.revision, "revision", "", "Pin to a specific Git commit SHA")
+	cmd.Flags().StringToStringVarP(&opts.params, "param", "P", nil, "Parameters (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.systemProps, "system", "S", nil, "System properties (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.envVars, "env", "E", nil, "Environment variables (key=value)")
-	cmd.Flags().StringVarP(&opts.comment, "comment", "m", "", "Run comment")
-	cmd.Flags().StringSliceVarP(&opts.tags, "tag", "t", nil, "Run tags (can be repeated)")
-	cmd.Flags().BoolVar(&opts.personal, "personal", false, "Run as personal build")
+	cmd.Flags().StringVarP(&opts.comment, "comment", "m", "", "Comment to attach")
+	cmd.Flags().StringSliceVarP(&opts.tags, "tag", "t", nil, "Tags (can be repeated)")
+	cmd.Flags().BoolVar(&opts.personal, "personal", false, "Personal build")
 	localChangesFlag := cmd.Flags().VarPF(&localChangesValue{val: &opts.localChanges}, "local-changes", "l", "Include local changes (git, -, or path; default: git)")
 	localChangesFlag.NoOptDefVal = "git"
 	cmd.Flags().BoolVar(&opts.noPush, "no-push", false, "Skip auto-push of branch to remote")
-	cmd.Flags().BoolVar(&opts.cleanSources, "clean", false, "Clean sources before run")
+	cmd.Flags().BoolVar(&opts.cleanSources, "clean", false, "Clean sources before start")
 	cmd.Flags().BoolVar(&opts.rebuildDeps, "rebuild-deps", false, "Rebuild all dependencies")
 	cmd.Flags().BoolVar(&opts.rebuildFailedDeps, "rebuild-failed-deps", false, "Rebuild failed/incomplete dependencies")
 	cmd.Flags().IntSliceVar(&opts.reuseDeps, "reuse-deps", nil, "Reuse existing builds as snapshot deps (build IDs, comma-separated or repeated)")
 	cmd.Flags().BoolVar(&opts.queueAtTop, "top", false, "Add to top of queue")
-	cmd.Flags().IntVar(&opts.agent, "agent", 0, "Run on specific agent (by ID)")
+	cmd.Flags().IntVar(&opts.agent, "agent", 0, "Use specific agent (by ID)")
 	opts.addToCmd(cmd)
-	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open run in browser")
-	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Show what would be triggered without running")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Preview without triggering")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON (for scripting)")
 
 	return cmd

--- a/internal/cmd/run/tree.go
+++ b/internal/cmd/run/tree.go
@@ -42,7 +42,7 @@ func newRunTreeCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "tree <run-id>",
-		Short: "Display snapshot dependency tree for a run",
+		Short: "Display snapshot dependency tree",
 		Example: `  teamcity run tree 12345
   teamcity run tree 12345 --depth 2
   teamcity run tree 12345 --json`,

--- a/internal/cmd/run/tree.go
+++ b/internal/cmd/run/tree.go
@@ -41,7 +41,7 @@ func newRunTreeCmd(f *cmdutil.Factory) *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
-		Use:   "tree <run-id>",
+		Use:   "tree <id>",
 		Short: "Display snapshot dependency tree",
 		Example: `  teamcity run tree 12345
   teamcity run tree 12345 --depth 2

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -31,7 +31,7 @@ func newRunWatchCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runWatchOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "watch <run-id>",
+		Use:   "watch <id>",
 		Short: "Watch a run until it completes",
 		Long: `Watch a run in real-time until it completes.
 
@@ -49,7 +49,7 @@ For a simpler, pipe-friendly log stream, use "teamcity run log --follow" instead
 	}
 
 	cmd.Flags().IntVarP(&opts.interval, "interval", "i", 5, "Refresh interval in seconds")
-	cmd.Flags().BoolVar(&opts.logs, "logs", false, "Stream build logs while watching")
+	cmd.Flags().BoolVar(&opts.logs, "logs", false, "Stream logs while watching")
 	cmd.Flags().BoolVar(&opts.quiet, "quiet", false, "Minimal output, show only state changes and result")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Wait for completion and output result as JSON")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 0, "Timeout duration (e.g., 30m, 1h)")

--- a/internal/cmdutil/alias_help.go
+++ b/internal/cmdutil/alias_help.go
@@ -1,0 +1,118 @@
+package cmdutil
+
+import (
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// AliasAwareHelp makes help output reflect whichever alias the user typed.
+func AliasAwareHelp(cmd *cobra.Command, canonical, alias string) {
+	base := cmd.HelpFunc()
+	replacer := buildNounReplacer(canonical, alias)
+
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		target, name := detectAlias(c, cmd)
+		if target == nil {
+			base(c, args)
+			return
+		}
+		swap := snapshotAndSwap(c, target, name, replacer)
+		base(c, args)
+		swap.restore()
+	})
+}
+
+type helpSnapshot struct {
+	aliased     *cobra.Command
+	origUse     string
+	origAliases []string
+	helpCmd     *cobra.Command
+	origShort   string
+	origLong    string
+	origExample string
+	subShorts   []savedShort
+}
+
+type savedShort struct {
+	cmd  *cobra.Command
+	orig string
+}
+
+func (s *helpSnapshot) restore() {
+	s.aliased.Use = s.origUse
+	s.aliased.Aliases = s.origAliases
+	s.helpCmd.Short, s.helpCmd.Long, s.helpCmd.Example = s.origShort, s.origLong, s.origExample
+	for _, b := range s.subShorts {
+		b.cmd.Short = b.orig
+	}
+}
+
+func snapshotAndSwap(helpCmd, aliased *cobra.Command, called string, r *strings.Replacer) *helpSnapshot {
+	snap := &helpSnapshot{
+		aliased:     aliased,
+		origUse:     aliased.Use,
+		origAliases: aliased.Aliases,
+		helpCmd:     helpCmd,
+		origShort:   helpCmd.Short,
+		origLong:    helpCmd.Long,
+		origExample: helpCmd.Example,
+	}
+
+	aliased.Use = called
+	swapped := make([]string, 0, len(snap.origAliases))
+	for _, a := range snap.origAliases {
+		if a != called {
+			swapped = append(swapped, a)
+		}
+	}
+	swapped = append(swapped, snap.origUse)
+	aliased.Aliases = swapped
+
+	if r != nil {
+		helpCmd.Short = r.Replace(helpCmd.Short)
+		helpCmd.Long = r.Replace(helpCmd.Long)
+		helpCmd.Example = r.Replace(helpCmd.Example)
+		for _, sub := range helpCmd.Commands() {
+			if replaced := r.Replace(sub.Short); replaced != sub.Short {
+				snap.subShorts = append(snap.subShorts, savedShort{sub, sub.Short})
+				sub.Short = replaced
+			}
+		}
+	}
+
+	return snap
+}
+
+// detectAlias checks whether the command (or a parent) was invoked via alias.
+func detectAlias(c, aliasRoot *cobra.Command) (*cobra.Command, string) {
+	if ca := c.CalledAs(); ca != "" && ca != c.Name() {
+		return c, ca
+	}
+	// Cobra only sets CalledAs on the leaf command; for parents we check os.Args.
+	for _, alias := range aliasRoot.Aliases {
+		if slices.Contains(os.Args[1:], alias) {
+			return aliasRoot, alias
+		}
+	}
+	return nil, ""
+}
+
+// buildNounReplacer generates old→new pairs from canonical/alias nouns.
+func buildNounReplacer(canonical, alias string) *strings.Replacer {
+	if canonical == "" || alias == "" {
+		return nil
+	}
+	cp, ap := canonical+"s", alias+"s"
+	return strings.NewReplacer(
+		cp+" ("+ap+")", ap+" ("+cp+")",
+		"a new "+canonical, "a new "+alias,
+		"a "+canonical, "a "+alias,
+		"two "+cp, "two "+ap,
+		"recent "+cp, "recent "+ap,
+		cp, ap,
+		"teamcity "+canonical+" ", "teamcity "+alias+" ",
+	)
+}

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -70,15 +70,12 @@ func (f *Factory) Client() (api.ClientInterface, error) {
 // InitOutput configures output settings from Factory flags.
 // Called once after flags are parsed (in PersistentPreRun).
 func (f *Factory) InitOutput() {
-	noColor := os.Getenv("NO_COLOR") != "" ||
+	explicitDisable := os.Getenv("NO_COLOR") != "" ||
 		os.Getenv("TEAMCITY_NO_COLOR") != "" ||
-		os.Getenv("TERM") == "dumb" ||
-		f.NoColor ||
-		!isatty.IsTerminal(os.Stdout.Fd())
-
-	if noColor {
-		color.NoColor = true
-	}
+		f.NoColor
+	forceColor := os.Getenv("FORCE_COLOR") != "" && !explicitDisable
+	color.NoColor = !forceColor &&
+		(explicitDisable || os.Getenv("TERM") == "dumb" || !isatty.IsTerminal(os.Stdout.Fd()))
 
 	f.Printer.Quiet = f.Quiet
 	f.Printer.Verbose = f.Verbose

--- a/internal/cmdutil/failure.go
+++ b/internal/cmdutil/failure.go
@@ -12,7 +12,7 @@ import (
 const maxFailedTestsToShow = 10
 
 func PrintFailureSummary(p *output.Printer, client api.ClientInterface, buildID, buildNumber, webURL, statusText string) {
-	header := fmt.Sprintf("%s Build %s  #%s failed", output.Red("✗"), buildID, buildNumber)
+	header := fmt.Sprintf("%s %s  #%s failed", output.Red("✗"), buildID, buildNumber)
 	if statusText != "" {
 		header += ": " + statusText
 	}
@@ -24,13 +24,13 @@ func PrintFailureSummary(p *output.Printer, client api.ClientInterface, buildID,
 
 	tests, testsErr = client.GetBuildTests(buildID, true, maxFailedTestsToShow)
 	if testsErr != nil {
-		p.Debug("Failed to fetch build tests: %v", testsErr)
+		p.Debug("Failed to fetch tests: %v", testsErr)
 	} else if tests.Failed > 0 {
 		hasTests = true
 	}
 
 	if problems, err := client.GetBuildProblems(buildID); err != nil {
-		p.Debug("Failed to fetch build problems: %v", err)
+		p.Debug("Failed to fetch problems: %v", err)
 	} else if problems.Count > 0 {
 		_, _ = fmt.Fprintf(p.Out, "\nProblems:\n")
 		for _, prob := range problems.ProblemOccurrence {
@@ -92,7 +92,7 @@ func BuildResultError(p *output.Printer, client api.ClientInterface, build *api.
 		PrintFailureSummary(p, client, fmt.Sprintf("%d", build.ID), build.Number, build.WebURL, build.StatusText)
 		return &ExitError{Code: ExitFailure}
 	default:
-		_, _ = fmt.Fprintf(p.Out, "%s Build %d  #%s canceled\n", output.Yellow("○"), build.ID, build.Number)
+		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s canceled\n", output.Yellow("○"), output.Cyan(jobName), build.ID, build.Number)
 		return &ExitError{Code: ExitCancelled}
 	}
 }

--- a/internal/cmdutil/failure_summary_test.go
+++ b/internal/cmdutil/failure_summary_test.go
@@ -45,7 +45,7 @@ func TestPrintFailureSummary(t *testing.T) {
 			api.ProblemOccurrences{},
 			"compilation error",
 		)
-		assert.Contains(t, out, "Build 123")
+		assert.Contains(t, out, "123")
 		assert.Contains(t, out, "#42 failed: compilation error")
 		assert.Contains(t, out, "https://tc/build/123")
 	})


### PR DESCRIPTION
## Summary

Fixes #220. Makes the CLI approachable for users who know TeamCity's classic vocabulary (*build*, *build configuration*) while keeping `run`/`job` as the canonical nouns.

## What changes

**Cobra aliases** — `build` and `buildtype` just work:
- `teamcity build list` ≡ `teamcity run list`
- `teamcity buildtype view X` ≡ `teamcity job view X`

Both show up in `--help` as `Aliases: run, build` / `job, buildtype`, teaching the mapping on first use.

**Help text cleanup** — subcommand Shorts and flag descriptions pruned of redundant `run` nouns where parent context already set them. Examples:
- `List run artifacts` → `List artifacts`
- `View run log` → `View log`
- `Open run in browser` → `Open in browser`
- `Watch run until it completes` → `Watch until completion`
- `Build parameters (key=value)` → `Parameters (key=value)`

**Placeholders** — `<run-id>` / `[run-id]` → `<id>` / `[id]` across all run subcommands. Argument type is now vocab-neutral regardless of which alias the user types.

**Runtime output** — `Pinned run #12345` → `Pinned #12345`, `Canceled run #X` → `Canceled #X`, etc. Classic users no longer see stale vocab after invoking via `build`.

**`agent reboot --after-build` → `--graceful`** — renamed to avoid build/run overload and match universal CLI idiom (kubectl, docker, systemctl). Old flag remains as a deprecated alias for backward compatibility.

## Design notes

- Canonical names (`run`, `job`) stay. The aliases are a bridge, not a rename.
- Longs, Examples, and docs stay canonical — they're the authoritative voice.
- TC terms of art kept intact where they carry specific meaning: `personal build`, `build queue`, `build agent`, `rebuild dependencies`.
- Flag naming rule going forward: mention *run*/*build*/*job* in flag help only when (1) it's a TC term of art, (2) it disambiguates between entities, or (3) it's a dictionary-English verb.

## Example

```bash
teamcity build view 12345            # works, alias
teamcity buildtype list              # works, alias
teamcity agent reboot 1 --graceful   # new canonical flag
teamcity agent reboot 1 --after-build  # prints deprecation notice, still works
```

## Test Plan

- [x] Unit tests pass (\`just unit\`)
- [x] Linter passes (\`just lint\`)
- [x] Added acceptance tests for both aliases (\`run-alias-build.txtar\`, \`job-alias-buildtype.txtar\`)
- [x] No breaking behavior change (old \`--after-build\` still works with warning)