### PR TITLE
[codex] Add pagination flags to list commands

### DIFF
--- a/api/agents.go
+++ b/api/agents.go
@@ -11,45 +11,57 @@ import (
 
 // AgentsOptions represents options for listing agents
 type AgentsOptions struct {
-	Authorized bool   // Filter by authorization status
-	Connected  bool   // Filter by connection status
-	Enabled    bool   // Filter by enabled status
-	Pool       string // Filter by pool name
-	Limit      int
-	Fields     []string // Fields to return (uses AgentFields.Default if empty)
+	Authorized   bool   // Filter by authorization status
+	Connected    bool   // Filter by connection status
+	Enabled      bool   // Filter by enabled status
+	Pool         string // Filter by pool name
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string // Fields to return (uses AgentFields.Default if empty)
 }
 
 // GetAgents returns a list of agents
 func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
-	locator := NewLocator()
-
-	if opts.Authorized {
-		locator.Add("authorized", "true")
-	} else {
-		locator.Add("authorized", "any")
-	}
-
-	if opts.Connected {
-		locator.Add("connected", "true")
-	}
-	if opts.Enabled {
-		locator.Add("enabled", "true")
-	}
-	if opts.Pool != "" {
-		if _, err := strconv.Atoi(opts.Pool); err == nil {
-			locator.AddRaw("pool", "(id:"+opts.Pool+")")
-		} else {
-			locator.AddRaw("pool", "(name:"+opts.Pool+")")
-		}
-	}
-	locator.AddIntDefault("count", opts.Limit, 100)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = AgentFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,agent(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("agent", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator()
+
+		if opts.Authorized {
+			locator.Add("authorized", "true")
+		} else {
+			locator.Add("authorized", "any")
+		}
+
+		if opts.Connected {
+			locator.Add("connected", "true")
+		}
+		if opts.Enabled {
+			locator.Add("enabled", "true")
+		}
+		if opts.Pool != "" {
+			if _, err := strconv.Atoi(opts.Pool); err == nil {
+				locator.AddRaw("pool", "(id:"+opts.Pool+")")
+			} else {
+				locator.AddRaw("pool", "(name:"+opts.Pool+")")
+			}
+		}
+		locator.AddIntDefault("count", opts.Limit, 100).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result AgentList
 	if err := c.get(path, &result); err != nil {

--- a/api/agents.go
+++ b/api/agents.go
@@ -32,7 +32,7 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -67,6 +67,7 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 
 	return &result, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -921,7 +921,7 @@ func TestPoolOperations(T *testing.T) {
 	// Not parallel - modifies pool state
 
 	T.Run("list pools", func(t *testing.T) {
-		pools, err := client.GetAgentPools(nil)
+		pools, err := client.GetAgentPools(api.AgentPoolsOptions{})
 		require.NoError(t, err)
 		assert.Greater(t, pools.Count, 0, "should have at least one pool")
 		t.Logf("Found %d pools", pools.Count)

--- a/api/builds.go
+++ b/api/builds.go
@@ -77,7 +77,7 @@ func (c *Client) GetBuilds(opts BuildsOptions) (*BuildList, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fields)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fields)
 		if err != nil {
 			return nil, err
 		}
@@ -92,6 +92,7 @@ func (c *Client) GetBuilds(opts BuildsOptions) (*BuildList, error) {
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 
 	for i := range result.Builds {
 		cleanupBuildTriggered(&result.Builds[i])
@@ -420,16 +421,7 @@ func (c *Client) GetBuildSnapshotDependencies(buildID string) (*BuildList, error
 		}
 		combined.Builds = append(combined.Builds, page.Builds...)
 		combined.Count += page.Count
-		path = page.NextHref
-		if next, err := url.Parse(path); err == nil && next.IsAbs() {
-			path = next.RequestURI()
-		}
-		if base, err := url.Parse(c.BaseURL); err == nil && len(base.Path) > 1 {
-			path = strings.TrimPrefix(path, base.Path)
-		}
-		if c.APIVersion != "" && strings.HasPrefix(path, "/app/rest/") {
-			path = strings.Replace(path, "/app/rest/"+c.APIVersion+"/", "/app/rest/", 1)
-		}
+		path = c.normalizeContinuationPath(page.NextHref)
 	}
 	return &combined, nil
 }

--- a/api/builds.go
+++ b/api/builds.go
@@ -12,19 +12,21 @@ import (
 
 // BuildsOptions represents options for listing builds
 type BuildsOptions struct {
-	BuildTypeID string
-	Branch      string
-	Status      string
-	State       string
-	User        string
-	Project     string
-	Number      string
-	Revision    string
-	Favorites   bool
-	Limit       int
-	SinceDate   string
-	UntilDate   string
-	Fields      []string
+	BuildTypeID  string
+	Branch       string
+	Status       string
+	State        string
+	User         string
+	Project      string
+	Number       string
+	Revision     string
+	Favorites    bool
+	Limit        int
+	Skip         int
+	SinceDate    string
+	UntilDate    string
+	ContinuePath string
+	Fields       []string
 }
 
 const favoriteBuildTag = ".teamcity.star"
@@ -66,15 +68,25 @@ func currentUserFavoriteBuildsTagLocator() *Locator {
 
 // GetBuilds returns a list of builds
 func (c *Client) GetBuilds(opts BuildsOptions) (*BuildList, error) {
-	locator := opts.Locator().
-		AddIntDefault("count", opts.Limit, 30)
-
 	buildFields := opts.Fields
 	if len(buildFields) == 0 {
 		buildFields = BuildFields.Default
 	}
-	fields := fmt.Sprintf("count,build(%s)", ToAPIFields(buildFields))
-	path := fmt.Sprintf("/app/rest/builds?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fields))
+	fields := paginatedFieldsParam("build", buildFields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fields)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := opts.Locator().
+			AddIntDefault("count", opts.Limit, 30).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/builds?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fields))
+	}
 
 	var result BuildList
 	if err := c.get(path, &result); err != nil {

--- a/api/builds_queue.go
+++ b/api/builds_queue.go
@@ -8,28 +8,40 @@ import (
 
 // QueueOptions represents options for listing queued builds
 type QueueOptions struct {
-	BuildTypeID string
-	Limit       int
-	Fields      []string
+	BuildTypeID  string
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 // GetBuildQueue returns the build queue
 func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
-	locator := NewLocator().
-		Add("buildType", opts.BuildTypeID).
-		AddInt("count", opts.Limit)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = QueuedBuildFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,build(%s)", ToAPIFields(fields))
+	fieldsParam := paginatedFieldsParam("build", fields)
 
-	path := "/app/rest/buildQueue"
-	if !locator.IsEmpty() {
-		path = fmt.Sprintf("%s?locator=%s&fields=%s", path, locator.Encode(), url.QueryEscape(fieldsParam))
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
 	} else {
-		path = fmt.Sprintf("%s?fields=%s", path, url.QueryEscape(fieldsParam))
+		locator := NewLocator().
+			Add("buildType", opts.BuildTypeID).
+			AddInt("count", opts.Limit).
+			AddInt("start", opts.Skip)
+
+		path = "/app/rest/buildQueue"
+		if !locator.IsEmpty() {
+			path = fmt.Sprintf("%s?locator=%s&fields=%s", path, locator.Encode(), url.QueryEscape(fieldsParam))
+		} else {
+			path = fmt.Sprintf("%s?fields=%s", path, url.QueryEscape(fieldsParam))
+		}
 	}
 
 	var queue BuildQueue

--- a/api/builds_queue.go
+++ b/api/builds_queue.go
@@ -26,7 +26,7 @@ func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -48,6 +48,7 @@ func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
 	if err := c.get(path, &queue); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&queue.Href, &queue.NextHref)
 	return &queue, nil
 }
 

--- a/api/cloud.go
+++ b/api/cloud.go
@@ -10,23 +10,29 @@ import (
 )
 
 type CloudProfilesOptions struct {
-	ProjectID string
-	Limit     int
-	Fields    []string
+	ProjectID    string
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 type CloudImagesOptions struct {
-	ProjectID string
-	Profile   string
-	Limit     int
-	Fields    []string
+	ProjectID    string
+	Profile      string
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 type CloudInstancesOptions struct {
-	ProjectID string
-	Image     string
-	Limit     int
-	Fields    []string
+	ProjectID    string
+	Image        string
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 // cloudLocator normalizes a value into a cloud resource locator.
@@ -82,16 +88,26 @@ func isCloudIDLikeLocator(value string) bool {
 }
 
 func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList, error) {
-	locator := NewLocator().
-		Add("project", opts.ProjectID).
-		AddIntDefault("count", opts.Limit, 100)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = CloudProfileFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,cloudProfile(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/cloud/profiles?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("cloudProfile", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			Add("project", opts.ProjectID).
+			AddIntDefault("count", opts.Limit, 100).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/cloud/profiles?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result CloudProfileList
 	if err := c.get(path, &result); err != nil {
@@ -111,19 +127,29 @@ func (c *Client) GetCloudProfile(locator string) (*CloudProfile, error) {
 }
 
 func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error) {
-	locator := NewLocator().
-		Add("project", opts.ProjectID)
-	if opts.Profile != "" {
-		locator.AddRaw("profile", "("+cloudLocator(opts.Profile, "id")+")")
-	}
-	locator.AddIntDefault("count", opts.Limit, 100)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = CloudImageFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,cloudImage(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/cloud/images?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("cloudImage", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			Add("project", opts.ProjectID)
+		if opts.Profile != "" {
+			locator.AddRaw("profile", "("+cloudLocator(opts.Profile, "id")+")")
+		}
+		locator.AddIntDefault("count", opts.Limit, 100).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/cloud/images?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result CloudImageList
 	if err := c.get(path, &result); err != nil {
@@ -143,19 +169,29 @@ func (c *Client) GetCloudImage(locator string) (*CloudImage, error) {
 }
 
 func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceList, error) {
-	locator := NewLocator().
-		Add("project", opts.ProjectID)
-	if opts.Image != "" {
-		locator.AddRaw("image", "("+cloudLocator(opts.Image, "name")+")")
-	}
-	locator.AddIntDefault("count", opts.Limit, 100)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = CloudInstanceFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,cloudInstance(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/cloud/instances?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("cloudInstance", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			Add("project", opts.ProjectID)
+		if opts.Image != "" {
+			locator.AddRaw("image", "("+cloudLocator(opts.Image, "name")+")")
+		}
+		locator.AddIntDefault("count", opts.Limit, 100).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/cloud/instances?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result CloudInstanceList
 	if err := c.get(path, &result); err != nil {

--- a/api/cloud.go
+++ b/api/cloud.go
@@ -97,7 +97,7 @@ func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList,
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -113,6 +113,7 @@ func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList,
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 	return &result, nil
 }
 
@@ -136,7 +137,7 @@ func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -155,6 +156,7 @@ func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 	return &result, nil
 }
 
@@ -178,7 +180,7 @@ func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceLi
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -197,6 +199,7 @@ func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceLi
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 	return &result, nil
 }
 

--- a/api/interface.go
+++ b/api/interface.go
@@ -106,7 +106,7 @@ type ClientInterface interface {
 	GetAgentIncompatibleBuildTypes(id int) (*CompatibilityList, error)
 
 	// Agent Pools
-	GetAgentPools(fields []string) (*PoolList, error)
+	GetAgentPools(opts AgentPoolsOptions) (*PoolList, error)
 	GetAgentPool(id int) (*Pool, error)
 	AddProjectToPool(poolID int, projectID string) error
 	RemoveProjectFromPool(poolID int, projectID string) error

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -10,23 +10,35 @@ import (
 
 // BuildTypesOptions represents options for listing build configurations
 type BuildTypesOptions struct {
-	Project string
-	Limit   int
-	Fields  []string
+	Project      string
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 // GetBuildTypes returns a list of build configurations
 func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
-	locator := NewLocator().
-		Add("affectedProject", opts.Project).
-		AddIntDefault("count", opts.Limit, 30)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = BuildTypeFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,buildType(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/buildTypes?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("buildType", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			Add("affectedProject", opts.Project).
+			AddIntDefault("count", opts.Limit, 30).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/buildTypes?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result BuildTypeList
 	if err := c.get(path, &result); err != nil {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -28,7 +28,7 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -44,6 +44,7 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 
 	return &result, nil
 }

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -12,7 +12,7 @@ func paginatedFieldsParam(itemKey string, fields []string) string {
 	return fmt.Sprintf("count,href,nextHref,%s(%s)", itemKey, ToAPIFields(fields))
 }
 
-func rewriteContinuationPath(path string, limit int, fieldsParam string) (string, error) {
+func (c *Client) rewriteContinuationPath(path string, limit int, fieldsParam string) (string, error) {
 	u, err := url.Parse(path)
 	if err != nil {
 		return "", fmt.Errorf("parse continuation path: %w", err)
@@ -29,7 +29,42 @@ func rewriteContinuationPath(path string, limit int, fieldsParam string) (string
 	}
 
 	u.RawQuery = query.Encode()
-	return u.RequestURI(), nil
+	return c.normalizeContinuationPath(u.RequestURI()), nil
+}
+
+func (c *Client) normalizePageHrefs(hrefs ...*string) {
+	for _, href := range hrefs {
+		if href == nil {
+			continue
+		}
+		*href = c.normalizeContinuationPath(*href)
+	}
+}
+
+func (c *Client) normalizeContinuationPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	if u, err := url.Parse(path); err == nil {
+		path = u.RequestURI()
+	}
+
+	if base, err := url.Parse(c.BaseURL); err == nil {
+		basePath := strings.TrimSuffix(base.Path, "/")
+		if basePath != "" && basePath != "/" {
+			path = strings.TrimPrefix(path, basePath)
+		}
+	}
+
+	if c.APIVersion != "" {
+		versionPrefix := "/app/rest/" + c.APIVersion + "/"
+		if strings.HasPrefix(path, versionPrefix) {
+			path = strings.Replace(path, versionPrefix, "/app/rest/", 1)
+		}
+	}
+
+	return path
 }
 
 func setLocatorInt(locator, key string, value int) string {

--- a/api/pagination.go
+++ b/api/pagination.go
@@ -1,0 +1,99 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+func paginatedFieldsParam(itemKey string, fields []string) string {
+	return fmt.Sprintf("count,href,nextHref,%s(%s)", itemKey, ToAPIFields(fields))
+}
+
+func rewriteContinuationPath(path string, limit int, fieldsParam string) (string, error) {
+	u, err := url.Parse(path)
+	if err != nil {
+		return "", fmt.Errorf("parse continuation path: %w", err)
+	}
+
+	query := u.Query()
+	query.Set("fields", fieldsParam)
+
+	if limit > 0 {
+		locator := query.Get("locator")
+		if locator != "" {
+			query.Set("locator", setLocatorInt(locator, "count", limit))
+		}
+	}
+
+	u.RawQuery = query.Encode()
+	return u.RequestURI(), nil
+}
+
+func setLocatorInt(locator, key string, value int) string {
+	prefix := key + ":"
+	replacement := fmt.Sprintf("%s%d", prefix, value)
+	parts := splitLocator(locator)
+	index := slices.IndexFunc(parts, func(part string) bool {
+		rest, ok := strings.CutPrefix(part, prefix)
+		if !ok {
+			return false
+		}
+		_, err := strconv.Atoi(rest)
+		return err == nil
+	})
+	if index >= 0 {
+		parts[index] = replacement
+	} else {
+		parts = append(parts, replacement)
+	}
+	return strings.Join(parts, ",")
+}
+
+func splitLocator(locator string) []string {
+	if locator == "" {
+		return nil
+	}
+
+	parts := make([]string, 0, 8)
+	var current strings.Builder
+	depth := 0
+	escaped := false
+
+	for _, r := range locator {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+
+		switch r {
+		case '$':
+			current.WriteRune(r)
+			escaped = true
+		case '(':
+			depth++
+			current.WriteRune(r)
+		case ')':
+			depth = max(depth-1, 0)
+			current.WriteRune(r)
+		case ',':
+			if depth == 0 {
+				parts = append(parts, current.String())
+				current.Reset()
+				continue
+			}
+			current.WriteRune(r)
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if current.Len() > 0 {
+		parts = append(parts, current.String())
+	}
+
+	return parts
+}

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestRewriteContinuationPathOverridesCountAndFields(t *testing.T) {
-	path, err := rewriteContinuationPath(
+	client := NewClient("https://example.com", "token")
+
+	path, err := client.rewriteContinuationPath(
 		"/app/rest/buildTypes?locator=affectedProject:TestProject,count:30,start:30&fields=count,href,nextHref,buildType(id,name)",
 		10,
 		paginatedFieldsParam("buildType", []string{"id", "name", "projectId"}),
@@ -19,6 +21,23 @@ func TestRewriteContinuationPathOverridesCountAndFields(t *testing.T) {
 	assert.Contains(t, path, "start%3A30")
 	assert.Contains(t, path, "projectId")
 	assert.Contains(t, path, "nextHref")
+}
+
+func TestRewriteContinuationPathNormalizesBasePathAndVersion(t *testing.T) {
+	client := NewClient("https://example.com/teamcity", "token", WithAPIVersion("2023.1"))
+
+	path, err := client.rewriteContinuationPath(
+		"/teamcity/app/rest/2023.1/buildTypes?locator=affectedProject:TestProject,count:30,start:30&fields=count,href,nextHref,buildType(id,name)",
+		10,
+		paginatedFieldsParam("buildType", []string{"id", "name"}),
+	)
+	require.NoError(t, err)
+
+	assert.NotContains(t, path, "/teamcity/")
+	assert.NotContains(t, path, "/app/rest/2023.1/")
+	assert.Contains(t, path, "/app/rest/buildTypes")
+	assert.Contains(t, path, "count%3A10")
+	assert.Contains(t, path, "start%3A30")
 }
 
 func TestSetLocatorIntReplacesExistingValue(t *testing.T) {

--- a/api/pagination_test.go
+++ b/api/pagination_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRewriteContinuationPathOverridesCountAndFields(t *testing.T) {
+	path, err := rewriteContinuationPath(
+		"/app/rest/buildTypes?locator=affectedProject:TestProject,count:30,start:30&fields=count,href,nextHref,buildType(id,name)",
+		10,
+		paginatedFieldsParam("buildType", []string{"id", "name", "projectId"}),
+	)
+	require.NoError(t, err)
+
+	assert.Contains(t, path, "count%3A10")
+	assert.Contains(t, path, "start%3A30")
+	assert.Contains(t, path, "projectId")
+	assert.Contains(t, path, "nextHref")
+}
+
+func TestSetLocatorIntReplacesExistingValue(t *testing.T) {
+	locator := setLocatorInt("affectedProject:TestProject,count:30,start:30", "count", 5)
+	assert.Equal(t, "affectedProject:TestProject,count:5,start:30", locator)
+}
+
+func TestSetLocatorIntAppendsMissingValue(t *testing.T) {
+	locator := setLocatorInt("affectedProject:TestProject,start:30", "count", 5)
+	assert.Equal(t, "affectedProject:TestProject,start:30,count:5", locator)
+}

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -12,19 +12,29 @@ import (
 
 // GetPipelines lists pipelines, optionally filtered by project.
 func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, error) {
-	locator := NewLocator().
-		AddIntDefault("count", opts.Limit, 100)
-	if opts.Project != "" {
-		locator.AddLocator("parentProject", NewLocator().Add("id", opts.Project))
-	}
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = PipelineFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,pipeline(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/pipelines?locator=%s&fields=%s",
-		locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("pipeline", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			AddIntDefault("count", opts.Limit, 100).
+			AddInt("start", opts.Skip)
+		if opts.Project != "" {
+			locator.AddLocator("parentProject", NewLocator().Add("id", opts.Project))
+		}
+		path = fmt.Sprintf("/app/rest/pipelines?locator=%s&fields=%s",
+			locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result PipelineList
 	if err := c.get(path, &result); err != nil {

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -21,7 +21,7 @@ func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -40,6 +40,7 @@ func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, error) {
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 	return &result, nil
 }
 

--- a/api/pools.go
+++ b/api/pools.go
@@ -25,7 +25,7 @@ func (c *Client) GetAgentPools(opts AgentPoolsOptions) (*PoolList, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -40,6 +40,7 @@ func (c *Client) GetAgentPools(opts AgentPoolsOptions) (*PoolList, error) {
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 
 	return &result, nil
 }

--- a/api/pools.go
+++ b/api/pools.go
@@ -7,14 +7,34 @@ import (
 	"net/url"
 )
 
-// GetAgentPools returns all agent pools
-func (c *Client) GetAgentPools(requestedFields []string) (*PoolList, error) {
-	fields := requestedFields
+type AgentPoolsOptions struct {
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
+}
+
+// GetAgentPools returns all agent pools.
+func (c *Client) GetAgentPools(opts AgentPoolsOptions) (*PoolList, error) {
+	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = PoolFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,agentPool(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/agentPools?fields=%s", url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("agentPool", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			AddIntDefault("count", opts.Limit, 100).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/agentPools?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result PoolList
 	if err := c.get(path, &result); err != nil {

--- a/api/pools_test.go
+++ b/api/pools_test.go
@@ -21,7 +21,7 @@ func TestGetAgentPools(t *testing.T) {
 		})
 	})
 
-	result, err := client.GetAgentPools(nil)
+	result, err := client.GetAgentPools(AgentPoolsOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 2, result.Count)
 }

--- a/api/projects.go
+++ b/api/projects.go
@@ -29,7 +29,7 @@ func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -45,6 +45,7 @@ func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 
 	return &result, nil
 }

--- a/api/projects.go
+++ b/api/projects.go
@@ -11,23 +11,35 @@ import (
 
 // ProjectsOptions represents options for listing projects
 type ProjectsOptions struct {
-	Parent string
-	Limit  int
-	Fields []string
+	Parent       string
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 // GetProjects returns a list of projects
 func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
-	locator := NewLocator().
-		Add("parentProject", opts.Parent).
-		AddIntDefault("count", opts.Limit, 30)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = ProjectFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,project(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/projects?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("project", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			Add("parentProject", opts.Parent).
+			AddIntDefault("count", opts.Limit, 30).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/projects?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result ProjectList
 	if err := c.get(path, &result); err != nil {

--- a/api/types.go
+++ b/api/types.go
@@ -28,6 +28,8 @@ type Project struct {
 // ProjectList represents a list of projects
 type ProjectList struct {
 	Count    int       `json:"count"`
+	Href     string    `json:"href,omitempty"`
+	NextHref string    `json:"nextHref,omitempty"`
 	Projects []Project `json:"project"`
 }
 
@@ -46,6 +48,8 @@ type BuildType struct {
 // BuildTypeList represents a list of build configurations
 type BuildTypeList struct {
 	Count      int         `json:"count"`
+	Href       string      `json:"href,omitempty"`
+	NextHref   string      `json:"nextHref,omitempty"`
 	BuildTypes []BuildType `json:"buildType"`
 }
 
@@ -125,8 +129,10 @@ type Pool struct {
 
 // PoolList represents a list of agent pools
 type PoolList struct {
-	Count int    `json:"count"`
-	Pools []Pool `json:"agentPool"`
+	Count    int    `json:"count"`
+	Href     string `json:"href,omitempty"`
+	NextHref string `json:"nextHref,omitempty"`
+	Pools    []Pool `json:"agentPool"`
 }
 
 // Compatibility represents build type compatibility info
@@ -164,9 +170,10 @@ type QueuedBuild struct {
 
 // BuildQueue represents the build queue
 type BuildQueue struct {
-	Count  int           `json:"count"`
-	Href   string        `json:"href"`
-	Builds []QueuedBuild `json:"build"`
+	Count    int           `json:"count"`
+	Href     string        `json:"href"`
+	NextHref string        `json:"nextHref,omitempty"`
+	Builds   []QueuedBuild `json:"build"`
 }
 
 // TriggerBuildRequest represents a request to trigger a build
@@ -394,6 +401,8 @@ type CloudProfile struct {
 
 type CloudProfileList struct {
 	Count    int            `json:"count"`
+	Href     string         `json:"href,omitempty"`
+	NextHref string         `json:"nextHref,omitempty"`
 	Profiles []CloudProfile `json:"cloudProfile"`
 }
 
@@ -407,8 +416,10 @@ type CloudImage struct {
 }
 
 type CloudImageList struct {
-	Count  int          `json:"count"`
-	Images []CloudImage `json:"cloudImage"`
+	Count    int          `json:"count"`
+	Href     string       `json:"href,omitempty"`
+	NextHref string       `json:"nextHref,omitempty"`
+	Images   []CloudImage `json:"cloudImage"`
 }
 
 // CloudInstance represents a running cloud instance
@@ -424,6 +435,8 @@ type CloudInstance struct {
 
 type CloudInstanceList struct {
 	Count     int             `json:"count"`
+	Href      string          `json:"href,omitempty"`
+	NextHref  string          `json:"nextHref,omitempty"`
 	Instances []CloudInstance `json:"cloudInstance"`
 }
 
@@ -449,15 +462,19 @@ type VcsRoot struct {
 
 // VcsRootList represents a list of VCS roots
 type VcsRootList struct {
-	Count   int       `json:"count"`
-	VcsRoot []VcsRoot `json:"vcs-root"`
+	Count    int       `json:"count"`
+	Href     string    `json:"href,omitempty"`
+	NextHref string    `json:"nextHref,omitempty"`
+	VcsRoot  []VcsRoot `json:"vcs-root"`
 }
 
 // VcsRootsOptions represents options for listing VCS roots
 type VcsRootsOptions struct {
-	Project string // affectedProject locator
-	Limit   int
-	Fields  []string
+	Project      string // affectedProject locator
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 // SSHKey represents an SSH key uploaded to a TeamCity project
@@ -541,6 +558,8 @@ type PipelineJob struct {
 // PipelineList represents a list of pipelines
 type PipelineList struct {
 	Count     int        `json:"count"`
+	Href      string     `json:"href,omitempty"`
+	NextHref  string     `json:"nextHref,omitempty"`
 	Pipelines []Pipeline `json:"pipeline,omitempty"`
 }
 
@@ -564,9 +583,11 @@ type PipelineVcsRootRef struct {
 
 // PipelinesOptions represents options for listing pipelines
 type PipelinesOptions struct {
-	Project string
-	Limit   int
-	Fields  []string
+	Project      string
+	Limit        int
+	Skip         int
+	ContinuePath string
+	Fields       []string
 }
 
 // PipelineRun represents pipeline execution metadata on a build

--- a/api/vcs_roots.go
+++ b/api/vcs_roots.go
@@ -11,16 +11,26 @@ import (
 
 // GetVcsRoots returns a list of VCS roots
 func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
-	locator := NewLocator().
-		Add("affectedProject", opts.Project).
-		AddIntDefault("count", opts.Limit, 100)
-
 	fields := opts.Fields
 	if len(fields) == 0 {
 		fields = VcsRootFields.Default
 	}
-	fieldsParam := fmt.Sprintf("count,vcs-root(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/vcs-roots?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	fieldsParam := paginatedFieldsParam("vcs-root", fields)
+
+	path := opts.ContinuePath
+	if path != "" {
+		var err error
+		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		locator := NewLocator().
+			Add("affectedProject", opts.Project).
+			AddIntDefault("count", opts.Limit, 100).
+			AddInt("start", opts.Skip)
+		path = fmt.Sprintf("/app/rest/vcs-roots?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
+	}
 
 	var result VcsRootList
 	if err := c.get(path, &result); err != nil {

--- a/api/vcs_roots.go
+++ b/api/vcs_roots.go
@@ -20,7 +20,7 @@ func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
 	path := opts.ContinuePath
 	if path != "" {
 		var err error
-		path, err = rewriteContinuationPath(path, opts.Limit, fieldsParam)
+		path, err = c.rewriteContinuationPath(path, opts.Limit, fieldsParam)
 		if err != nil {
 			return nil, err
 		}
@@ -36,6 +36,7 @@ func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
 	if err := c.get(path, &result); err != nil {
 		return nil, err
 	}
+	c.normalizePageHrefs(&result.Href, &result.NextHref)
 	return &result, nil
 }
 

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -52,6 +52,8 @@ func newAgentListCmd(f *cmdutil.Factory) *cobra.Command {
 		Example: `  teamcity agent list
   teamcity agent list --pool Default
   teamcity agent list --connected
+  teamcity agent list --limit 50 --skip 50
+  teamcity agent list --continue <token>
   teamcity agent list --json
   teamcity agent list --json=id,name,connected,enabled
   teamcity agent list --plain
@@ -65,19 +67,22 @@ func newAgentListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.connected, "connected", false, "Show only connected agents")
 	cmd.Flags().BoolVar(&opts.enabled, "enabled", false, "Show only enabled agents")
 	cmd.Flags().BoolVar(&opts.authorized, "authorized", false, "Show only authorized agents")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.SetContinueConflicts(cmd, "pool", "connected", "enabled", "authorized")
 
 	return cmd
 }
 
 func (opts *agentListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	agents, err := client.GetAgents(api.AgentsOptions{
-		Pool:       opts.pool,
-		Connected:  opts.connected,
-		Enabled:    opts.enabled,
-		Authorized: opts.authorized,
-		Limit:      opts.Limit,
-		Fields:     fields,
+		Pool:         opts.pool,
+		Connected:    opts.connected,
+		Enabled:      opts.enabled,
+		Authorized:   opts.authorized,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -102,9 +107,10 @@ func (opts *agentListOptions) fetch(client api.ClientInterface, fields []string)
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     agents,
+		JSON:     agents.Agents,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1, 2}},
 		EmptyMsg: "No agents found",
+		Page:     &cmdutil.ListPageInfo{Count: len(agents.Agents), ContinuePath: agents.NextHref},
 	}, nil
 }
 

--- a/internal/cmd/agent/agent_test.go
+++ b/internal/cmd/agent/agent_test.go
@@ -1,12 +1,17 @@
 package agent_test
 
 import (
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 )
 
 func init() { color.NoColor = true }
@@ -31,6 +36,30 @@ func TestAgentList_plain(t *testing.T) {
 		"1 \tAgent 1\tDefault\tConnected   \n" +
 		"2 \tAgent 2\tDefault\tDisconnected\n"
 	assert.Equal(t, want, got)
+}
+
+func TestAgentListPlainPrintsContinuationTokenToStderr(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/agents", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.AgentList{
+			Count:    2,
+			Href:     "/app/rest/agents?locator=count:2,start:0",
+			NextHref: "/app/rest/agents?locator=count:2,start:2",
+			Agents: []api.Agent{
+				{ID: 1, Name: "Agent 1", Connected: true, Enabled: true, Authorized: true, Pool: &api.Pool{Name: "Default"}},
+				{ID: 2, Name: "Agent 2", Connected: false, Enabled: true, Authorized: true, Pool: &api.Pool{Name: "Default"}},
+			},
+		})
+	})
+
+	_, stderr := cmdtest.CaptureSplitOutput(t, ts.Factory, "agent", "list", "--plain", "--limit", "2")
+	require.Contains(t, stderr, "Continue: ")
+
+	token := strings.TrimSpace(strings.TrimPrefix(stderr, "Continue: "))
+	path, offset, err := cmdutil.DecodeContinueToken("teamcity agent list", token)
+	require.NoError(t, err)
+	assert.Equal(t, "/app/rest/agents?locator=count:2,start:2", path)
+	assert.Zero(t, offset)
 }
 
 func TestAgentView(T *testing.T) {

--- a/internal/cmd/job/job_test.go
+++ b/internal/cmd/job/job_test.go
@@ -1,11 +1,16 @@
 package job_test
 
 import (
+	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testJob = "TestProject_Build"
@@ -25,6 +30,60 @@ func TestJobView(T *testing.T) {
 
 	cmdtest.RunCmdWithFactory(T, f, "job", "view", testJob)
 	cmdtest.RunCmdWithFactory(T, f, "job", "view", testJob, "--json")
+}
+
+func TestJobListContinuePreservesAllMode(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/buildTypes", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.RawQuery, "start%3A1") {
+			cmdtest.JSON(w, api.BuildTypeList{
+				Count: 1,
+				Href:  "/app/rest/buildTypes?locator=count:30,start:1",
+				BuildTypes: []api.BuildType{
+					{ID: "TestProject_CI_Build", Name: "Pipeline Build", ProjectID: "TestProject"},
+				},
+			})
+			return
+		}
+
+		cmdtest.JSON(w, api.BuildTypeList{
+			Count:    1,
+			Href:     "/app/rest/buildTypes?locator=count:1,start:0",
+			NextHref: "/app/rest/buildTypes?locator=count:1,start:1",
+			BuildTypes: []api.BuildType{
+				{ID: "Library_Build", Name: "Library Build", ProjectID: "Library"},
+			},
+		})
+	})
+
+	stdout := cmdtest.CaptureOutput(t, ts.Factory, "job", "list", "--all", "--json", "--limit", "1")
+
+	var firstPage struct {
+		Count    int             `json:"count"`
+		Items    []api.BuildType `json:"items"`
+		Continue string          `json:"continue"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &firstPage))
+	require.Len(t, firstPage.Items, 1)
+	assert.Equal(t, "Library_Build", firstPage.Items[0].ID)
+
+	path, offset, state, err := cmdutil.DecodeContinueTokenWithState("teamcity job list", firstPage.Continue)
+	require.NoError(t, err)
+	assert.Equal(t, "/app/rest/buildTypes?locator=count:1,start:1", path)
+	assert.Zero(t, offset)
+	assert.JSONEq(t, `{"all":true}`, string(state))
+
+	stdout = cmdtest.CaptureOutput(t, ts.Factory, "job", "list", "--continue", firstPage.Continue, "--json")
+
+	var secondPage struct {
+		Count    int             `json:"count"`
+		Items    []api.BuildType `json:"items"`
+		Continue string          `json:"continue"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &secondPage))
+	require.Len(t, secondPage.Items, 1)
+	assert.Equal(t, "TestProject_CI_Build", secondPage.Items[0].ID)
+	assert.Empty(t, secondPage.Continue)
 }
 
 func TestJobPauseResume(T *testing.T) {

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -26,6 +26,8 @@ func newJobListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Example: `  teamcity job list
   teamcity job list --project Falcon
+  teamcity job list --limit 30 --skip 30
+  teamcity job list --continue <token>
   teamcity job list --json
   teamcity job list --json=id,name,webUrl
   teamcity job list --plain
@@ -37,7 +39,8 @@ func newJobListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "Include pipelines")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 30)
+	cmdutil.SetContinueConflicts(cmd, "project", "all")
 
 	return cmd
 }
@@ -62,34 +65,20 @@ func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (
 		fetchFields = append(slices.Clone(fields), "projectId")
 	}
 
-	jobs, err := client.GetBuildTypes(api.BuildTypesOptions{
-		Project: opts.project,
-		Limit:   limit,
-		Fields:  fetchFields,
-	})
+	jobs, pageInfo, err := opts.fetchJobsPage(client, fetchFields, pipelineProjectIDs, limit)
 	if err != nil {
 		return nil, err
 	}
-
-	if len(pipelineProjectIDs) > 0 {
-		filtered := jobs.BuildTypes[:0]
-		for _, j := range jobs.BuildTypes {
-			if !isPipelineOwned(j.ProjectID, pipelineProjectIDs) {
-				filtered = append(filtered, j)
-			}
+	if len(pipelineProjectIDs) > 0 && len(fields) > 0 && !slices.Contains(fields, "projectId") {
+		for i := range jobs {
+			jobs[i].ProjectID = ""
 		}
-		jobs.BuildTypes = filtered
-		jobs.Count = len(filtered)
-	}
-	if len(jobs.BuildTypes) > opts.Limit {
-		jobs.BuildTypes = jobs.BuildTypes[:opts.Limit]
-		jobs.Count = opts.Limit
 	}
 
 	headers := []string{"ID", "NAME", "PROJECT", "STATUS"}
 	var rows [][]string
 
-	for _, j := range jobs.BuildTypes {
+	for _, j := range jobs {
 		status := output.Green("Active")
 		if j.Paused {
 			status = output.Faint("Paused")
@@ -107,7 +96,118 @@ func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (
 		JSON:     jobs,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
 		EmptyMsg: "No jobs found",
+		Page:     pageInfo,
 	}, nil
+}
+
+func (opts *jobListOptions) fetchJobsPage(
+	client api.ClientInterface,
+	fields []string,
+	pipelineProjectIDs map[string]bool,
+	limit int,
+) ([]api.BuildType, *cmdutil.ListPageInfo, error) {
+	if len(pipelineProjectIDs) == 0 {
+		page, err := client.GetBuildTypes(api.BuildTypesOptions{
+			Project:      opts.project,
+			Limit:        opts.Limit,
+			Skip:         opts.Skip,
+			ContinuePath: opts.ContinuePath,
+			Fields:       fields,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return page.BuildTypes, &cmdutil.ListPageInfo{
+			Count:        len(page.BuildTypes),
+			ContinuePath: page.NextHref,
+		}, nil
+	}
+
+	collected := make([]api.BuildType, 0, opts.Limit)
+	skipRemaining := opts.Skip
+	offsetRemaining := opts.ContinueOffset
+	continuePath := opts.ContinuePath
+	continueOffset := 0
+
+	for {
+		page, err := client.GetBuildTypes(api.BuildTypesOptions{
+			Project:      opts.project,
+			Limit:        limit,
+			ContinuePath: continuePath,
+			Fields:       fields,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+
+		pagePath := page.Href
+		if pagePath == "" {
+			pagePath = continuePath
+		}
+
+		filtered := filterPipelineJobs(page.BuildTypes, pipelineProjectIDs)
+		if offsetRemaining > 0 {
+			if offsetRemaining >= len(filtered) {
+				offsetRemaining -= len(filtered)
+				if page.NextHref == "" {
+					return collected, &cmdutil.ListPageInfo{Count: len(collected)}, nil
+				}
+				continuePath = page.NextHref
+				continue
+			}
+			filtered = filtered[offsetRemaining:]
+			offsetRemaining = 0
+		}
+		if skipRemaining > 0 {
+			if skipRemaining >= len(filtered) {
+				skipRemaining -= len(filtered)
+				if page.NextHref == "" {
+					return collected, &cmdutil.ListPageInfo{Count: len(collected)}, nil
+				}
+				continuePath = page.NextHref
+				continue
+			}
+			filtered = filtered[skipRemaining:]
+			skipRemaining = 0
+		}
+
+		remaining := opts.Limit - len(collected)
+		if remaining <= 0 {
+			break
+		}
+		if len(filtered) > remaining {
+			collected = append(collected, filtered[:remaining]...)
+			consumed := len(filterPipelineJobs(page.BuildTypes, pipelineProjectIDs)) - len(filtered) + remaining
+			continuePath = pagePath
+			continueOffset = consumed
+			break
+		}
+
+		collected = append(collected, filtered...)
+		if page.NextHref == "" {
+			continuePath = ""
+			continueOffset = 0
+			break
+		}
+		continuePath = page.NextHref
+		continueOffset = 0
+	}
+
+	return collected, &cmdutil.ListPageInfo{
+		Count:          len(collected),
+		ContinuePath:   continuePath,
+		ContinueOffset: continueOffset,
+	}, nil
+}
+
+func filterPipelineJobs(jobs []api.BuildType, pipelineProjectIDs map[string]bool) []api.BuildType {
+	filtered := make([]api.BuildType, 0, len(jobs))
+	for _, j := range jobs {
+		if !isPipelineOwned(j.ProjectID, pipelineProjectIDs) {
+			filtered = append(filtered, j)
+		}
+	}
+	return filtered
 }
 
 func newJobViewCmd(f *cmdutil.Factory) *cobra.Command {

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -1,6 +1,8 @@
 package job
 
 import (
+	"encoding/json"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -15,6 +17,10 @@ type jobListOptions struct {
 	project string
 	all     bool
 	cmdutil.ListFlags
+}
+
+type jobListContinueState struct {
+	All bool `json:"all,omitzero"`
 }
 
 func newJobListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -46,6 +52,10 @@ func newJobListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
+	if err := opts.applyContinueState(); err != nil {
+		return nil, err
+	}
+
 	pipelineProjectIDs := map[string]bool{}
 	if !opts.all && client.SupportsFeature("pipelines") {
 		if pipelines, err := client.GetPipelines(api.PipelinesOptions{Limit: 10000}); err == nil {
@@ -118,8 +128,9 @@ func (opts *jobListOptions) fetchJobsPage(
 			return nil, nil, err
 		}
 		return page.BuildTypes, &cmdutil.ListPageInfo{
-			Count:        len(page.BuildTypes),
-			ContinuePath: page.NextHref,
+			Count:         len(page.BuildTypes),
+			ContinuePath:  page.NextHref,
+			ContinueState: opts.continueState(),
 		}, nil
 	}
 
@@ -197,7 +208,29 @@ func (opts *jobListOptions) fetchJobsPage(
 		Count:          len(collected),
 		ContinuePath:   continuePath,
 		ContinueOffset: continueOffset,
+		ContinueState:  opts.continueState(),
 	}, nil
+}
+
+func (opts *jobListOptions) continueState() any {
+	if !opts.all {
+		return nil
+	}
+	return jobListContinueState{All: true}
+}
+
+func (opts *jobListOptions) applyContinueState() error {
+	if len(opts.ContinueState) == 0 {
+		return nil
+	}
+
+	var state jobListContinueState
+	if err := json.Unmarshal(opts.ContinueState, &state); err != nil {
+		return fmt.Errorf("invalid continuation token")
+	}
+
+	opts.all = state.All
+	return nil
 }
 
 func filterPipelineJobs(jobs []api.BuildType, pipelineProjectIDs map[string]bool) []api.BuildType {

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -22,6 +22,8 @@ func newPipelineListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Example: `  teamcity pipeline list
   teamcity pipeline list --project MyProject
+  teamcity pipeline list --limit 30 --skip 30
+  teamcity pipeline list --continue <token>
   teamcity pipeline list --json
   teamcity pipeline list --json=id,name
   teamcity pipeline list --plain`,
@@ -31,16 +33,19 @@ func newPipelineListCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 30)
+	cmdutil.SetContinueConflicts(cmd, "project")
 
 	return cmd
 }
 
 func (opts *pipelineListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	pipelines, err := client.GetPipelines(api.PipelinesOptions{
-		Project: opts.project,
-		Limit:   opts.Limit,
-		Fields:  fields,
+		Project:      opts.project,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -68,8 +73,9 @@ func (opts *pipelineListOptions) fetch(client api.ClientInterface, fields []stri
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     pipelines,
+		JSON:     pipelines.Pipelines,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
 		EmptyMsg: "No pipelines found",
+		Page:     &cmdutil.ListPageInfo{Count: len(pipelines.Pipelines), ContinuePath: pipelines.NextHref},
 	}, nil
 }

--- a/internal/cmd/pool/list.go
+++ b/internal/cmd/pool/list.go
@@ -19,22 +19,30 @@ func newPoolListCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:   "List agent pools",
 		Aliases: []string{"ls"},
 		Example: `  teamcity pool list
+  teamcity pool list --limit 20 --skip 20
+  teamcity pool list --continue <token>
   teamcity pool list --json
   teamcity pool list --json=id,name,maxAgents
   teamcity pool list --plain`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return cmdutil.RunList(f, cmd, flags, &api.PoolFields, fetchPools)
+			return cmdutil.RunList(f, cmd, flags, &api.PoolFields, func(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
+				return fetchPools(client, flags, fields)
+			})
 		},
 	}
 
-	cmdutil.AddJSONFieldsFlag(cmd, &flags.JSONFields)
-	cmdutil.AddPlainFlags(cmd, flags)
+	cmdutil.AddPaginatedListFlags(cmd, flags, 100)
 
 	return cmd
 }
 
-func fetchPools(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	pools, err := client.GetAgentPools(fields)
+func fetchPools(client api.ClientInterface, flags *cmdutil.ListFlags, fields []string) (*cmdutil.ListResult, error) {
+	pools, err := client.GetAgentPools(api.AgentPoolsOptions{
+		Limit:        flags.Limit,
+		Skip:         flags.Skip,
+		ContinuePath: flags.ContinuePath,
+		Fields:       fields,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -56,9 +64,10 @@ func fetchPools(client api.ClientInterface, fields []string) (*cmdutil.ListResul
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     pools,
+		JSON:     pools.Pools,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows},
 		EmptyMsg: "No agent pools found",
+		Page:     &cmdutil.ListPageInfo{Count: len(pools.Pools), ContinuePath: pools.NextHref},
 	}, nil
 }
 

--- a/internal/cmd/project/cloud.go
+++ b/internal/cmd/project/cloud.go
@@ -55,6 +55,8 @@ func newCloudProfileListCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Example: `  teamcity project cloud profile list
   teamcity project cloud profile list --project MyProject
+  teamcity project cloud profile list --limit 50 --skip 50
+  teamcity project cloud profile list --continue <token>
   teamcity project cloud profile list --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.CloudProfileFields, opts.fetch)
@@ -62,16 +64,19 @@ func newCloudProfileListCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.SetContinueConflicts(cmd, "project")
 
 	return cmd
 }
 
 func (opts *cloudProfileListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	profiles, err := client.GetCloudProfiles(api.CloudProfilesOptions{
-		ProjectID: opts.project,
-		Limit:     opts.Limit,
-		Fields:    fields,
+		ProjectID:    opts.project,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -89,9 +94,10 @@ func (opts *cloudProfileListOptions) fetch(client api.ClientInterface, fields []
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     profiles,
+		JSON:     profiles.Profiles,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1}},
 		EmptyMsg: "No cloud profiles found",
+		Page:     &cmdutil.ListPageInfo{Count: len(profiles.Profiles), ContinuePath: profiles.NextHref},
 	}, nil
 }
 
@@ -178,6 +184,8 @@ func newCloudImageListCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Example: `  teamcity project cloud image list
   teamcity project cloud image list --project MyProject --profile aws-prod
+  teamcity project cloud image list --limit 50 --skip 50
+  teamcity project cloud image list --continue <token>
   teamcity project cloud image list --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.CloudImageFields, opts.fetch)
@@ -186,17 +194,20 @@ func newCloudImageListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().StringVar(&opts.profile, "profile", "", "Filter by cloud profile")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.SetContinueConflicts(cmd, "project", "profile")
 
 	return cmd
 }
 
 func (opts *cloudImageListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	images, err := client.GetCloudImages(api.CloudImagesOptions{
-		ProjectID: opts.project,
-		Profile:   opts.profile,
-		Limit:     opts.Limit,
-		Fields:    fields,
+		ProjectID:    opts.project,
+		Profile:      opts.profile,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -219,9 +230,10 @@ func (opts *cloudImageListOptions) fetch(client api.ClientInterface, fields []st
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     images,
+		JSON:     images.Images,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2}},
 		EmptyMsg: "No cloud images found",
+		Page:     &cmdutil.ListPageInfo{Count: len(images.Images), ContinuePath: images.NextHref},
 	}, nil
 }
 
@@ -352,6 +364,8 @@ func newCloudInstanceListCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:    cobra.NoArgs,
 		Example: `  teamcity project cloud instance list
   teamcity project cloud instance list --project MyProject --image ubuntu-22-large
+  teamcity project cloud instance list --limit 50 --skip 50
+  teamcity project cloud instance list --continue <token>
   teamcity project cloud instance list --json`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.CloudInstanceFields, opts.fetch)
@@ -360,17 +374,20 @@ func newCloudInstanceListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().StringVar(&opts.image, "image", "", "Filter by cloud image")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.SetContinueConflicts(cmd, "project", "image")
 
 	return cmd
 }
 
 func (opts *cloudInstanceListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	instances, err := client.GetCloudInstances(api.CloudInstancesOptions{
-		ProjectID: opts.project,
-		Image:     opts.image,
-		Limit:     opts.Limit,
-		Fields:    fields,
+		ProjectID:    opts.project,
+		Image:        opts.image,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -406,9 +423,10 @@ func (opts *cloudInstanceListOptions) fetch(client api.ClientInterface, fields [
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     instances,
+		JSON:     instances.Instances,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2, 3, 5}},
 		EmptyMsg: "No cloud instances found",
+		Page:     &cmdutil.ListPageInfo{Count: len(instances.Instances), ContinuePath: instances.NextHref},
 	}, nil
 }
 

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -55,6 +55,8 @@ func newProjectListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Example: `  teamcity project list
   teamcity project list --parent Falcon
+  teamcity project list --limit 50 --skip 50
+  teamcity project list --continue <token>
   teamcity project list --json
   teamcity project list --json=id,name,webUrl
   teamcity project list --plain
@@ -65,16 +67,19 @@ func newProjectListCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.parent, "parent", "p", "", "Filter by parent project ID")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.SetContinueConflicts(cmd, "parent")
 
 	return cmd
 }
 
 func (opts *projectListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	projects, err := client.GetProjects(api.ProjectsOptions{
-		Parent: opts.parent,
-		Limit:  opts.Limit,
-		Fields: fields,
+		Parent:       opts.parent,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -97,9 +102,10 @@ func (opts *projectListOptions) fetch(client api.ClientInterface, fields []strin
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     projects,
+		JSON:     projects.Projects,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
 		EmptyMsg: "No projects found",
+		Page:     &cmdutil.ListPageInfo{Count: len(projects.Projects), ContinuePath: projects.NextHref},
 	}, nil
 }
 

--- a/internal/cmd/project/project_test.go
+++ b/internal/cmd/project/project_test.go
@@ -2,12 +2,15 @@ package project_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,6 +23,37 @@ func TestProjectList(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, f, "project", "list", "--limit", "5")
 	cmdtest.RunCmdWithFactory(T, f, "project", "list", "--parent", "_Root", "--limit", "3")
 	cmdtest.RunCmdWithFactory(T, f, "project", "list", "--json", "--limit", "2")
+}
+
+func TestProjectListJSONPaginationEnvelope(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/projects", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.ProjectList{
+			Count:    2,
+			Href:     "/app/rest/projects?locator=count:2,start:0",
+			NextHref: "/app/rest/projects?locator=count:2,start:2",
+			Projects: []api.Project{
+				{ID: "_Root", Name: "Root"},
+				{ID: "TestProject", Name: "Test Project", ParentProjectID: "_Root"},
+			},
+		})
+	})
+
+	stdout, _ := cmdtest.CaptureSplitOutput(t, ts.Factory, "project", "list", "--json", "--limit", "2")
+
+	var result struct {
+		Count    int           `json:"count"`
+		Items    []api.Project `json:"items"`
+		Continue string        `json:"continue"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, 2, result.Count)
+	assert.Len(t, result.Items, 2)
+
+	path, offset, err := cmdutil.DecodeContinueToken("teamcity project list", result.Continue)
+	require.NoError(t, err)
+	assert.Equal(t, "/app/rest/projects?locator=count:2,start:2", path)
+	assert.Zero(t, offset)
 }
 
 func TestProjectView(T *testing.T) {

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -51,6 +51,8 @@ func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Example: `  teamcity project vcs list
   teamcity project vcs list --project MyProject
+  teamcity project vcs list --limit 50 --skip 50
+  teamcity project vcs list --continue <token>
   teamcity project vcs list --project MyProject --json
   teamcity project vcs list --plain`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -59,7 +61,8 @@ func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.SetContinueConflicts(cmd, "project")
 
 	return cmd
 }
@@ -67,9 +70,11 @@ func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
 func (opts *vcsListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	project := cmp.Or(opts.project, "_Root")
 	roots, err := client.GetVcsRoots(api.VcsRootsOptions{
-		Project: project,
-		Limit:   opts.Limit,
-		Fields:  fields,
+		Project:      project,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -93,9 +98,10 @@ func (opts *vcsListOptions) fetch(client api.ClientInterface, fields []string) (
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     roots,
+		JSON:     roots.VcsRoot,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2, 3}},
 		EmptyMsg: "No VCS roots found",
+		Page:     &cmdutil.ListPageInfo{Count: len(roots.VcsRoot), ContinuePath: roots.NextHref},
 	}, nil
 }
 

--- a/internal/cmd/queue/list.go
+++ b/internal/cmd/queue/list.go
@@ -23,6 +23,8 @@ func newQueueListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Example: `  teamcity queue list
   teamcity queue list --job Falcon_Build
+  teamcity queue list --limit 20 --skip 20
+  teamcity queue list --continue <token>
   teamcity queue list --json
   teamcity queue list --json=id,state,webUrl
   teamcity queue list --plain
@@ -33,16 +35,19 @@ func newQueueListCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Filter by job ID")
-	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
+	cmdutil.AddPaginatedListFlags(cmd, &opts.ListFlags, 30)
+	cmdutil.SetContinueConflicts(cmd, "job")
 
 	return cmd
 }
 
 func (opts *queueListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	queue, err := client.GetBuildQueue(api.QueueOptions{
-		BuildTypeID: opts.job,
-		Limit:       opts.Limit,
-		Fields:      fields,
+		BuildTypeID:  opts.job,
+		Limit:        opts.Limit,
+		Skip:         opts.Skip,
+		ContinuePath: opts.ContinuePath,
+		Fields:       fields,
 	})
 	if err != nil {
 		return nil, err
@@ -72,8 +77,9 @@ func (opts *queueListOptions) fetch(client api.ClientInterface, fields []string)
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     queue,
+		JSON:     queue.Builds,
 		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1, 2, 4}},
 		EmptyMsg: "No runs in queue",
+		Page:     &cmdutil.ListPageInfo{Count: len(queue.Builds), ContinuePath: queue.NextHref},
 	}, nil
 }

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 )
 
@@ -41,6 +42,40 @@ func TestRunListBackwardsDateRange(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 
 	cmdtest.RunCmdWithFactoryExpectErr(T, ts.Factory, "is more recent than", "run", "list", "--since", "2020-01-01", "--until", "2019-01-01")
+}
+
+func TestRunListJSONPaginationEnvelope(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/builds", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.BuildList{
+			Count:    1,
+			Href:     "/app/rest/builds?locator=count:1,start:0",
+			NextHref: "/app/rest/builds?locator=count:1,start:1",
+			Builds: []api.Build{{
+				ID:          1,
+				Number:      "1",
+				Status:      "SUCCESS",
+				State:       "finished",
+				BuildTypeID: "TestProject_Build",
+			}},
+		})
+	})
+
+	stdout := cmdtest.CaptureOutput(t, ts.Factory, "run", "list", "--json", "--limit", "1")
+
+	var result struct {
+		Count    int         `json:"count"`
+		Items    []api.Build `json:"items"`
+		Continue string      `json:"continue"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	assert.Equal(t, 1, result.Count)
+	assert.Len(t, result.Items, 1)
+
+	path, offset, err := cmdutil.DecodeContinueToken("teamcity run list", result.Continue)
+	require.NoError(t, err)
+	assert.Equal(t, "/app/rest/builds?locator=count:1,start:1", path)
+	assert.Zero(t, offset)
 }
 
 func TestRunView(T *testing.T) {

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -21,20 +21,29 @@ var runListCurrentBranchFn = getCurrentBranch
 var runListHeadRevisionFn = getHeadRevision // used in tests
 
 type runListOptions struct {
-	job        string
-	branch     string
-	status     string
-	user       string
-	revision   string
-	favorites  bool
-	project    string
-	limit      int
-	since      string
-	until      string
-	jsonFields string
-	plain      bool
-	noHeader   bool
-	web        bool
+	job           string
+	branch        string
+	status        string
+	user          string
+	revision      string
+	favorites     bool
+	project       string
+	limit         int
+	skip          int
+	since         string
+	until         string
+	continueToken string
+	continuePath  string
+	jsonFields    string
+	plain         bool
+	noHeader      bool
+	web           bool
+}
+
+type runListJSON struct {
+	Count    int         `json:"count"`
+	Items    []api.Build `json:"items"`
+	Continue string      `json:"continue,omitzero"`
 }
 
 func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -54,6 +63,8 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run list --revision abc1234
   teamcity run list --revision @head --job Falcon_Build
   teamcity run list --since 24h
+  teamcity run list --limit 50 --skip 50
+  teamcity run list --continue <token> --json
   teamcity run list --json
   teamcity run list --json=id,status,webUrl
   teamcity run list --plain | grep failure`,
@@ -70,6 +81,8 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.favorites, "favorites", false, "Show favorites for the current user")
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number of items")
+	cmd.Flags().IntVar(&opts.skip, "skip", 0, "Skip the first N items")
+	cmd.Flags().StringVar(&opts.continueToken, "continue", "", "Continue from a previous page token")
 	cmd.Flags().StringVar(&opts.since, "since", "", "Finished after this time (e.g., 24h, 2026-01-21)")
 	cmd.Flags().StringVar(&opts.until, "until", "", "Finished before this time (e.g., 12h, 2026-01-22)")
 	cmdutil.AddJSONFieldsFlag(cmd, &opts.jsonFields)
@@ -78,13 +91,29 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "plain")
+	cmd.MarkFlagsMutuallyExclusive("skip", "continue")
+	cmd.MarkFlagsMutuallyExclusive("skip", "web")
+	cmdutil.SetContinueConflicts(cmd, "job", "branch", "status", "user", "revision", "favorites", "project", "since", "until", "web")
 
 	return cmd
 }
 
 func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) error {
+	if err := cmdutil.ValidateContinueConflicts(cmd); err != nil {
+		return err
+	}
 	if err := cmdutil.ValidateLimit(opts.limit); err != nil {
 		return err
+	}
+	if err := cmdutil.ValidateSkip(opts.skip); err != nil {
+		return err
+	}
+	if opts.continueToken != "" {
+		continuePath, _, err := cmdutil.DecodeContinueToken(cmd.CommandPath(), opts.continueToken)
+		if err != nil {
+			return err
+		}
+		opts.continuePath = continuePath
 	}
 	jsonResult, showHelp, err := cmdutil.ParseJSONFields(cmd, opts.jsonFields, &api.BuildFields, f.Printer.Out)
 	if err != nil {
@@ -114,8 +143,20 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 		return err
 	}
 
+	continueToken := ""
+	if runs.NextHref != "" {
+		continueToken, err = cmdutil.EncodeContinueToken(cmd.CommandPath(), runs.NextHref, 0)
+		if err != nil {
+			return err
+		}
+	}
+
 	if jsonResult.Enabled {
-		return f.Printer.PrintJSON(runs)
+		return f.Printer.PrintJSON(runListJSON{
+			Count:    len(runs.Builds),
+			Items:    runs.Builds,
+			Continue: continueToken,
+		})
 	}
 
 	if runs.Count == 0 {
@@ -189,6 +230,9 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 		output.AutoSizeColumns(headers, rows, 2, 2, 3, 4)
 		p.PrintTable(headers, rows)
 	}
+	if continueToken != "" {
+		_, _ = fmt.Fprintf(p.ErrOut, "Continue: %s\n", continueToken)
+	}
 	return nil
 }
 
@@ -226,18 +270,20 @@ func resolveRunListRequest(client api.ClientInterface, opts *runListOptions, fie
 
 	return &runListRequest{
 		builds: api.BuildsOptions{
-			BuildTypeID: opts.job,
-			Branch:      branch,
-			Status:      statusFilter,
-			State:       stateFilter,
-			User:        user,
-			Project:     opts.project,
-			Revision:    revision,
-			Favorites:   opts.favorites,
-			Limit:       opts.limit,
-			SinceDate:   sinceDate,
-			UntilDate:   untilDate,
-			Fields:      fields,
+			BuildTypeID:  opts.job,
+			Branch:       branch,
+			Status:       statusFilter,
+			State:        stateFilter,
+			User:         user,
+			Project:      opts.project,
+			Revision:     revision,
+			Favorites:    opts.favorites,
+			Limit:        opts.limit,
+			Skip:         opts.skip,
+			SinceDate:    sinceDate,
+			UntilDate:    untilDate,
+			ContinuePath: opts.continuePath,
+			Fields:       fields,
 		},
 		webPath:  resolveRunListWebPath(opts),
 		emptyMsg: resolveRunListEmptyMessage(opts),

--- a/internal/cmdtest/testutil.go
+++ b/internal/cmdtest/testutil.go
@@ -173,6 +173,22 @@ func CaptureOutput(t *testing.T, f *cmdutil.Factory, args ...string) string {
 	return buf.String()
 }
 
+// CaptureSplitOutput executes a CLI command and returns stdout and stderr separately.
+func CaptureSplitOutput(t *testing.T, f *cmdutil.Factory, args ...string) (string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	f.Printer = &output.Printer{Out: &stdout, ErrOut: &stderr}
+
+	rootCmd := cmd.NewRootCmdWithFactory(f)
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+
+	err := rootCmd.Execute()
+	require.NoError(t, err, "Execute(%v)", args)
+	return stdout.String(), stderr.String()
+}
+
 // CaptureErr executes a CLI command, asserts it errors, and returns the error.
 func CaptureErr(t *testing.T, f *cmdutil.Factory, args ...string) error {
 	t.Helper()

--- a/internal/cmdutil/helpers.go
+++ b/internal/cmdutil/helpers.go
@@ -31,6 +31,14 @@ func ValidateLimit(limit int) error {
 	return nil
 }
 
+// ValidateSkip returns an error if skip is negative.
+func ValidateSkip(skip int) error {
+	if skip < 0 {
+		return fmt.Errorf("--skip must be zero or a positive number, got %d", skip)
+	}
+	return nil
+}
+
 // ParseID converts a string argument to an integer ID.
 func ParseID(s string, entity string) (int, error) {
 	id, err := strconv.Atoi(s)

--- a/internal/cmdutil/helpers_test.go
+++ b/internal/cmdutil/helpers_test.go
@@ -17,6 +17,13 @@ func TestValidateLimit(t *testing.T) {
 	assert.Contains(t, ValidateLimit(-5).Error(), "--limit must be a positive number")
 }
 
+func TestValidateSkip(t *testing.T) {
+	assert.NoError(t, ValidateSkip(0))
+	assert.NoError(t, ValidateSkip(25))
+	assert.Error(t, ValidateSkip(-1))
+	assert.Contains(t, ValidateSkip(-5).Error(), "--skip must be zero or a positive number")
+}
+
 func TestParseID(t *testing.T) {
 	id, err := ParseID("42", "build")
 	require.NoError(t, err)

--- a/internal/cmdutil/list.go
+++ b/internal/cmdutil/list.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -15,6 +16,7 @@ type ListFlags struct {
 	ContinueToken  string
 	ContinuePath   string
 	ContinueOffset int
+	ContinueState  json.RawMessage
 	JSONFields     string
 	Plain          bool
 	NoHeader       bool
@@ -88,12 +90,13 @@ func RunList(
 		}
 	}
 	if cmd.Flags().Lookup("continue") != nil && flags.ContinueToken != "" {
-		continuePath, continueOffset, err := DecodeContinueToken(cmd.CommandPath(), flags.ContinueToken)
+		continuePath, continueOffset, continueState, err := DecodeContinueTokenWithState(cmd.CommandPath(), flags.ContinueToken)
 		if err != nil {
 			return err
 		}
 		flags.ContinuePath = continuePath
 		flags.ContinueOffset = continueOffset
+		flags.ContinueState = continueState
 	}
 
 	jsonResult, showHelp, err := ParseJSONFields(cmd, flags.JSONFields, fieldSpec, f.Printer.Out)
@@ -116,7 +119,12 @@ func RunList(
 
 	continueToken := ""
 	if result.Page != nil && result.Page.ContinuePath != "" {
-		continueToken, err = EncodeContinueToken(cmd.CommandPath(), result.Page.ContinuePath, result.Page.ContinueOffset)
+		continueToken, err = EncodeContinueTokenWithState(
+			cmd.CommandPath(),
+			result.Page.ContinuePath,
+			result.Page.ContinueOffset,
+			result.Page.ContinueState,
+		)
 		if err != nil {
 			return err
 		}

--- a/internal/cmdutil/list.go
+++ b/internal/cmdutil/list.go
@@ -1,6 +1,8 @@
 package cmdutil
 
 import (
+	"fmt"
+
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -8,10 +10,14 @@ import (
 
 // ListFlags holds the common flags shared by all list commands.
 type ListFlags struct {
-	Limit      int
-	JSONFields string
-	Plain      bool
-	NoHeader   bool
+	Limit          int
+	Skip           int
+	ContinueToken  string
+	ContinuePath   string
+	ContinueOffset int
+	JSONFields     string
+	Plain          bool
+	NoHeader       bool
 }
 
 // AddListFlags registers --limit, --json, --plain, and --no-header flags on a command.
@@ -19,6 +25,14 @@ func AddListFlags(cmd *cobra.Command, flags *ListFlags, defaultLimit int) {
 	cmd.Flags().IntVarP(&flags.Limit, "limit", "n", defaultLimit, "Maximum number of items")
 	AddJSONFieldsFlag(cmd, &flags.JSONFields)
 	AddPlainFlags(cmd, flags)
+}
+
+// AddPaginatedListFlags registers list flags plus --skip and --continue pagination flags.
+func AddPaginatedListFlags(cmd *cobra.Command, flags *ListFlags, defaultLimit int) {
+	AddListFlags(cmd, flags, defaultLimit)
+	cmd.Flags().IntVar(&flags.Skip, "skip", 0, "Skip the first N items")
+	cmd.Flags().StringVar(&flags.ContinueToken, "continue", "", "Continue from a previous page token")
+	cmd.MarkFlagsMutuallyExclusive("skip", "continue")
 }
 
 // AddPlainFlags registers --plain and --no-header flags on a command.
@@ -42,6 +56,13 @@ type ListResult struct {
 	JSON     any
 	Table    ListTable
 	EmptyMsg string
+	Page     *ListPageInfo
+}
+
+type paginatedListJSON struct {
+	Count    int    `json:"count"`
+	Items    any    `json:"items"`
+	Continue string `json:"continue,omitzero"`
 }
 
 // RunList handles the shared boilerplate for list commands:
@@ -53,10 +74,26 @@ func RunList(
 	fieldSpec *api.FieldSpec,
 	fetch func(client api.ClientInterface, fields []string) (*ListResult, error),
 ) error {
+	if err := ValidateContinueConflicts(cmd); err != nil {
+		return err
+	}
 	if cmd.Flags().Lookup("limit") != nil {
 		if err := ValidateLimit(flags.Limit); err != nil {
 			return err
 		}
+	}
+	if cmd.Flags().Lookup("skip") != nil {
+		if err := ValidateSkip(flags.Skip); err != nil {
+			return err
+		}
+	}
+	if cmd.Flags().Lookup("continue") != nil && flags.ContinueToken != "" {
+		continuePath, continueOffset, err := DecodeContinueToken(cmd.CommandPath(), flags.ContinueToken)
+		if err != nil {
+			return err
+		}
+		flags.ContinuePath = continuePath
+		flags.ContinueOffset = continueOffset
 	}
 
 	jsonResult, showHelp, err := ParseJSONFields(cmd, flags.JSONFields, fieldSpec, f.Printer.Out)
@@ -77,7 +114,22 @@ func RunList(
 		return err
 	}
 
+	continueToken := ""
+	if result.Page != nil && result.Page.ContinuePath != "" {
+		continueToken, err = EncodeContinueToken(cmd.CommandPath(), result.Page.ContinuePath, result.Page.ContinueOffset)
+		if err != nil {
+			return err
+		}
+	}
+
 	if jsonResult.Enabled {
+		if result.Page != nil {
+			return f.Printer.PrintJSON(paginatedListJSON{
+				Count:    max(result.Page.Count, len(result.Table.Rows)),
+				Items:    result.JSON,
+				Continue: continueToken,
+			})
+		}
 		return f.Printer.PrintJSON(result.JSON)
 	}
 
@@ -97,6 +149,10 @@ func RunList(
 			output.AutoSizeColumns(result.Table.Headers, result.Table.Rows, 2, result.Table.FlexCols...)
 		}
 		f.Printer.PrintTable(result.Table.Headers, result.Table.Rows)
+	}
+
+	if continueToken != "" {
+		_, _ = fmt.Fprintf(f.Printer.ErrOut, "Continue: %s\n", continueToken)
 	}
 	return nil
 }

--- a/internal/cmdutil/pagination.go
+++ b/internal/cmdutil/pagination.go
@@ -1,0 +1,110 @@
+package cmdutil
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const continueTokenVersion = 1
+const continueConflictsAnnotation = "teamcity-cli/continue-conflicts"
+
+type continueToken struct {
+	Version int    `json:"version"`
+	Command string `json:"command"`
+	Path    string `json:"path"`
+	Offset  int    `json:"offset,omitzero"`
+}
+
+// ListPageInfo contains pagination metadata for paginated list commands.
+type ListPageInfo struct {
+	Count          int
+	ContinuePath   string
+	ContinueOffset int
+}
+
+// EncodeContinueToken converts internal pagination state into an opaque CLI token.
+func EncodeContinueToken(commandPath, path string, offset int) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+
+	payload, err := json.Marshal(continueToken{
+		Version: continueTokenVersion,
+		Command: commandPath,
+		Path:    path,
+		Offset:  offset,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encode continuation token: %w", err)
+	}
+
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+// DecodeContinueToken validates and decodes a continuation token for a command.
+func DecodeContinueToken(commandPath, token string) (string, int, error) {
+	payload, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid continuation token")
+	}
+
+	var decoded continueToken
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return "", 0, fmt.Errorf("invalid continuation token")
+	}
+
+	switch {
+	case decoded.Version != continueTokenVersion:
+		return "", 0, fmt.Errorf("unsupported continuation token version")
+	case decoded.Command != commandPath:
+		return "", 0, fmt.Errorf("continuation token does not belong to %q", commandPath)
+	case decoded.Path == "":
+		return "", 0, fmt.Errorf("invalid continuation token")
+	case decoded.Offset < 0:
+		return "", 0, fmt.Errorf("invalid continuation token")
+	default:
+		return decoded.Path, decoded.Offset, nil
+	}
+}
+
+// SetContinueConflicts records flags that are incompatible with --continue for a command.
+func SetContinueConflicts(cmd *cobra.Command, flagNames ...string) {
+	if len(flagNames) == 0 {
+		return
+	}
+	if cmd.Annotations == nil {
+		cmd.Annotations = map[string]string{}
+	}
+	cmd.Annotations[continueConflictsAnnotation] = strings.Join(flagNames, ",")
+}
+
+// ValidateContinueConflicts checks whether --continue is combined with incompatible flags.
+func ValidateContinueConflicts(cmd *cobra.Command) error {
+	if cmd.Flags().Lookup("continue") == nil || !cmd.Flags().Changed("continue") {
+		return nil
+	}
+
+	conflictList := cmd.Annotations[continueConflictsAnnotation]
+	if conflictList == "" {
+		return nil
+	}
+
+	conflicts := make([]string, 0, 4)
+	for flagName := range strings.SplitSeq(conflictList, ",") {
+		if flagName != "" && cmd.Flags().Changed(flagName) && !slices.Contains(conflicts, flagName) {
+			conflicts = append(conflicts, flagName)
+		}
+	}
+	if len(conflicts) == 0 {
+		return nil
+	}
+	if len(conflicts) == 1 {
+		return fmt.Errorf("--continue cannot be used with --%s", conflicts[0])
+	}
+	return fmt.Errorf("--continue cannot be used with flags: --%s", strings.Join(conflicts, ", --"))
+}

--- a/internal/cmdutil/pagination.go
+++ b/internal/cmdutil/pagination.go
@@ -14,10 +14,11 @@ const continueTokenVersion = 1
 const continueConflictsAnnotation = "teamcity-cli/continue-conflicts"
 
 type continueToken struct {
-	Version int    `json:"version"`
-	Command string `json:"command"`
-	Path    string `json:"path"`
-	Offset  int    `json:"offset,omitzero"`
+	Version int             `json:"version"`
+	Command string          `json:"command"`
+	Path    string          `json:"path"`
+	Offset  int             `json:"offset,omitzero"`
+	State   json.RawMessage `json:"state,omitzero"`
 }
 
 // ListPageInfo contains pagination metadata for paginated list commands.
@@ -25,20 +26,37 @@ type ListPageInfo struct {
 	Count          int
 	ContinuePath   string
 	ContinueOffset int
+	ContinueState  any
 }
 
 // EncodeContinueToken converts internal pagination state into an opaque CLI token.
 func EncodeContinueToken(commandPath, path string, offset int) (string, error) {
+	return EncodeContinueTokenWithState(commandPath, path, offset, nil)
+}
+
+// EncodeContinueTokenWithState converts internal pagination state into an opaque CLI token.
+func EncodeContinueTokenWithState(commandPath, path string, offset int, state any) (string, error) {
 	if path == "" {
 		return "", nil
 	}
 
-	payload, err := json.Marshal(continueToken{
+	token := continueToken{
 		Version: continueTokenVersion,
 		Command: commandPath,
 		Path:    path,
 		Offset:  offset,
-	})
+	}
+	if state != nil {
+		rawState, err := json.Marshal(state)
+		if err != nil {
+			return "", fmt.Errorf("encode continuation token: %w", err)
+		}
+		if string(rawState) != "{}" && string(rawState) != "null" {
+			token.State = rawState
+		}
+	}
+
+	payload, err := json.Marshal(token)
 	if err != nil {
 		return "", fmt.Errorf("encode continuation token: %w", err)
 	}
@@ -48,27 +66,33 @@ func EncodeContinueToken(commandPath, path string, offset int) (string, error) {
 
 // DecodeContinueToken validates and decodes a continuation token for a command.
 func DecodeContinueToken(commandPath, token string) (string, int, error) {
+	path, offset, _, err := DecodeContinueTokenWithState(commandPath, token)
+	return path, offset, err
+}
+
+// DecodeContinueTokenWithState validates and decodes a continuation token for a command.
+func DecodeContinueTokenWithState(commandPath, token string) (string, int, json.RawMessage, error) {
 	payload, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
-		return "", 0, fmt.Errorf("invalid continuation token")
+		return "", 0, nil, fmt.Errorf("invalid continuation token")
 	}
 
 	var decoded continueToken
 	if err := json.Unmarshal(payload, &decoded); err != nil {
-		return "", 0, fmt.Errorf("invalid continuation token")
+		return "", 0, nil, fmt.Errorf("invalid continuation token")
 	}
 
 	switch {
 	case decoded.Version != continueTokenVersion:
-		return "", 0, fmt.Errorf("unsupported continuation token version")
+		return "", 0, nil, fmt.Errorf("unsupported continuation token version")
 	case decoded.Command != commandPath:
-		return "", 0, fmt.Errorf("continuation token does not belong to %q", commandPath)
+		return "", 0, nil, fmt.Errorf("continuation token does not belong to %q", commandPath)
 	case decoded.Path == "":
-		return "", 0, fmt.Errorf("invalid continuation token")
+		return "", 0, nil, fmt.Errorf("invalid continuation token")
 	case decoded.Offset < 0:
-		return "", 0, fmt.Errorf("invalid continuation token")
+		return "", 0, nil, fmt.Errorf("invalid continuation token")
 	default:
-		return decoded.Path, decoded.Offset, nil
+		return decoded.Path, decoded.Offset, decoded.State, nil
 	}
 }
 

--- a/internal/cmdutil/pagination_test.go
+++ b/internal/cmdutil/pagination_test.go
@@ -1,0 +1,43 @@
+package cmdutil
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContinueTokenRoundTrip(t *testing.T) {
+	token, err := EncodeContinueToken("teamcity project list", "/app/rest/projects?locator=count:2,start:2", 0)
+	require.NoError(t, err)
+
+	path, offset, err := DecodeContinueToken("teamcity project list", token)
+	require.NoError(t, err)
+	assert.Equal(t, "/app/rest/projects?locator=count:2,start:2", path)
+	assert.Zero(t, offset)
+}
+
+func TestContinueTokenCommandMismatch(t *testing.T) {
+	token, err := EncodeContinueToken("teamcity agent list", "/app/rest/agents?locator=count:2,start:2", 0)
+	require.NoError(t, err)
+
+	_, _, err = DecodeContinueToken("teamcity project list", token)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not belong")
+}
+
+func TestValidateContinueConflicts(t *testing.T) {
+	cmd := &cobra.Command{Use: "list"}
+	cmd.Flags().String("continue", "", "")
+	cmd.Flags().String("project", "", "")
+	cmd.Flags().Bool("all", false, "")
+	SetContinueConflicts(cmd, "project", "all")
+
+	require.NoError(t, cmd.Flags().Set("continue", "token"))
+	require.NoError(t, cmd.Flags().Set("project", "TestProject"))
+
+	err := ValidateContinueConflicts(cmd)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--continue cannot be used with --project")
+}

--- a/internal/cmdutil/pagination_test.go
+++ b/internal/cmdutil/pagination_test.go
@@ -27,6 +27,17 @@ func TestContinueTokenCommandMismatch(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not belong")
 }
 
+func TestContinueTokenStateRoundTrip(t *testing.T) {
+	token, err := EncodeContinueTokenWithState("teamcity job list", "/app/rest/buildTypes?locator=count:2,start:2", 1, map[string]bool{"all": true})
+	require.NoError(t, err)
+
+	path, offset, state, err := DecodeContinueTokenWithState("teamcity job list", token)
+	require.NoError(t, err)
+	assert.Equal(t, "/app/rest/buildTypes?locator=count:2,start:2", path)
+	assert.Equal(t, 1, offset)
+	assert.JSONEq(t, `{"all":true}`, string(state))
+}
+
 func TestValidateContinueConflicts(t *testing.T) {
 	cmd := &cobra.Command{Use: "list"}
 	cmd.Flags().String("continue", "", "")


### PR DESCRIPTION
## Summary

Adds `--skip` and `--continue` support to the TeamCity-backed paginated `list` commands, with shared pagination plumbing across the CLI and API layers.

## What Changed

- added shared pagination/token handling in `cmdutil`
- added API support for `start`, `nextHref`, and continuation-path rewriting on paginated endpoints
- updated supported list commands to expose `--skip` and `--continue`
- changed paginated `--json` output to the CLI-owned envelope:
  - `count`
  - `items`
  - `continue`
- printed continuation tokens to `stderr` for table/plain output when another page is available
- kept `project ssh list` and `project connection list` unchanged
- added regression coverage for token handling and representative command behavior

## Why

Issue #237 asked for pagination that works both for page offsets and for reliable continuation in scripts. The CLI previously only exposed `--limit`, which made paging fragile and inconsistent across commands.

## Root Cause

List commands were building one-off list requests without a shared continuation model. Some TeamCity responses already exposed `nextHref`, but the CLI was not surfacing it or carrying enough pagination state forward for follow-up requests.

## User Impact

Users can now page through supported list commands with either:

```bash
teamcity <group> list --limit 30 --skip 30
teamcity <group> list --continue <token>
```

This is especially useful for scripting against large TeamCity instances.

## Validation

- `go test ./...`

Closes #237