### PR TITLE
feat(output): display canceled builds with ⊘ icon

### DIFF
--- a/api/builds.go
+++ b/api/builds.go
@@ -376,7 +376,7 @@ func (c *Client) CancelBuild(buildID string, comment string) error {
 // GetBuildSnapshotDependencies returns all immediate dependency builds in a snapshot dependency chain.
 func (c *Client) GetBuildSnapshotDependencies(buildID string) (*BuildList, error) {
 	locator := fmt.Sprintf("snapshotDependency:(to:(id:%s),recursive:false),defaultFilter:false", buildID)
-	fields := "count,nextHref,build(id,number,status,state,buildTypeId,buildType(id,name))"
+	fields := "count,nextHref,build(id,number,status,statusText,state,buildTypeId,buildType(id,name))"
 	path := fmt.Sprintf("/app/rest/builds?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(fields))
 
 	var combined BuildList

--- a/api/fields.go
+++ b/api/fields.go
@@ -87,7 +87,7 @@ var BuildFields = FieldSpec{
 		"usedByOtherBuilds",
 	},
 	Default: []string{
-		"id", "number", "status", "state", "branchName", "buildTypeId",
+		"id", "number", "status", "statusText", "state", "branchName", "buildTypeId",
 		"buildType.id", "buildType.name", "buildType.projectName",
 		"triggered.type", "triggered.user.name", "triggered.user.username",
 		"startDate", "finishDate", "queuedDate", "agent.name",

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -308,7 +308,7 @@ func TestInvalidStatusFilter(T *testing.T) {
 func TestValidStatusFilter(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 
-	validStatuses := []string{"success", "failure", "running", "queued"}
+	validStatuses := []string{"success", "failure", "running", "queued", "canceled"}
 	for _, status := range validStatuses {
 		T.Run(status, func(t *testing.T) {
 			rootCmd := cmd.NewRootCmdWithFactory(ts.Factory)
@@ -335,6 +335,7 @@ func TestStatusFilterLocator(T *testing.T) {
 		{"queued", "state%3Aqueued", "", "status%3AQUEUED"},
 		{"error", "status%3AERROR", "state%3Afinished", ""},
 		{"unknown", "status%3AUNKNOWN", "state%3Afinished", ""},
+		{"canceled", "status%3AUNKNOWN", "state%3Afinished", ""},
 	}
 
 	for _, tt := range tests {
@@ -507,7 +508,7 @@ func TestRunStart_reused(t *testing.T) {
 func TestRunList_invalid_status(t *testing.T) {
 	ts := cmdtest.SetupMockClient(t)
 	err := cmdtest.CaptureErr(t, ts.Factory, "run", "list", "--status", "bogus")
-	assert.Equal(t, `invalid status "bogus", must be one of: success, failure, running, queued, error, unknown`, err.Error())
+	assert.Equal(t, `invalid status "bogus", must be one of: success, failure, running, queued, error, unknown, canceled`, err.Error())
 }
 
 func TestRunList_invalid_limit(t *testing.T) {

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -386,8 +386,8 @@ func renderDiff(p *output.Printer, d1, d2 buildData) {
 }
 
 func renderDiffHeader(p *output.Printer, b1, b2 *api.Build) {
-	icon1 := output.StatusIcon(b1.Status, b1.State)
-	icon2 := output.StatusIcon(b2.Status, b2.State)
+	icon1 := output.StatusIcon(b1.Status, b1.State, b1.StatusText)
+	icon2 := output.StatusIcon(b2.Status, b2.State, b2.StatusText)
 
 	jobName := b1.BuildTypeID
 	if b1.BuildType != nil {
@@ -439,13 +439,13 @@ func renderStatusDiff(p *output.Printer, b1, b2 *api.Build) bool {
 
 	sectionHeader(p, "STATUS")
 
-	statusLine1 := output.StatusText(b1.Status, b1.State)
-	if b1.StatusText != "" && b1.StatusText != b1.Status {
-		statusLine1 += output.Faint("  " + truncate(b1.StatusText, 80))
+	statusLine1 := output.StatusText(b1.Status, b1.State, b1.StatusText)
+	if detail := statusTextDetail(b1); detail != "" {
+		statusLine1 += output.Faint("  " + truncate(detail, 80))
 	}
-	statusLine2 := output.StatusText(b2.Status, b2.State)
-	if b2.StatusText != "" && b2.StatusText != b2.Status {
-		statusLine2 += output.Faint("  " + truncate(b2.StatusText, 80))
+	statusLine2 := output.StatusText(b2.Status, b2.State, b2.StatusText)
+	if detail := statusTextDetail(b2); detail != "" {
+		statusLine2 += output.Faint("  " + truncate(detail, 80))
 	}
 
 	diffLine(p, "-", "red", "%s", statusLine1)
@@ -699,6 +699,16 @@ func agentName(b *api.Build) string {
 		return b.Agent.Name
 	}
 	return ""
+}
+
+func statusTextDetail(b *api.Build) string {
+	if b.StatusText == "" || b.StatusText == b.Status {
+		return ""
+	}
+	if strings.EqualFold(b.StatusText, "Canceled") {
+		return ""
+	}
+	return b.StatusText
 }
 
 func statusString(b *api.Build) string {

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -134,10 +134,10 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 	for _, r := range runs.Builds {
 		var status, runRef string
 		if opts.plain {
-			status = output.PlainStatusText(r.Status, r.State)
+			status = output.PlainStatusText(r.Status, r.State, r.StatusText)
 			runRef = fmt.Sprintf("%d", r.ID)
 		} else {
-			status = fmt.Sprintf("%s %s", output.StatusIcon(r.Status, r.State), output.StatusText(r.Status, r.State))
+			status = fmt.Sprintf("%s %s", output.StatusIcon(r.Status, r.State, r.StatusText), output.StatusText(r.Status, r.State, r.StatusText))
 			runRef = fmt.Sprintf("%d  #%s", r.ID, r.Number)
 		}
 
@@ -287,7 +287,7 @@ func resolveRunListStatus(status string) (statusFilter, stateFilter string, err 
 		return "", "", nil
 	}
 
-	validValues := []string{"success", "failure", "running", "queued", "error", "unknown"}
+	validValues := []string{"success", "failure", "running", "queued", "error", "unknown", "canceled"}
 	v := strings.ToLower(status)
 	if !slices.Contains(validValues, v) {
 		return "", "", fmt.Errorf("invalid status %q, must be one of: %s", status, strings.Join(validValues, ", "))
@@ -296,6 +296,8 @@ func resolveRunListStatus(status string) (statusFilter, stateFilter string, err 
 	switch v {
 	case "running", "queued":
 		return "", v, nil
+	case "canceled":
+		return "unknown", "finished", nil
 	default:
 		return v, "finished", nil
 	}
@@ -400,7 +402,7 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 
 	pipelineRun, _ := client.GetBuildPipelineRun(fmt.Sprintf("%d", build.ID))
 
-	icon := output.StatusIcon(build.Status, build.State)
+	icon := output.StatusIcon(build.Status, build.State, build.StatusText)
 	jobName := build.BuildTypeID
 	if pipelineRun != nil && pipelineRun.Pipeline != nil && pipelineRun.Pipeline.Name != "" {
 		jobName = pipelineRun.Pipeline.Name + " ⬡"

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -100,9 +100,9 @@ func reuseDepRow(d reuseDep) (icon, summary string) {
 	}
 	parts = append(parts, cmp.Or(btName, b.BuildTypeID))
 	if (b.State != "" && b.State != "finished") || (b.Status != "" && !strings.EqualFold(b.Status, "SUCCESS")) {
-		parts = append(parts, output.StatusText(b.Status, b.State))
+		parts = append(parts, output.StatusText(b.Status, b.State, b.StatusText))
 	}
-	return output.StatusIcon(b.Status, b.State), strings.Join(parts, "  ")
+	return output.StatusIcon(b.Status, b.State, b.StatusText), strings.Join(parts, "  ")
 }
 
 func printQueuedRun(p *output.Printer, build *api.Build, context string) {

--- a/internal/cmd/run/tree.go
+++ b/internal/cmd/run/tree.go
@@ -19,13 +19,14 @@ type RunTreeNode struct {
 	Name         string        `json:"name"`
 	BuildTypeID  string        `json:"buildTypeId"`
 	Status       string        `json:"status,omitempty"`
+	StatusText   string        `json:"statusText,omitempty"`
 	State        string        `json:"state,omitempty"`
 	Dependencies []RunTreeNode `json:"dependencies"`
 	circular     bool
 }
 
 func (n RunTreeNode) toDisplayNode() output.TreeNode {
-	label := output.StatusIcon(n.Status, n.State) + " " + output.Cyan(n.Name) + " " + output.Faint(strconv.Itoa(n.ID))
+	label := output.StatusIcon(n.Status, n.State, n.StatusText) + " " + output.Cyan(n.Name) + " " + output.Faint(strconv.Itoa(n.ID))
 	if n.circular {
 		return output.TreeNode{Label: label + " " + output.Yellow("(circular)")}
 	}
@@ -93,7 +94,7 @@ func runRunTree(f *cmdutil.Factory, runID string, depth int, jsonOut bool) error
 }
 
 func printPipelineTree(p *output.Printer, build *api.Build, pr *api.PipelineRun, node RunTreeNode) {
-	icon := output.StatusIcon(build.Status, build.State)
+	icon := output.StatusIcon(build.Status, build.State, build.StatusText)
 	header := fmt.Sprintf("%s %s ⬡  %d  #%s", icon, output.Cyan(pr.Pipeline.Name), build.ID, build.Number)
 	if build.BranchName != "" {
 		header += "  · " + build.BranchName
@@ -115,7 +116,7 @@ func printPipelineTree(p *output.Printer, build *api.Build, pr *api.PipelineRun,
 	}
 
 	for _, dep := range node.Dependencies {
-		icon := output.StatusIcon(dep.Status, dep.State)
+		icon := output.StatusIcon(dep.Status, dep.State, dep.StatusText)
 		padded := fmt.Sprintf("%-*s", maxNameLen+2, dep.Name)
 		_, _ = fmt.Fprintf(p.Out, "  %s %s %s\n", icon, padded, output.Faint(strconv.Itoa(dep.ID)))
 	}
@@ -163,6 +164,7 @@ func buildRunTree(client api.ClientInterface, b api.Build, depth int, path map[s
 		Name:         name,
 		BuildTypeID:  b.BuildTypeID,
 		Status:       b.Status,
+		StatusText:   b.StatusText,
 		State:        b.State,
 		Dependencies: []RunTreeNode{},
 	}

--- a/internal/cmd/run/tui/tui.go
+++ b/internal/cmd/run/tui/tui.go
@@ -210,8 +210,8 @@ func (m watchModel) renderHeader() string {
 		jobName = m.build.BuildType.Name
 	}
 
-	icon := output.StatusIcon(m.build.Status, m.build.State)
-	status := output.StatusText(m.build.Status, m.build.State)
+	icon := output.StatusIcon(m.build.Status, m.build.State, m.build.StatusText)
+	status := output.StatusText(m.build.Status, m.build.State, m.build.StatusText)
 
 	header := fmt.Sprintf("%s %s %d  #%s %s · %s", icon, output.Bold(jobName), m.build.ID, m.build.Number, output.Faint(m.build.WebURL), status)
 	if m.build.PercentageComplete > 0 && m.build.State != "finished" {

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -199,7 +199,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 				progress = fmt.Sprintf(" (%d%%)", build.PercentageComplete)
 			}
 			_, _ = fmt.Fprintf(p.Out, "\r%s %s %d  #%s %s · %s%s    ",
-				output.StatusIcon(build.Status, build.State),
+				output.StatusIcon(build.Status, build.State, build.StatusText),
 				output.Cyan(jobName),
 				build.ID,
 				build.Number,

--- a/internal/output/status.go
+++ b/internal/output/status.go
@@ -2,13 +2,21 @@ package output
 
 import "strings"
 
-// StatusIcon returns a colored status icon
-func StatusIcon(status, state string) string {
+func isCanceled(status, statusText string) bool {
+	return strings.EqualFold(status, "UNKNOWN") && strings.HasPrefix(strings.ToLower(statusText), "canceled")
+}
+
+// StatusIcon returns a colored status icon.
+func StatusIcon(status, state string, statusText ...string) string {
 	if state == "running" {
 		return Yellow("●")
 	}
 	if state == "queued" {
 		return Faint("◦")
+	}
+
+	if len(statusText) > 0 && isCanceled(status, statusText[0]) {
+		return Faint("⊘")
 	}
 
 	switch strings.ToUpper(status) {
@@ -23,13 +31,17 @@ func StatusIcon(status, state string) string {
 	}
 }
 
-// StatusText returns colored status text
-func StatusText(status, state string) string {
+// StatusText returns colored status text.
+func StatusText(status, state string, apiStatusText ...string) string {
 	if state == "running" {
 		return Yellow("Running")
 	}
 	if state == "queued" {
 		return Faint("Queued")
+	}
+
+	if len(apiStatusText) > 0 && isCanceled(status, apiStatusText[0]) {
+		return Faint("Canceled")
 	}
 
 	switch strings.ToUpper(status) {
@@ -39,18 +51,24 @@ func StatusText(status, state string) string {
 		return Red("Failed")
 	case "ERROR":
 		return Red("Error")
+	case "UNKNOWN":
+		return Yellow("Unknown")
 	default:
 		return status
 	}
 }
 
-// PlainStatusIcon returns a plain text status icon (for --plain output)
-func PlainStatusIcon(status, state string) string {
+// PlainStatusIcon returns a plain text status icon (for --plain output).
+func PlainStatusIcon(status, state string, statusText ...string) string {
 	if state == "running" {
 		return "*"
 	}
 	if state == "queued" {
 		return "o"
+	}
+
+	if len(statusText) > 0 && isCanceled(status, statusText[0]) {
+		return "/"
 	}
 
 	switch strings.ToUpper(status) {
@@ -65,13 +83,16 @@ func PlainStatusIcon(status, state string) string {
 	}
 }
 
-// PlainStatusText returns plain status text (for --plain output)
-func PlainStatusText(status, state string) string {
+// PlainStatusText returns plain status text (for --plain output).
+func PlainStatusText(status, state string, apiStatusText ...string) string {
 	if state == "running" {
 		return "running"
 	}
 	if state == "queued" {
 		return "queued"
+	}
+	if len(apiStatusText) > 0 && isCanceled(status, apiStatusText[0]) {
+		return "canceled"
 	}
 	return strings.ToLower(status)
 }

--- a/internal/output/status_test.go
+++ b/internal/output/status_test.go
@@ -13,30 +13,31 @@ func TestStatusIcon(T *testing.T) {
 	tests := []struct {
 		status       string
 		state        string
+		statusText   string
 		wantContains string
 	}{
-		{"SUCCESS", "", "✓"},
-		{"FAILURE", "", "✗"},
-		{"ERROR", "", "✗"},
-		{"UNKNOWN", "", "?"},
-		{"OTHER", "", "○"},
-		{"", "running", "●"},
-		{"", "queued", "◦"},
-		// Case insensitivity tests
-		{"success", "", "✓"},
-		{"failure", "", "✗"},
-		{"Success", "", "✓"},
-		{"Failure", "", "✗"},
-		// Empty and edge cases
-		{"", "", "○"},
-		{" ", "", "○"},
+		{"SUCCESS", "", "", "✓"},
+		{"FAILURE", "", "", "✗"},
+		{"ERROR", "", "", "✗"},
+		{"UNKNOWN", "", "", "?"},
+		{"UNKNOWN", "", "Canceled (user)", "⊘"},
+		{"OTHER", "", "", "○"},
+		{"", "running", "", "●"},
+		{"", "queued", "", "◦"},
+		{"success", "", "", "✓"},
+		{"failure", "", "", "✗"},
+		{"Success", "", "", "✓"},
+		{"Failure", "", "", "✗"},
+		{"", "", "", "○"},
+		{" ", "", "", "○"},
+		{"SUCCESS", "", "Canceled", "✓"},
 	}
 
 	for _, tc := range tests {
-		T.Run(tc.status+"/"+tc.state, func(t *testing.T) {
+		T.Run(tc.status+"/"+tc.state+"/"+tc.statusText, func(t *testing.T) {
 			t.Parallel()
 
-			got := stripansi.Strip(StatusIcon(tc.status, tc.state))
+			got := stripansi.Strip(StatusIcon(tc.status, tc.state, tc.statusText))
 			assert.Contains(t, got, tc.wantContains)
 		})
 	}
@@ -48,21 +49,25 @@ func TestStatusText(T *testing.T) {
 	tests := []struct {
 		status       string
 		state        string
+		statusText   string
 		wantContains string
 	}{
-		{"SUCCESS", "", "Success"},
-		{"FAILURE", "", "Failed"},
-		{"ERROR", "", "Error"},
-		{"", "running", "Running"},
-		{"", "queued", "Queued"},
-		{"OTHER", "", "OTHER"},
+		{"SUCCESS", "", "", "Success"},
+		{"FAILURE", "", "", "Failed"},
+		{"ERROR", "", "", "Error"},
+		{"UNKNOWN", "", "", "Unknown"},
+		{"UNKNOWN", "", "Canceled", "Canceled"},
+		{"", "running", "", "Running"},
+		{"", "queued", "", "Queued"},
+		{"OTHER", "", "", "OTHER"},
+		{"SUCCESS", "", "Canceled", "Success"},
 	}
 
 	for _, tc := range tests {
-		T.Run(tc.status+"/"+tc.state, func(t *testing.T) {
+		T.Run(tc.status+"/"+tc.state+"/"+tc.statusText, func(t *testing.T) {
 			t.Parallel()
 
-			got := stripansi.Strip(StatusText(tc.status, tc.state))
+			got := stripansi.Strip(StatusText(tc.status, tc.state, tc.statusText))
 			assert.Contains(t, got, tc.wantContains)
 		})
 	}
@@ -71,23 +76,26 @@ func TestStatusText(T *testing.T) {
 func TestPlainStatusIcon(T *testing.T) {
 	T.Parallel()
 	tests := []struct {
-		status string
-		state  string
-		want   string
+		status     string
+		state      string
+		statusText string
+		want       string
 	}{
-		{"SUCCESS", "", "+"},
-		{"FAILURE", "", "x"},
-		{"ERROR", "", "x"},
-		{"UNKNOWN", "", "?"},
-		{"OTHER", "", "-"},
-		{"", "running", "*"},
-		{"", "queued", "o"},
+		{"SUCCESS", "", "", "+"},
+		{"FAILURE", "", "", "x"},
+		{"ERROR", "", "", "x"},
+		{"UNKNOWN", "", "", "?"},
+		{"UNKNOWN", "", "Canceled", "/"},
+		{"OTHER", "", "-", "-"},
+		{"", "running", "", "*"},
+		{"", "queued", "", "o"},
+		{"SUCCESS", "", "Canceled", "+"},
 	}
 
 	for _, tc := range tests {
-		T.Run(tc.status+"/"+tc.state, func(t *testing.T) {
+		T.Run(tc.status+"/"+tc.state+"/"+tc.statusText, func(t *testing.T) {
 			t.Parallel()
-			got := PlainStatusIcon(tc.status, tc.state)
+			got := PlainStatusIcon(tc.status, tc.state, tc.statusText)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -97,21 +105,24 @@ func TestPlainStatusText(T *testing.T) {
 	T.Parallel()
 
 	tests := []struct {
-		status string
-		state  string
-		want   string
+		status     string
+		state      string
+		statusText string
+		want       string
 	}{
-		{"SUCCESS", "", "success"},
-		{"FAILURE", "", "failure"},
-		{"", "running", "running"},
-		{"", "queued", "queued"},
+		{"SUCCESS", "", "", "success"},
+		{"FAILURE", "", "", "failure"},
+		{"UNKNOWN", "", "Canceled", "canceled"},
+		{"", "running", "", "running"},
+		{"", "queued", "", "queued"},
+		{"SUCCESS", "", "Canceled", "success"},
 	}
 
 	for _, tc := range tests {
-		T.Run(tc.status+"/"+tc.state, func(t *testing.T) {
+		T.Run(tc.status+"/"+tc.state+"/"+tc.statusText, func(t *testing.T) {
 			t.Parallel()
 
-			got := PlainStatusText(tc.status, tc.state)
+			got := PlainStatusText(tc.status, tc.state, tc.statusText)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
## Summary

Canceled builds (TeamCity `status: UNKNOWN` + `statusText: Canceled`) were shown as `? UNKNOWN` in CLI output. Now they display as `⊘ Canceled` across all views. Also adds `--status canceled` as a filter alias.

## Changes

**`internal/output/status.go`**
- All 4 status functions accept optional `statusText` variadic param
- When `status=UNKNOWN` and `statusText` starts with "Canceled", show `⊘ Canceled` (faint) instead of `? Unknown`
- Added `isCanceled()` helper gated on UNKNOWN status to prevent false matches on other statuses

**`api/fields.go`, `api/builds.go`**
- Added `statusText` to default build fields so list queries fetch it
- Added `statusText` to snapshot dependency fields for tree view

**`internal/cmd/run/list.go`**
- `--status canceled` accepted as alias → maps to `status:UNKNOWN,state:finished` locator

**`internal/cmd/run/diff.go`**
- Extracted `statusTextDetail()` to avoid showing redundant "Canceled" text while preserving richer details like "Canceled (reason)"

**Callers updated**: `list.go`, `start.go`, `watch.go`, `tui.go`, `diff.go`, `tree.go` all pass `statusText` through

## Design Decisions

- Used variadic `statusText ...string` param to avoid breaking existing callers that don't have `statusText` available
- `isCanceled()` is gated on `status == "UNKNOWN"` — a SUCCESS/FAILURE build with coincidental "Canceled" in statusText won't be misclassified
- `--status canceled` maps to the same API locator as `--status unknown` since TeamCity has no native "canceled" status

## Example

```
$ teamcity run list --status canceled --limit 5
STATUS      RUN         JOB           BRANCH  TRIGGERED BY    DURATION  AGE
⊘ Canceled  7654  #39   Sandbox_Test  main    Viktor Tiulpin  11s       5h ago
⊘ Canceled  7626  #38   Sandbox_Test  main    Viktor Tiulpin  10s       5h ago
⊘ Canceled  7611  #37   Sandbox_Test  main    Viktor Tiulpin  21s       5h ago
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, `--status canceled` is an alias value not a new flag
- [x] If adding a data-producing command: includes `--json` support — N/A
- [x] If modifying `--json` output: no field removals/renames (additive only) — `statusText` already present in JSON, just now fetched by default
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`