### PR TITLE
feat(analytics): add FUS telemetry pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ docs-out/
 # OS
 .DS_Store
 .teamcity/target/
+
+# Generated from internal/analytics/scheme.go via scripts/generate-fus-schema.go
+/internal/analytics/schema.json

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -93,6 +93,7 @@ func TestAcceptance(t *testing.T) {
 		"queue",
 		"alias",
 		"skill",
+		"analytics",
 	}
 
 	for _, dir := range dirs {

--- a/acceptance/testdata/analytics/optout.txtar
+++ b/acceptance/testdata/analytics/optout.txtar
@@ -1,0 +1,75 @@
+# Verifies every documented analytics opt-out path + priority order.
+# Each `teamcity --debug` triggers PersistentPreRun → setupAnalytics, which
+# logs the analytics enable/disable state to stderr via Printer.Debug.
+#
+# Priority chain (first match wins):
+#   1. DO_NOT_TRACK=1                  → disabled
+#   2. TEAMCITY_ANALYTICS=0|false|no   → disabled
+#   3. config: analytics=false         → disabled
+#   4. otherwise                       → enabled
+
+# Clear server URL/token so the bare `teamcity` invocation just renders the
+# welcome banner without network activity.
+env TEAMCITY_URL=
+env TEAMCITY_TOKEN=
+env TEAMCITY_GUEST=
+
+# 1. Default: no opt-out → enabled.
+exec teamcity --debug
+stderr '\[debug\] analytics: enabled '
+
+# 2. DO_NOT_TRACK=1 disables (highest priority).
+env DO_NOT_TRACK=1
+exec teamcity --debug
+stderr '\[debug\] analytics: disabled \(DO_NOT_TRACK\)'
+! stderr '\[debug\] analytics: enabled '
+env DO_NOT_TRACK=
+
+# 3. TEAMCITY_ANALYTICS=0 disables.
+env TEAMCITY_ANALYTICS=0
+exec teamcity --debug
+stderr '\[debug\] analytics: disabled \(TEAMCITY_ANALYTICS=0\)'
+env TEAMCITY_ANALYTICS=
+
+# 4. TEAMCITY_ANALYTICS=false disables (alternate falsy spelling).
+env TEAMCITY_ANALYTICS=false
+exec teamcity --debug
+stderr '\[debug\] analytics: disabled \(TEAMCITY_ANALYTICS=0\)'
+env TEAMCITY_ANALYTICS=
+
+# 5. TEAMCITY_ANALYTICS=no disables (another falsy spelling).
+env TEAMCITY_ANALYTICS=no
+exec teamcity --debug
+stderr '\[debug\] analytics: disabled \(TEAMCITY_ANALYTICS=0\)'
+env TEAMCITY_ANALYTICS=
+
+# 6. Persistent config flag: `teamcity config set analytics false`.
+exec teamcity config set analytics false --no-input
+exec teamcity --debug
+stderr '\[debug\] analytics: disabled \(config: analytics=false\)'
+
+# 7. Priority: TEAMCITY_ANALYTICS=0 wins over config=true.
+exec teamcity config set analytics true --no-input
+env TEAMCITY_ANALYTICS=0
+exec teamcity --debug
+stderr '\[debug\] analytics: disabled \(TEAMCITY_ANALYTICS=0\)'
+env TEAMCITY_ANALYTICS=
+
+# 8. Priority: DO_NOT_TRACK wins over TEAMCITY_ANALYTICS=0.
+env DO_NOT_TRACK=1
+env TEAMCITY_ANALYTICS=0
+exec teamcity --debug
+stderr '\[debug\] analytics: disabled \(DO_NOT_TRACK\)'
+env DO_NOT_TRACK=
+env TEAMCITY_ANALYTICS=
+
+# 9. Re-enable via config: clearing all opt-outs returns to enabled.
+exec teamcity --debug
+stderr '\[debug\] analytics: enabled '
+
+# 10. config get reports the current value.
+exec teamcity config get analytics --no-input
+stdout '^true$'
+exec teamcity config set analytics false --no-input
+exec teamcity config get analytics --no-input
+stdout '^false$'

--- a/api/types.go
+++ b/api/types.go
@@ -291,6 +291,7 @@ type Server struct {
 	VersionMinor int    `json:"versionMinor"`
 	BuildNumber  string `json:"buildNumber"`
 	WebURL       string `json:"webUrl"`
+	InternalID   string `json:"internalId,omitempty"`
 }
 
 type Change struct {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
-	github.com/JetBrains/fus-reporting-api-go v0.0.0-20260415121423-32ee791c38a2
+	github.com/JetBrains/fus-reporting-api-go v0.1.0
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/JetBrains/fus-reporting-api-go v0.0.0-20260415121423-32ee791c38a2
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
@@ -26,6 +27,7 @@ require (
 	github.com/rogpeppe/go-internal v1.14.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.41.0
@@ -105,7 +107,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.16 // indirect
 	github.com/tklauser/numcpus v0.11.0 // indirect
@@ -120,7 +121,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260128011058-8636f8732409 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,12 @@ github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEK
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/JetBrains/fus-reporting-api-go v0.0.0-20260415121423-32ee791c38a2 h1:g8kfJLIlOkyyujfqDnSNW5Y33jba4w8nCRjvphe804U=
 github.com/JetBrains/fus-reporting-api-go v0.0.0-20260415121423-32ee791c38a2/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
+github.com/JetBrains/fus-reporting-api-go v0.0.0-20260416082822-78ed6cf979b1 h1:W28vWMwCFxDcKb5kXnQpVcP1f4JBfEOJ8Wub8XmmVBc=
+github.com/JetBrains/fus-reporting-api-go v0.0.0-20260416082822-78ed6cf979b1/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
+github.com/JetBrains/fus-reporting-api-go v0.0.0-20260416111710-135e5707d1ee h1:HzmN9ltmIBMKX2Q7TkURyOYvrXAVz3WlbAQknR+fcIA=
+github.com/JetBrains/fus-reporting-api-go v0.0.0-20260416111710-135e5707d1ee/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
+github.com/JetBrains/fus-reporting-api-go v0.1.0 h1:nqzKrfVSGxg3WZRlfnJ4tO0C0Aas3F4CMCpyd4KmtiQ=
+github.com/JetBrains/fus-reporting-api-go v0.1.0/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkk
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/JetBrains/fus-reporting-api-go v0.0.0-20260415121423-32ee791c38a2 h1:g8kfJLIlOkyyujfqDnSNW5Y33jba4w8nCRjvphe804U=
+github.com/JetBrains/fus-reporting-api-go v0.0.0-20260415121423-32ee791c38a2/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
@@ -287,8 +289,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
-golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
+golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.41.0 h1:QCgPso/Q3RTJx2Th4bDLqML4W6iJiaXFq2/ftQF13YU=

--- a/internal/analytics/api_resource.go
+++ b/internal/analytics/api_resource.go
@@ -1,0 +1,57 @@
+package analytics
+
+import "strings"
+
+// APIResource maps a `/app/rest/...` endpoint to a coarse resource bucket; unknown → "other".
+func APIResource(endpoint string) string {
+	p := strings.TrimSpace(endpoint)
+	p = strings.TrimPrefix(p, "/")
+	p = strings.TrimPrefix(p, "app/rest/")
+	if p == "" {
+		return "other"
+	}
+	if i := strings.IndexAny(p, "/?"); i >= 0 {
+		p = p[:i]
+	}
+	switch p {
+	case "builds", "buildQueue":
+		return "builds"
+	case "buildTypes":
+		return "build_types"
+	case "projects":
+		return "projects"
+	case "agents", "agentPools", "agentTypes":
+		return "agents"
+	case "users", "userGroups", "roles", "audit":
+		return "users"
+	case "vcs-roots", "vcs-root-instances":
+		return "vcs"
+	case "queue":
+		return "queue"
+	case "tests", "testOccurrences", "testScopes":
+		return "tests"
+	case "problems", "problemOccurrences", "investigations", "mutes":
+		return "problems"
+	case "changes":
+		return "changes"
+	case "pipelines":
+		return "pipelines"
+	case "cloud":
+		return "cloud"
+	case "server":
+		return "server"
+	default:
+		return "other"
+	}
+}
+
+// NormalizeHTTPMethod maps an HTTP method to the wire enum; unknown → GET.
+func NormalizeHTTPMethod(method string) string {
+	upper := strings.ToUpper(strings.TrimSpace(method))
+	switch upper {
+	case "GET", "POST", "PUT", "DELETE", "PATCH":
+		return upper
+	default:
+		return "GET"
+	}
+}

--- a/internal/analytics/api_resource_test.go
+++ b/internal/analytics/api_resource_test.go
@@ -1,0 +1,54 @@
+package analytics
+
+import "testing"
+
+func TestAPIResource(t *testing.T) {
+	cases := map[string]string{
+		"":                       "other",
+		"/":                      "other",
+		"/app/rest/builds/12345": "builds",
+		"/app/rest/builds":       "builds",
+		"/app/rest/builds?locator=defaultFilter:false": "builds",
+		"/app/rest/buildTypes/MyBuild":                 "build_types",
+		"/app/rest/projects":                           "projects",
+		"/app/rest/agentPools/1":                       "agents",
+		"/app/rest/agents":                             "agents",
+		"/app/rest/vcs-roots/id:Foo":                   "vcs",
+		"/app/rest/vcs-root-instances":                 "vcs",
+		"/app/rest/queue":                              "queue",
+		"/app/rest/buildQueue":                         "builds",
+		"/app/rest/testOccurrences":                    "tests",
+		"/app/rest/problemOccurrences":                 "problems",
+		"/app/rest/investigations":                     "problems",
+		"/app/rest/changes":                            "changes",
+		"/app/rest/pipelines":                          "pipelines",
+		"/app/rest/cloud":                              "cloud",
+		"/app/rest/server":                             "server",
+		"/app/rest/users":                              "users",
+		"/app/rest/userGroups":                         "users",
+		"app/rest/builds":                              "builds",
+		"/app/rest/some-future-thing":                  "other",
+	}
+	for in, want := range cases {
+		if got := APIResource(in); got != want {
+			t.Errorf("APIResource(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalizeHTTPMethod(t *testing.T) {
+	cases := map[string]string{
+		"GET":     "GET",
+		"get":     "GET",
+		"Post":    "POST",
+		"DELETE":  "DELETE",
+		"PATCH":   "PATCH",
+		"OPTIONS": "GET",
+		"":        "GET",
+	}
+	for in, want := range cases {
+		if got := NormalizeHTTPMethod(in); got != want {
+			t.Errorf("NormalizeHTTPMethod(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -83,21 +83,42 @@ func (c *Client) boot() {
 			c.logf("analytics: boot failed (data dir): %v", err)
 			return
 		}
-		validator, err := fus.NewValidator(Scheme)
+
+		var fusConfig *fus.FUSConfig
+		if c.staging {
+			fusConfig, err = fus.FetchTestConfig(RecorderID, ProductCode)
+		} else {
+			fusConfig, err = fus.LoadOrFetchConfig(RecorderID, ProductCode, c.cliVersion, dir, fus.RegionAll)
+		}
+		if err != nil {
+			c.logf("analytics: boot failed (config): %v", err)
+			return
+		}
+
+		if c.salt != "" {
+			fusConfig.Salt = c.salt
+		} else {
+			c.salt = fusConfig.Salt
+		}
+
+		scheme := Scheme
+		if url := fusConfig.SchemeURL(ProductCode); url != "" {
+			if remote, err := fus.LoadOrFetchScheme(url, dir); err == nil {
+				scheme = remote
+				c.logf("analytics: using CDN metadata (version=%s groups=%d)", scheme.Version, len(scheme.Groups))
+			} else {
+				c.logf("analytics: CDN metadata unavailable, using embedded scheme: %v", err)
+			}
+		}
+
+		validator, err := fus.NewValidator(scheme)
 		if err != nil {
 			c.logf("analytics: boot failed (validator): %v", err)
 			return
 		}
-		opts := []fus.LoggerOption{fus.WithValidator(validator)}
-		if c.staging {
-			stagingCfg, err := fus.FetchTestConfig(RecorderID, ProductCode)
-			if err != nil {
-				c.logf("analytics: boot failed (staging config): %v", err)
-				return
-			}
-			opts = append(opts, fus.WithFUSConfig(stagingCfg))
-		}
+		anonymizer := fus.NewAnonymizer(scheme, []byte(c.salt))
 		logger, err := fus.NewLogger(
+			context.Background(),
 			fus.RecorderConfig{
 				RecorderID:        RecorderID,
 				RecorderVersion:   RecorderVersion,
@@ -106,7 +127,9 @@ func (c *Client) boot() {
 				DataDir:           dir,
 				AnonymizationSalt: c.salt,
 			},
-			opts...,
+			fus.WithFUSConfig(fusConfig),
+			fus.WithValidator(validator),
+			fus.WithAnonymizer(anonymizer),
 		)
 		if err != nil {
 			c.logf("analytics: boot failed (logger): %v", err)
@@ -232,14 +255,13 @@ func (c *Client) Flush(ctx context.Context) error {
 	return c.logger.Flush(ctx)
 }
 
-// Close flushes with a 2s timeout; idempotent.
 func (c *Client) Close() error {
 	if c == nil || c.logger == nil {
 		return nil
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
-	err := c.logger.Flush(ctx)
+	err := c.logger.Close(ctx)
 	switch {
 	case errors.Is(err, context.DeadlineExceeded):
 		c.logf("analytics: flush timed out after 2s")

--- a/internal/analytics/client.go
+++ b/internal/analytics/client.go
@@ -1,0 +1,253 @@
+package analytics
+
+import (
+	"cmp"
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	fus "github.com/JetBrains/fus-reporting-api-go"
+)
+
+// Client is nil-safe. Pass nil for "disabled" — every Track* method becomes a no-op.
+type Client struct {
+	mu sync.Mutex
+
+	staging       bool
+	salt          string
+	logger        *fus.Logger
+	session       *Session
+	env           Environment
+	source        string
+	cliVersion    string
+	serverVersion string
+	serverType    string
+	authSource    string
+	hasLinkedPrj  bool
+	debug         func(string, ...any)
+	bootOnce      sync.Once
+}
+
+type Config struct {
+	Staging          bool
+	Salt             string
+	CLIVersion       string
+	ServerVersion    string // YYYY.MM[.x]; omitted from session event when empty
+	ServerType       string // "cloud" | "on_prem"; omitted when empty
+	AuthSource       string
+	HasLinkedProject bool
+	Session          *Session
+	Environment      Environment
+
+	// Debug, when non-nil, receives one line per lifecycle event (boot, track, flush).
+	// Pass f.Printer.Debug to surface only with --verbose / --debug.
+	Debug func(string, ...any)
+}
+
+// New builds a Client; FUS logger boots lazily on first Track and noops on failure.
+func New(cfg Config) *Client {
+	return &Client{
+		session:       cfg.Session,
+		env:           cfg.Environment,
+		source:        ClassifySource(cfg.Environment),
+		cliVersion:    cfg.CLIVersion,
+		serverVersion: cfg.ServerVersion,
+		serverType:    cfg.ServerType,
+		authSource:    cfg.AuthSource,
+		hasLinkedPrj:  cfg.HasLinkedProject,
+		staging:       cfg.Staging,
+		salt:          cfg.Salt,
+		debug:         cfg.Debug,
+	}
+}
+
+func (c *Client) logf(format string, args ...any) {
+	if c == nil || c.debug == nil {
+		return
+	}
+	c.debug(format, args...)
+}
+
+func (c *Client) SessionID() string {
+	if c == nil || c.session == nil {
+		return ""
+	}
+	return c.session.ID
+}
+
+func (c *Client) boot() {
+	c.bootOnce.Do(func() {
+		dir, err := DataDir()
+		if err != nil {
+			c.logf("analytics: boot failed (data dir): %v", err)
+			return
+		}
+		validator, err := fus.NewValidator(Scheme)
+		if err != nil {
+			c.logf("analytics: boot failed (validator): %v", err)
+			return
+		}
+		opts := []fus.LoggerOption{fus.WithValidator(validator)}
+		if c.staging {
+			stagingCfg, err := fus.FetchTestConfig(RecorderID, ProductCode)
+			if err != nil {
+				c.logf("analytics: boot failed (staging config): %v", err)
+				return
+			}
+			opts = append(opts, fus.WithFUSConfig(stagingCfg))
+		}
+		logger, err := fus.NewLogger(
+			fus.RecorderConfig{
+				RecorderID:        RecorderID,
+				RecorderVersion:   RecorderVersion,
+				ProductCode:       ProductCode,
+				BuildVersion:      c.cliVersion,
+				DataDir:           dir,
+				AnonymizationSalt: c.salt,
+			},
+			opts...,
+		)
+		if err != nil {
+			c.logf("analytics: boot failed (logger): %v", err)
+			return
+		}
+		c.logger = logger
+		c.logf("analytics: ready (recorder=%s product=%s staging=%v salt=%t buffer=%s)",
+			RecorderID, ProductCode, c.staging, c.salt != "", dir)
+	})
+}
+
+func (c *Client) track(group string, state bool, eventID string, data map[string]any) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.boot()
+	if c.logger == nil {
+		return
+	}
+	c.logger.Track(fus.EventGroup{ID: group, Version: groupVersion, State: state}, eventID, data)
+	c.logf("analytics: emit %s/%s (%d fields)", group, eventID, len(data))
+}
+
+// Track emits a counter event. Field names and values must match the scheme;
+// TestLintScheme catches drift at test time.
+func (c *Client) Track(group, eventID string, data map[string]any) {
+	c.track(group, false, eventID, data)
+}
+
+// TrackSession emits the session.invoked state event once per new session.
+func (c *Client) TrackSession() {
+	if c == nil || c.session == nil || !c.session.IsNew {
+		return
+	}
+	data := map[string]any{
+		"session_id":         c.session.ID,
+		"cli_version":        c.cliVersion,
+		"os":                 c.env.OS,
+		"arch":               c.env.Arch,
+		"ci_system":          c.env.CISystem,
+		"auth_source":        cmp.Or(c.authSource, AuthSourceNone),
+		"ai_agent":           c.env.AIAgent,
+		"has_linked_project": c.hasLinkedPrj,
+	}
+	if c.serverVersion != "" {
+		data["server_version"] = c.serverVersion
+	}
+	if c.serverType != "" {
+		data["server_type"] = c.serverType
+	}
+	c.track(GroupSession, true, EventInvoked, data)
+}
+
+// CommandEvent carries the command-executed counter event; typed because exit code and error type need normalization.
+type CommandEvent struct {
+	Command        string
+	HasJSON        bool
+	HasGitContext  bool
+	HasLinkContext bool
+	FlagCount      int
+	ExitCode       int
+	DurationMS     int64
+	ErrorType      string
+}
+
+func (c *Client) TrackCommand(e CommandEvent) {
+	if c == nil {
+		return
+	}
+	exit := "0"
+	switch {
+	case e.ExitCode == 2:
+		exit = "2"
+	case e.ExitCode != 0:
+		exit = "1"
+	}
+	c.track(GroupCommand, false, EventExecuted, map[string]any{
+		"session_id":       c.SessionID(),
+		"command":          NormalizeCommand(e.Command),
+		"source":           c.source,
+		"has_json":         e.HasJSON,
+		"has_git_context":  e.HasGitContext,
+		"has_link_context": e.HasLinkContext,
+		"flag_count":       e.FlagCount,
+		"exit_code":        exit,
+		"duration_ms":      e.DurationMS,
+		"error_type":       cmp.Or(e.ErrorType, ErrorNone),
+	})
+}
+
+// APIEvent carries the api-invoked counter event; typed because raw endpoints need sanitization.
+type APIEvent struct {
+	Method     string
+	Endpoint   string
+	StatusCode int
+	Paginated  bool
+	Slurp      bool
+	HadFields  bool
+	HadInput   bool
+}
+
+func (c *Client) TrackAPI(e APIEvent) {
+	if c == nil {
+		return
+	}
+	c.track(GroupAPI, false, EventInvoked, map[string]any{
+		"method":       NormalizeHTTPMethod(e.Method),
+		"resource":     APIResource(e.Endpoint),
+		"status_code":  e.StatusCode,
+		"is_paginated": e.Paginated,
+		"is_slurp":     e.Slurp,
+		"had_fields":   e.HadFields,
+		"had_input":    e.HadInput,
+	})
+}
+
+func (c *Client) Flush(ctx context.Context) error {
+	if c == nil || c.logger == nil {
+		return nil
+	}
+	return c.logger.Flush(ctx)
+}
+
+// Close flushes with a 2s timeout; idempotent.
+func (c *Client) Close() error {
+	if c == nil || c.logger == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := c.logger.Flush(ctx)
+	switch {
+	case errors.Is(err, context.DeadlineExceeded):
+		c.logf("analytics: flush timed out after 2s")
+		return nil
+	case err != nil:
+		c.logf("analytics: flush failed: %v", err)
+	default:
+		c.logf("analytics: flushed")
+	}
+	return err
+}

--- a/internal/analytics/client_test.go
+++ b/internal/analytics/client_test.go
@@ -1,0 +1,46 @@
+package analytics
+
+import (
+	"testing"
+	"time"
+)
+
+// TestClient_NilSafe verifies the Track surface accepts a nil receiver — the contract for "disabled".
+func TestClient_NilSafe(t *testing.T) {
+	var c *Client
+	c.TrackSession()
+	c.TrackCommand(CommandEvent{Command: "run.start"})
+	c.TrackAPI(APIEvent{Method: "GET", Endpoint: "/app/rest/builds"})
+	c.Track(GroupAuth, EventLoginCompleted, map[string]any{
+		"method": AuthMethodToken, "is_success": true, "error_type": ErrorNone,
+	})
+	if err := c.Flush(t.Context()); err != nil {
+		t.Errorf("Flush nil: %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Errorf("Close nil: %v", err)
+	}
+	if c.SessionID() != "" {
+		t.Errorf("nil SessionID = %q, want empty", c.SessionID())
+	}
+}
+
+// TestClient_BootFailureBecomesNoop exercises the lazy-boot error path.
+func TestClient_BootFailureBecomesNoop(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	c := New(Config{
+		CLIVersion: "0.1.0-test",
+		Session:    &Session{ID: "00000000-0000-4000-8000-000000000000", IsNew: true, LastActive: time.Now()},
+		Environment: Environment{
+			OS: "darwin", Arch: "arm64", CISystem: CINone, AIAgent: "none",
+		},
+		AuthSource: AuthSourceNone,
+	})
+
+	c.TrackCommand(CommandEvent{Command: "run.list"})
+	c.TrackCommand(CommandEvent{Command: "run.list"})
+	if err := c.Close(); err != nil {
+		t.Errorf("Close after boot failure: %v", err)
+	}
+}

--- a/internal/analytics/detect.go
+++ b/internal/analytics/detect.go
@@ -1,0 +1,96 @@
+package analytics
+
+import (
+	"os"
+	"runtime"
+
+	"github.com/tiulpin/instill"
+)
+
+type Environment struct {
+	OS       string
+	Arch     string
+	CISystem string
+	AIAgent  string
+}
+
+func DetectEnvironment() Environment {
+	return Environment{
+		OS:       NormalizeOS(runtime.GOOS),
+		Arch:     NormalizeArch(runtime.GOARCH),
+		CISystem: DetectCI(),
+		AIAgent:  DetectAIAgent(),
+	}
+}
+
+func NormalizeOS(goos string) string {
+	switch goos {
+	case "darwin", "linux", "windows", "freebsd":
+		return goos
+	default:
+		return "other"
+	}
+}
+
+func NormalizeArch(goarch string) string {
+	switch goarch {
+	case "amd64", "arm64", "386":
+		return goarch
+	default:
+		return "other"
+	}
+}
+
+func DetectAIAgent() string {
+	r := instill.DetectRuntime()
+	if r == nil {
+		return CINone
+	}
+	return NormalizeAIAgent(r.Name)
+}
+
+// DetectCI returns the wire-enum value for the surrounding CI system; teamcity wins over generic CI.
+func DetectCI() string {
+	if os.Getenv("TEAMCITY_BUILD_PROPERTIES_FILE") != "" || os.Getenv("TEAMCITY_VERSION") != "" {
+		return CITeamCity
+	}
+	if os.Getenv("GITHUB_ACTIONS") != "" {
+		return CIGitHubActions
+	}
+	if os.Getenv("GITLAB_CI") != "" {
+		return CIGitLab
+	}
+	if os.Getenv("JENKINS_URL") != "" {
+		return CIJenkins
+	}
+	if os.Getenv("CIRCLECI") != "" {
+		return CICircleCI
+	}
+	if os.Getenv("BUILDKITE") != "" {
+		return CIBuildkite
+	}
+	if os.Getenv("TF_BUILD") != "" {
+		return CIAzure
+	}
+	if os.Getenv("TRAVIS") != "" {
+		return CITravis
+	}
+	if isTruthy(os.Getenv("CI")) {
+		return CIOther
+	}
+	return CINone
+}
+
+// ClassifySource collapses environment context into the four-bucket source taxonomy.
+func ClassifySource(env Environment) string {
+	if env.AIAgent != "none" {
+		return SourceAgent
+	}
+	if env.CISystem == CITeamCity {
+		return SourceBuildStep
+	}
+	if env.CISystem != CINone {
+		return SourceCI
+	}
+	return SourceHuman
+}

--- a/internal/analytics/detect_test.go
+++ b/internal/analytics/detect_test.go
@@ -1,0 +1,91 @@
+package analytics
+
+import "testing"
+
+func TestNormalizeOSArch(t *testing.T) {
+	cases := map[string]string{
+		"darwin":  "darwin",
+		"linux":   "linux",
+		"windows": "windows",
+		"freebsd": "freebsd",
+		"plan9":   "other",
+	}
+	for in, want := range cases {
+		if got := NormalizeOS(in); got != want {
+			t.Errorf("NormalizeOS(%q) = %q, want %q", in, got, want)
+		}
+	}
+	archCases := map[string]string{
+		"amd64": "amd64",
+		"arm64": "arm64",
+		"386":   "386",
+		"riscv": "other",
+	}
+	for in, want := range archCases {
+		if got := NormalizeArch(in); got != want {
+			t.Errorf("NormalizeArch(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestDetectCI(t *testing.T) {
+	allEnv := []string{
+		"TEAMCITY_BUILD_PROPERTIES_FILE", "TEAMCITY_VERSION",
+		"GITHUB_ACTIONS", "GITLAB_CI", "JENKINS_URL", "CIRCLECI",
+		"BUILDKITE", "TF_BUILD", "TRAVIS", "CI",
+	}
+	clear := func(t *testing.T) {
+		for _, k := range allEnv {
+			t.Setenv(k, "")
+		}
+	}
+
+	t.Run("none", func(t *testing.T) {
+		clear(t)
+		if got := DetectCI(); got != CINone {
+			t.Errorf("DetectCI = %q, want %q", got, CINone)
+		}
+	})
+	t.Run("teamcity wins over generic CI", func(t *testing.T) {
+		clear(t)
+		t.Setenv("TEAMCITY_VERSION", "2024.12")
+		t.Setenv("CI", "true")
+		if got := DetectCI(); got != CITeamCity {
+			t.Errorf("DetectCI = %q, want %q", got, CITeamCity)
+		}
+	})
+	t.Run("github actions", func(t *testing.T) {
+		clear(t)
+		t.Setenv("GITHUB_ACTIONS", "true")
+		if got := DetectCI(); got != CIGitHubActions {
+			t.Errorf("DetectCI = %q, want %q", got, CIGitHubActions)
+		}
+	})
+	t.Run("generic CI falls through to other", func(t *testing.T) {
+		clear(t)
+		t.Setenv("CI", "true")
+		if got := DetectCI(); got != CIOther {
+			t.Errorf("DetectCI = %q, want %q", got, CIOther)
+		}
+	})
+}
+
+func TestClassifySource(t *testing.T) {
+	cases := []struct {
+		name string
+		env  Environment
+		want string
+	}{
+		{"human", Environment{AIAgent: "none", CISystem: CINone}, SourceHuman},
+		{"agent always wins", Environment{AIAgent: "claude_code", CISystem: CITeamCity}, SourceAgent},
+		{"build_step from teamcity", Environment{AIAgent: "none", CISystem: CITeamCity}, SourceBuildStep},
+		{"ci from github", Environment{AIAgent: "none", CISystem: CIGitHubActions}, SourceCI},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifySource(tc.env); got != tc.want {
+				t.Errorf("ClassifySource = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/analytics/enums.go
+++ b/internal/analytics/enums.go
@@ -1,0 +1,73 @@
+package analytics
+
+import (
+	"slices"
+	"strings"
+)
+
+// allCommands enumerates every command path the CLI exposes for the `command` field; unknowns → "other".
+func allCommands() []string {
+	return []string{
+		"auth.login", "auth.logout", "auth.status",
+		"run.list", "run.view", "run.start", "run.cancel", "run.restart", "run.watch",
+		"run.log", "run.download", "run.artifacts", "run.tests", "run.pin", "run.unpin",
+		"run.tag", "run.untag", "run.comment", "run.changes", "run.tree", "run.diff",
+		"run.analysis", "run.metadata", "run.git",
+		"job.list", "job.view", "job.tree", "job.pause", "job.resume",
+		"job.param.list", "job.param.get", "job.param.set", "job.param.delete",
+		"project.list", "project.view", "project.tree", "project.create",
+		"project.vcs.list", "project.vcs.view", "project.vcs.create", "project.vcs.test", "project.vcs.delete",
+		"project.ssh.list", "project.ssh.upload", "project.ssh.generate", "project.ssh.delete",
+		"project.cloud.profile.list", "project.cloud.profile.view",
+		"project.cloud.image.list", "project.cloud.image.view",
+		"project.cloud.instance.list", "project.cloud.instance.view",
+		"project.connection.list", "project.token.put", "project.token.get",
+		"project.settings.status", "project.settings.export", "project.settings.validate",
+		"project.param.list", "project.param.get", "project.param.set", "project.param.delete",
+		"queue.list", "queue.remove", "queue.top", "queue.approve",
+		"agent.list", "agent.view", "agent.jobs", "agent.move", "agent.enable",
+		"agent.disable", "agent.authorize", "agent.deauthorize", "agent.terminal",
+		"agent.exec", "agent.reboot",
+		"pool.list", "pool.view", "pool.link", "pool.unlink",
+		"pipeline.list", "pipeline.view", "pipeline.validate", "pipeline.create",
+		"pipeline.delete", "pipeline.pull", "pipeline.push",
+		"api",
+		"alias.list", "alias.set", "alias.delete",
+		"config.list", "config.get", "config.set",
+		"skill.list", "skill.install", "skill.update", "skill.remove",
+		"update", "other",
+	}
+}
+
+// allAIAgents enumerates AI agent identifiers; mirrors instill names with `-` → `_`.
+func allAIAgents() []string {
+	return []string{
+		"claude_code", "junie", "cursor", "gemini_cli", "codex", "goose",
+		"augment", "github_copilot", "amp", "windsurf", "opencode", "trae",
+		"roo", "other", "none",
+	}
+}
+
+func skillAgentEnum() []string {
+	return slices.DeleteFunc(allAIAgents(), func(a string) bool { return a == "none" })
+}
+
+// NormalizeCommand returns the wire-safe value for a cobra command path; unknown → "other".
+func NormalizeCommand(path string) string {
+	if slices.Contains(allCommands(), path) {
+		return path
+	}
+	return "other"
+}
+
+// NormalizeAIAgent maps an instill agent name to the wire enum; "" → none, unknown → other.
+func NormalizeAIAgent(instillName string) string {
+	if instillName == "" {
+		return "none"
+	}
+	v := strings.ReplaceAll(instillName, "-", "_")
+	if slices.Contains(allAIAgents(), v) {
+		return v
+	}
+	return "other"
+}

--- a/internal/analytics/events.go
+++ b/internal/analytics/events.go
@@ -1,0 +1,132 @@
+package analytics
+
+const (
+	EventInvoked  = "invoked"
+	EventExecuted = "executed"
+
+	EventLoginCompleted = "login.completed"
+	EventLoginAbandoned = "login.abandoned"
+	EventTokenLoaded    = "token.loaded"
+
+	EventStarted       = "started"
+	EventWatchFinished = "watch.finished"
+	EventLogViewed     = "log.viewed"
+	EventTestsViewed   = "tests.viewed"
+	EventDiffViewed    = "diff.viewed"
+
+	EventTerminalClosed = "terminal.closed"
+	EventExecFinished   = "exec.finished"
+	EventStateChanged   = "state.changed"
+
+	EventValidated = "validated"
+	EventCreated   = "created"
+	EventSynced    = "synced"
+
+	EventManaged = "managed"
+)
+
+const (
+	SourceHuman     = "human"
+	SourceAgent     = "agent"
+	SourceCI        = "ci"
+	SourceBuildStep = "build_step"
+)
+
+const (
+	CINone          = "none"
+	CIOther         = "other"
+	CIGitHubActions = "github_actions"
+	CIGitLab        = "gitlab"
+	CIJenkins       = "jenkins"
+	CICircleCI      = "circleci"
+	CIBuildkite     = "buildkite"
+	CIAzure         = "azure"
+	CITravis        = "travis"
+	CITeamCity      = "teamcity"
+)
+
+const (
+	AuthSourceKeyring         = "keyring"
+	AuthSourceEnv             = "env"
+	AuthSourceBuildProperties = "build_properties"
+	AuthSourceGuest           = "guest"
+	AuthSourceNone            = "none"
+)
+
+const (
+	AuthMethodToken = "token"
+	AuthMethodGuest = "guest"
+)
+
+const (
+	AuthStepServer = "server"
+	AuthStepToken  = "token"
+	AuthStepVerify = "verify"
+)
+
+const (
+	ServerTypeCloud  = "cloud"
+	ServerTypeOnPrem = "on_prem"
+)
+
+const (
+	ErrorAuth       = "auth"
+	ErrorPermission = "permission"
+	ErrorNotFound   = "not_found"
+	ErrorNetwork    = "network"
+	ErrorValidation = "validation"
+	ErrorReadOnly   = "read_only"
+	ErrorInternal   = "internal"
+	ErrorNone       = "none"
+)
+
+const (
+	BuildStatusSuccess  = "success"
+	BuildStatusFailure  = "failure"
+	BuildStatusError    = "error"
+	BuildStatusCanceled = "canceled"
+)
+
+const (
+	LogModeFull   = "full"
+	LogModeFailed = "failed"
+	LogModeRaw    = "raw"
+	LogModeFollow = "follow"
+)
+
+const (
+	TestsFilterAll    = "all"
+	TestsFilterFailed = "failed"
+)
+
+const (
+	AgentActionEnable      = "enable"
+	AgentActionDisable     = "disable"
+	AgentActionAuthorize   = "authorize"
+	AgentActionDeauthorize = "deauthorize"
+	AgentActionMove        = "move"
+	AgentActionReboot      = "reboot"
+)
+
+const (
+	AgentExitUser         = "user"
+	AgentExitTimeout      = "timeout"
+	AgentExitDisconnected = "disconnected"
+	AgentExitError        = "error"
+)
+
+const (
+	PipelineActionPush = "push"
+	PipelineActionPull = "pull"
+)
+
+const (
+	SkillActionInstall = "install"
+	SkillActionUpdate  = "update"
+	SkillActionRemove  = "remove"
+)
+
+const (
+	SkillScopeGlobal  = "global"
+	SkillScopeProject = "project"
+)

--- a/internal/analytics/integration_test.go
+++ b/internal/analytics/integration_test.go
@@ -57,6 +57,7 @@ func TestPipeline_EndToEnd(t *testing.T) {
 		t.Fatalf("NewValidator: %v", err)
 	}
 	logger, err := fus.NewLogger(
+		t.Context(),
 		fus.RecorderConfig{
 			RecorderID:      RecorderID,
 			RecorderVersion: RecorderVersion,

--- a/internal/analytics/integration_test.go
+++ b/internal/analytics/integration_test.go
@@ -1,0 +1,148 @@
+package analytics
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	fus "github.com/JetBrains/fus-reporting-api-go"
+)
+
+// TestPipeline_EndToEnd exercises the whole client against a local mock that
+// stands in for the FUS config + send endpoints. It validates that:
+//
+//   - boot succeeds when given a fake FUSConfig (no network involved)
+//   - TrackSession + TrackCommand both reach the wire
+//   - emitted JSON carries the expected product/recorder identity, anonymized
+//     device + session, and our group/event/data fields
+//
+// This is the local equivalent of the staging probe described in DO-A-610 —
+// it does not need network access.
+func TestPipeline_EndToEnd(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		captured []byte
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		captured = body
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	// Build a client and override its boot so it uses our mock config.
+	c := New(Config{
+		CLIVersion: "0.1.0-test",
+		Session: &Session{
+			ID:         "11111111-2222-4333-8444-555555555555",
+			IsNew:      true,
+			LastActive: time.Now(),
+		},
+		Environment: Environment{OS: "darwin", Arch: "arm64", CISystem: CINone, AIAgent: "none"},
+		AuthSource:  AuthSourceNone,
+	})
+
+	// Inject a logger built with a stubbed FUSConfig so no network is needed.
+	validator, err := fus.NewValidator(Scheme)
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+	logger, err := fus.NewLogger(
+		fus.RecorderConfig{
+			RecorderID:      RecorderID,
+			RecorderVersion: RecorderVersion,
+			ProductCode:     ProductCode,
+			BuildVersion:    "0.1.0-test",
+			DataDir:         t.TempDir(),
+			DeviceID:        "test-device",
+		},
+		fus.WithFUSConfig(&fus.FUSConfig{SendEndpoint: server.URL, Salt: "test-salt"}),
+		fus.WithValidator(validator),
+	)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+	c.logger = logger
+	c.bootOnce.Do(func() {})
+
+	c.TrackSession()
+	c.TrackCommand(CommandEvent{
+		Command:    "run.start",
+		HasJSON:    true,
+		FlagCount:  2,
+		ExitCode:   0,
+		DurationMS: 1500,
+	})
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	mu.Lock()
+	body := captured
+	mu.Unlock()
+	if body == nil {
+		t.Fatal("no events captured at mock send endpoint")
+	}
+
+	var report fus.Report
+	if err := json.Unmarshal(body, &report); err != nil {
+		t.Fatalf("invalid report JSON: %v", err)
+	}
+	if len(report.Events) != 2 {
+		t.Fatalf("expected 2 events (session + command), got %d", len(report.Events))
+	}
+
+	for _, e := range report.Events {
+		if e.Product != ProductCode {
+			t.Errorf("product = %q, want %q", e.Product, ProductCode)
+		}
+		if e.Recorder.ID != RecorderID {
+			t.Errorf("recorder.id = %q, want %q", e.Recorder.ID, RecorderID)
+		}
+		if e.IDs["device"] == "" {
+			t.Error("device id empty")
+		}
+		if e.Session == "" {
+			t.Error("wire session empty")
+		}
+	}
+
+	// Verify each group landed and the command event carries our enums.
+	var gotSession, gotCommand bool
+	for _, e := range report.Events {
+		switch e.Group.ID {
+		case GroupSession:
+			gotSession = true
+			if !e.Group.State {
+				t.Error("session event must have state=true")
+			}
+			if e.Event.Data["ai_agent"] != "none" {
+				t.Errorf("session ai_agent = %v, want none", e.Event.Data["ai_agent"])
+			}
+		case GroupCommand:
+			gotCommand = true
+			if e.Event.Data["command"] != "run.start" {
+				t.Errorf("command field = %v, want run.start", e.Event.Data["command"])
+			}
+			if e.Event.Data["exit_code"] != "0" {
+				t.Errorf("exit_code = %v, want 0", e.Event.Data["exit_code"])
+			}
+		}
+	}
+	if !gotSession {
+		t.Error("session event missing from captured payload")
+	}
+	if !gotCommand {
+		t.Error("command event missing from captured payload")
+	}
+}

--- a/internal/analytics/notice.go
+++ b/internal/analytics/notice.go
@@ -1,0 +1,23 @@
+package analytics
+
+import (
+	"fmt"
+	"io"
+)
+
+const NoticeText = `Anonymous usage statistics help improve TeamCity CLI.
+To disable: teamcity config set analytics false
+            or set DO_NOT_TRACK=1
+Learn more: https://jb.gg/tc/analytics
+Data collection terms: https://www.jetbrains.com/legal/docs/terms/product_data_collection/
+
+`
+
+// PrintFirstRunNotice writes the one-time notice; suppressed when shown, opted out, quiet, or no-input.
+func PrintFirstRunNotice(errOut io.Writer, alreadyShown, optedOut, quiet, noInput bool) bool {
+	if alreadyShown || optedOut || quiet || noInput {
+		return false
+	}
+	_, _ = fmt.Fprint(errOut, NoticeText)
+	return true
+}

--- a/internal/analytics/optout.go
+++ b/internal/analytics/optout.go
@@ -1,0 +1,94 @@
+package analytics
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	EnvAnalytics  = "TEAMCITY_ANALYTICS"
+	EnvDoNotTrack = "DO_NOT_TRACK"
+	EnvStaging    = "TEAMCITY_ANALYTICS_STAGING"
+	EnvSalt       = "TEAMCITY_ANALYTICS_SALT"
+)
+
+const (
+	ConfigKey      = "analytics"
+	NoticeShownKey = "analytics_notice_shown"
+)
+
+type OptOutReason string
+
+const (
+	OptOutNone       OptOutReason = ""
+	OptOutDoNotTrack OptOutReason = "DO_NOT_TRACK"
+	OptOutEnv        OptOutReason = "TEAMCITY_ANALYTICS=0"
+	OptOutConfig     OptOutReason = "config: analytics=false"
+)
+
+// IsEnabled reports whether analytics tracking is on; precedence: DO_NOT_TRACK > TEAMCITY_ANALYTICS > config > on.
+func IsEnabled(configEnabled bool) (bool, OptOutReason) {
+	if isTruthy(os.Getenv(EnvDoNotTrack)) {
+		return false, OptOutDoNotTrack
+	}
+	if v := os.Getenv(EnvAnalytics); v != "" && !isTruthy(v) {
+		return false, OptOutEnv
+	}
+	if !configEnabled {
+		return false, OptOutConfig
+	}
+	return true, OptOutNone
+}
+
+func isTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// IsStaging reports whether to route events to the FUS staging endpoint.
+func IsStaging() bool {
+	return isTruthy(os.Getenv(EnvStaging))
+}
+
+// Salt returns the anonymization salt from $TEAMCITY_ANALYTICS_SALT, empty if unset.
+func Salt() string {
+	return os.Getenv(EnvSalt)
+}
+
+// DataDir returns ($XDG_CONFIG_HOME|~/.config)/tc/.analytics, creating it if missing.
+func DataDir() (string, error) {
+	base, err := configHomeBase()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(base, "tc", ".analytics")
+	return dir, os.MkdirAll(dir, 0o700)
+}
+
+// SessionFilePath returns the persisted application-session record path.
+func SessionFilePath() (string, error) {
+	base, err := configHomeBase()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(base, "tc")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, ".session"), nil
+}
+
+func configHomeBase() (string, error) {
+	if base := os.Getenv("XDG_CONFIG_HOME"); base != "" {
+		return base, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config"), nil
+}

--- a/internal/analytics/optout_test.go
+++ b/internal/analytics/optout_test.go
@@ -1,0 +1,50 @@
+package analytics
+
+import "testing"
+
+func TestIsEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		envDoNot    string
+		envTC       string
+		configEnabl bool
+		wantEnabled bool
+		wantReason  OptOutReason
+	}{
+		{"all defaults on", "", "", true, true, OptOutNone},
+		{"do not track wins", "1", "", true, false, OptOutDoNotTrack},
+		{"do not track lowercased", "true", "", true, false, OptOutDoNotTrack},
+		{"do not track ignored when zero", "0", "", true, true, OptOutNone},
+		{"env disable wins over config on", "", "0", true, false, OptOutEnv},
+		{"env enable=1 keeps default on", "", "1", true, true, OptOutNone},
+		{"config disable", "", "", false, false, OptOutConfig},
+		{"do not track beats env=1 and config", "1", "1", true, false, OptOutDoNotTrack},
+		{"env=false beats config on", "", "false", true, false, OptOutEnv},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(EnvDoNotTrack, tc.envDoNot)
+			t.Setenv(EnvAnalytics, tc.envTC)
+			gotEnabled, gotReason := IsEnabled(tc.configEnabl)
+			if gotEnabled != tc.wantEnabled {
+				t.Errorf("IsEnabled enabled = %v, want %v", gotEnabled, tc.wantEnabled)
+			}
+			if gotReason != tc.wantReason {
+				t.Errorf("IsEnabled reason = %q, want %q", gotReason, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestIsTruthy(t *testing.T) {
+	for _, on := range []string{"1", "true", "TRUE", "yes", "Yes", "on", " on "} {
+		if !isTruthy(on) {
+			t.Errorf("isTruthy(%q) = false, want true", on)
+		}
+	}
+	for _, off := range []string{"", "0", "false", "no", "off", "anything"} {
+		if isTruthy(off) {
+			t.Errorf("isTruthy(%q) = true, want false", off)
+		}
+	}
+}

--- a/internal/analytics/scheme.go
+++ b/internal/analytics/scheme.go
@@ -1,0 +1,241 @@
+// Package analytics implements the FUS telemetry pipeline for the TeamCity CLI.
+package analytics
+
+import (
+	fus "github.com/JetBrains/fus-reporting-api-go"
+)
+
+const (
+	ProductCode     = "TCX"
+	RecorderID      = "TCX"
+	RecorderVersion = 1
+	SchemeVersion   = "1"
+)
+
+const (
+	GroupSession  = "teamcity.cli.session"
+	GroupCommand  = "teamcity.cli.command"
+	GroupAPI      = "teamcity.cli.api"
+	GroupAuth     = "teamcity.cli.auth"
+	GroupBuild    = "teamcity.cli.build"
+	GroupAgent    = "teamcity.cli.agent"
+	GroupPipeline = "teamcity.cli.pipeline"
+	GroupSkill    = "teamcity.cli.skill"
+)
+
+const groupVersion = 1
+
+const (
+	regexpUUID          = "uuid"
+	regexpSemver        = "semver"
+	regexpServerVersion = "server_version"
+	regexpInteger       = "integer"
+	enumBoolean         = "boolean"
+	enumOS              = "os"
+	enumArch            = "arch"
+	enumServerType      = "server_type"
+	enumCISystem        = "ci_system"
+	enumAuthSource      = "auth_source"
+	enumAIAgent         = "ai_agent"
+	enumSource          = "source"
+	enumExitCode        = "exit_code"
+	enumErrorType       = "error_type"
+	enumHTTPMethod      = "http_method"
+	enumAPIResource     = "api_resource"
+	enumCommand         = "command"
+	enumSkillAgent      = "skill_agent"
+)
+
+// Scheme is the canonical FUS scheme; consumed at runtime and serialized to schema.json for AP registration.
+var Scheme = &fus.Scheme{
+	Version: SchemeVersion,
+	Rules: &fus.SchemeRules{
+		Enums: map[string][]string{
+			enumBoolean:     {"true", "false"},
+			enumOS:          {"darwin", "linux", "windows", "freebsd", "other"},
+			enumArch:        {"amd64", "arm64", "386", "other"},
+			enumServerType:  {"cloud", "on_prem"},
+			enumCISystem:    {"github_actions", "gitlab", "jenkins", "circleci", "buildkite", "azure", "travis", "teamcity", "other", "none"},
+			enumAuthSource:  {"keyring", "env", "build_properties", "guest", "none"},
+			enumAIAgent:     allAIAgents(),
+			enumSource:      {"human", "agent", "ci", "build_step"},
+			enumExitCode:    {"0", "1", "2"},
+			enumErrorType:   {"auth", "permission", "not_found", "network", "validation", "read_only", "internal", "none"},
+			enumHTTPMethod:  {"GET", "POST", "PUT", "DELETE", "PATCH"},
+			enumAPIResource: {"builds", "build_types", "projects", "agents", "users", "vcs", "queue", "tests", "problems", "changes", "pipelines", "cloud", "server", "other"},
+			enumCommand:     allCommands(),
+			enumSkillAgent:  skillAgentEnum(),
+		},
+		Regexps: map[string]string{
+			regexpUUID:          `[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`,
+			regexpSemver:        `\d+\.\d+\.\d+(?:-[0-9a-zA-Z.-]+)?`,
+			regexpServerVersion: `\d{4}\.\d{1,2}(?:\.\d+)?`,
+			regexpInteger:       `\d+`,
+		},
+	},
+	Groups: []fus.GroupSchema{
+		sessionGroup(),
+		commandGroup(),
+		apiGroup(),
+		authGroup(),
+		buildGroup(),
+		agentGroup(),
+		pipelineGroup(),
+		skillGroup(),
+	},
+}
+
+func sessionGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupSession,
+		Rules: &fus.SchemeRules{
+			EventID: []string{fus.EnumExpr(EventInvoked)},
+			EventData: map[string][]string{
+				"session_id":         {fus.RegexpRefExpr(regexpUUID)},
+				"cli_version":        {fus.RegexpRefExpr(regexpSemver)},
+				"server_version":     {fus.RegexpRefExpr(regexpServerVersion)},
+				"os":                 {fus.EnumRefExpr(enumOS)},
+				"arch":               {fus.EnumRefExpr(enumArch)},
+				"server_type":        {fus.EnumRefExpr(enumServerType)},
+				"ci_system":          {fus.EnumRefExpr(enumCISystem)},
+				"auth_source":        {fus.EnumRefExpr(enumAuthSource)},
+				"ai_agent":           {fus.EnumRefExpr(enumAIAgent)},
+				"has_linked_project": {fus.EnumRefExpr(enumBoolean)},
+			},
+		},
+	}
+}
+
+func commandGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupCommand,
+		Rules: &fus.SchemeRules{
+			EventID: []string{fus.EnumExpr(EventExecuted)},
+			EventData: map[string][]string{
+				"session_id":       {fus.RegexpRefExpr(regexpUUID)},
+				"command":          {fus.EnumRefExpr(enumCommand)},
+				"source":           {fus.EnumRefExpr(enumSource)},
+				"has_json":         {fus.EnumRefExpr(enumBoolean)},
+				"has_git_context":  {fus.EnumRefExpr(enumBoolean)},
+				"has_link_context": {fus.EnumRefExpr(enumBoolean)},
+				"flag_count":       {fus.RegexpRefExpr(regexpInteger)},
+				"exit_code":        {fus.EnumRefExpr(enumExitCode)},
+				"duration_ms":      {fus.RegexpRefExpr(regexpInteger)},
+				"error_type":       {fus.EnumRefExpr(enumErrorType)},
+			},
+		},
+	}
+}
+
+func apiGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupAPI,
+		Rules: &fus.SchemeRules{
+			EventID: []string{fus.EnumExpr(EventInvoked)},
+			EventData: map[string][]string{
+				"method":       {fus.EnumRefExpr(enumHTTPMethod)},
+				"resource":     {fus.EnumRefExpr(enumAPIResource)},
+				"status_code":  {fus.RegexpRefExpr(regexpInteger)},
+				"is_paginated": {fus.EnumRefExpr(enumBoolean)},
+				"is_slurp":     {fus.EnumRefExpr(enumBoolean)},
+				"had_fields":   {fus.EnumRefExpr(enumBoolean)},
+				"had_input":    {fus.EnumRefExpr(enumBoolean)},
+			},
+		},
+	}
+}
+
+func authGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupAuth,
+		Rules: &fus.SchemeRules{
+			EventID: []string{
+				fus.EnumExpr(EventLoginCompleted, EventLoginAbandoned, EventTokenLoaded),
+			},
+			EventData: map[string][]string{
+				"method":      {fus.EnumExpr("token", "guest")},
+				"is_success":  {fus.EnumRefExpr(enumBoolean)},
+				"error_type":  {fus.EnumRefExpr(enumErrorType)},
+				"failed_step": {fus.EnumExpr("server", "token", "verify")},
+				"source":      {fus.EnumExpr("keyring", "env", "build_properties", "guest")},
+				"is_expired":  {fus.EnumRefExpr(enumBoolean)},
+			},
+		},
+	}
+}
+
+func buildGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupBuild,
+		Rules: &fus.SchemeRules{
+			EventID: []string{
+				fus.EnumExpr(EventStarted, EventWatchFinished, EventLogViewed, EventTestsViewed, EventDiffViewed),
+			},
+			EventData: map[string][]string{
+				"is_personal":       {fus.EnumRefExpr(enumBoolean)},
+				"has_local_changes": {fus.EnumRefExpr(enumBoolean)},
+				"has_branch":        {fus.EnumRefExpr(enumBoolean)},
+				"has_revision":      {fus.EnumRefExpr(enumBoolean)},
+				"param_count":       {fus.RegexpRefExpr(regexpInteger)},
+				"is_watched":        {fus.EnumRefExpr(enumBoolean)},
+				"is_dry_run":        {fus.EnumRefExpr(enumBoolean)},
+				"duration_seconds":  {fus.RegexpRefExpr(regexpInteger)},
+				"final_status":      {fus.EnumExpr("success", "failure", "error", "canceled")},
+				"had_logs":          {fus.EnumRefExpr(enumBoolean)},
+				"is_timed_out":      {fus.EnumRefExpr(enumBoolean)},
+				"mode":              {fus.EnumExpr("full", "failed", "raw", "follow")},
+				"is_from_job":       {fus.EnumRefExpr(enumBoolean)},
+				"filter":            {fus.EnumExpr("all", "failed")},
+				"had_log_diff":      {fus.EnumRefExpr(enumBoolean)},
+			},
+		},
+	}
+}
+
+func agentGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupAgent,
+		Rules: &fus.SchemeRules{
+			EventID: []string{fus.EnumExpr(EventTerminalClosed, EventExecFinished, EventStateChanged)},
+			EventData: map[string][]string{
+				"duration_seconds": {fus.RegexpRefExpr(regexpInteger)},
+				"exit_reason":      {fus.EnumExpr("user", "timeout", "disconnected", "error")},
+				"exit_code":        {fus.RegexpRefExpr(regexpInteger)},
+				"had_timeout":      {fus.EnumRefExpr(enumBoolean)},
+				"action":           {fus.EnumExpr("enable", "disable", "authorize", "deauthorize", "move", "reboot")},
+			},
+		},
+	}
+}
+
+func pipelineGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupPipeline,
+		Rules: &fus.SchemeRules{
+			EventID: []string{fus.EnumExpr(EventValidated, EventCreated, EventSynced)},
+			EventData: map[string][]string{
+				"error_count":        {fus.RegexpRefExpr(regexpInteger)},
+				"warning_count":      {fus.RegexpRefExpr(regexpInteger)},
+				"is_from_file":       {fus.EnumRefExpr(enumBoolean)},
+				"used_cached_schema": {fus.EnumRefExpr(enumBoolean)},
+				"action":             {fus.EnumExpr("push", "pull")},
+			},
+		},
+	}
+}
+
+func skillGroup() fus.GroupSchema {
+	return fus.GroupSchema{
+		ID: GroupSkill,
+		Rules: &fus.SchemeRules{
+			EventID: []string{fus.EnumExpr(EventManaged)},
+			EventData: map[string][]string{
+				"action":           {fus.EnumExpr("install", "update", "remove")},
+				"agent":            {fus.EnumRefExpr(enumSkillAgent)},
+				"scope":            {fus.EnumExpr("global", "project")},
+				"is_auto_detected": {fus.EnumRefExpr(enumBoolean)},
+				"is_success":       {fus.EnumRefExpr(enumBoolean)},
+			},
+		},
+	}
+}

--- a/internal/analytics/scheme.go
+++ b/internal/analytics/scheme.go
@@ -87,7 +87,8 @@ var Scheme = &fus.Scheme{
 
 func sessionGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupSession,
+		ID:   GroupSession,
+		Type: fus.GroupTypeState,
 		Rules: &fus.SchemeRules{
 			EventID: []string{fus.EnumExpr(EventInvoked)},
 			EventData: map[string][]string{
@@ -103,12 +104,16 @@ func sessionGroup() fus.GroupSchema {
 				"has_linked_project": {fus.EnumRefExpr(enumBoolean)},
 			},
 		},
+		AnonymizedFields: []fus.AnonymizedField{
+			{Event: EventInvoked, Fields: []string{"session_id"}},
+		},
 	}
 }
 
 func commandGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupCommand,
+		ID:   GroupCommand,
+		Type: fus.GroupTypeCounter,
 		Rules: &fus.SchemeRules{
 			EventID: []string{fus.EnumExpr(EventExecuted)},
 			EventData: map[string][]string{
@@ -124,12 +129,16 @@ func commandGroup() fus.GroupSchema {
 				"error_type":       {fus.EnumRefExpr(enumErrorType)},
 			},
 		},
+		AnonymizedFields: []fus.AnonymizedField{
+			{Event: EventExecuted, Fields: []string{"session_id"}},
+		},
 	}
 }
 
 func apiGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupAPI,
+		ID:   GroupAPI,
+		Type: fus.GroupTypeCounter,
 		Rules: &fus.SchemeRules{
 			EventID: []string{fus.EnumExpr(EventInvoked)},
 			EventData: map[string][]string{
@@ -147,7 +156,8 @@ func apiGroup() fus.GroupSchema {
 
 func authGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupAuth,
+		ID:   GroupAuth,
+		Type: fus.GroupTypeCounter,
 		Rules: &fus.SchemeRules{
 			EventID: []string{
 				fus.EnumExpr(EventLoginCompleted, EventLoginAbandoned, EventTokenLoaded),
@@ -166,7 +176,8 @@ func authGroup() fus.GroupSchema {
 
 func buildGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupBuild,
+		ID:   GroupBuild,
+		Type: fus.GroupTypeCounter,
 		Rules: &fus.SchemeRules{
 			EventID: []string{
 				fus.EnumExpr(EventStarted, EventWatchFinished, EventLogViewed, EventTestsViewed, EventDiffViewed),
@@ -194,7 +205,8 @@ func buildGroup() fus.GroupSchema {
 
 func agentGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupAgent,
+		ID:   GroupAgent,
+		Type: fus.GroupTypeCounter,
 		Rules: &fus.SchemeRules{
 			EventID: []string{fus.EnumExpr(EventTerminalClosed, EventExecFinished, EventStateChanged)},
 			EventData: map[string][]string{
@@ -210,7 +222,8 @@ func agentGroup() fus.GroupSchema {
 
 func pipelineGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupPipeline,
+		ID:   GroupPipeline,
+		Type: fus.GroupTypeCounter,
 		Rules: &fus.SchemeRules{
 			EventID: []string{fus.EnumExpr(EventValidated, EventCreated, EventSynced)},
 			EventData: map[string][]string{
@@ -226,7 +239,8 @@ func pipelineGroup() fus.GroupSchema {
 
 func skillGroup() fus.GroupSchema {
 	return fus.GroupSchema{
-		ID: GroupSkill,
+		ID:   GroupSkill,
+		Type: fus.GroupTypeCounter,
 		Rules: &fus.SchemeRules{
 			EventID: []string{fus.EnumExpr(EventManaged)},
 			EventData: map[string][]string{

--- a/internal/analytics/scheme_test.go
+++ b/internal/analytics/scheme_test.go
@@ -1,0 +1,80 @@
+package analytics
+
+import (
+	"testing"
+
+	fus "github.com/JetBrains/fus-reporting-api-go"
+)
+
+// TestScheme_BuildsValidator ensures every group/event/field in the scheme is
+// well-formed enough for fus.NewValidator to accept. A failure here usually
+// means a typo in a rule expression or a duplicated reference name.
+func TestScheme_BuildsValidator(t *testing.T) {
+	if _, err := fus.NewValidator(Scheme); err != nil {
+		t.Fatalf("fus.NewValidator(Scheme): %v", err)
+	}
+}
+
+func TestScheme_HasAllExpectedGroups(t *testing.T) {
+	want := map[string]bool{
+		GroupSession: false, GroupCommand: false, GroupAPI: false,
+		GroupAuth: false, GroupBuild: false,
+		GroupAgent: false, GroupPipeline: false, GroupSkill: false,
+	}
+	for _, g := range Scheme.Groups {
+		if _, ok := want[g.ID]; ok {
+			want[g.ID] = true
+		} else {
+			t.Errorf("scheme contains unexpected group %q", g.ID)
+		}
+	}
+	for id, present := range want {
+		if !present {
+			t.Errorf("scheme missing expected group %q", id)
+		}
+	}
+}
+
+// TestScheme_FlatGroupsRespectFieldCap covers groups where every declared field
+// is sent on every event (session, command, api). Multi-event groups (build,
+// auth, agent, etc.) declare a union of fields across events, so they are
+// excluded — Track() enforces the per-event 10-field cap at runtime.
+func TestScheme_FlatGroupsRespectFieldCap(t *testing.T) {
+	flat := map[string]bool{
+		GroupSession: true,
+		GroupCommand: true,
+		GroupAPI:     true,
+	}
+	for _, g := range Scheme.Groups {
+		if !flat[g.ID] || g.Rules == nil {
+			continue
+		}
+		if n := len(g.Rules.EventData); n > fus.MaxDataFields {
+			t.Errorf("flat group %q declares %d fields, exceeds FUS cap of %d", g.ID, n, fus.MaxDataFields)
+		}
+	}
+}
+
+func TestNormalizeCommand(t *testing.T) {
+	if got := NormalizeCommand("run.start"); got != "run.start" {
+		t.Errorf("known command: got %q, want run.start", got)
+	}
+	if got := NormalizeCommand("never.heard.of"); got != "other" {
+		t.Errorf("unknown command: got %q, want other", got)
+	}
+}
+
+func TestNormalizeAIAgent(t *testing.T) {
+	cases := map[string]string{
+		"":               "none",
+		"claude-code":    "claude_code",
+		"junie":          "junie",
+		"github-copilot": "github_copilot",
+		"some-new-thing": "other",
+	}
+	for in, want := range cases {
+		if got := NormalizeAIAgent(in); got != want {
+			t.Errorf("NormalizeAIAgent(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/analytics/server_info.go
+++ b/internal/analytics/server_info.go
@@ -1,0 +1,78 @@
+package analytics
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// ServerInfo is the telemetry-only cache of TC server context, keyed by server URL.
+// Lives alongside the FUS buffer in DataDir so users can wipe all telemetry state in one shot.
+type ServerInfo struct {
+	Version string `json:"version,omitempty"`
+	Type    string `json:"type,omitempty"`
+}
+
+const serverInfoFile = "server-info.json"
+
+func serverInfoPath() (string, error) {
+	dir, err := DataDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, serverInfoFile), nil
+}
+
+// LoadServerInfo returns the cached server version + type for serverURL; empty strings when unknown.
+func LoadServerInfo(serverURL string) (version, serverType string) {
+	path, err := serverInfoPath()
+	if err != nil {
+		return "", ""
+	}
+	infos, err := readServerInfo(path)
+	if err != nil {
+		return "", ""
+	}
+	info := infos[serverURL]
+	return info.Version, info.Type
+}
+
+// SaveServerInfo writes the version + type for serverURL, merging into any existing entries.
+func SaveServerInfo(serverURL, version, serverType string) error {
+	path, err := serverInfoPath()
+	if err != nil {
+		return err
+	}
+	infos, _ := readServerInfo(path)
+	if infos == nil {
+		infos = map[string]ServerInfo{}
+	}
+	infos[serverURL] = ServerInfo{Version: version, Type: serverType}
+	data, err := json.MarshalIndent(infos, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWrite(path, data)
+}
+
+// atomicWrite stages bytes to a sibling temp file then renames into place.
+// Rename is atomic on POSIX, so concurrent readers never observe a half-written file.
+func atomicWrite(path string, data []byte) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func readServerInfo(path string) (map[string]ServerInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var infos map[string]ServerInfo
+	if err := json.Unmarshal(data, &infos); err != nil {
+		return nil, err
+	}
+	return infos, nil
+}

--- a/internal/analytics/server_info_test.go
+++ b/internal/analytics/server_info_test.go
@@ -1,0 +1,30 @@
+package analytics
+
+import "testing"
+
+func TestServerInfo_RoundTrip(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	const url = "https://teamcity.example.com"
+	v, st := LoadServerInfo(url)
+	if v != "" || st != "" {
+		t.Errorf("unset cache: got (%q, %q), want empty", v, st)
+	}
+
+	if err := SaveServerInfo(url, "2025.11", "cloud"); err != nil {
+		t.Fatalf("SaveServerInfo: %v", err)
+	}
+	v, st = LoadServerInfo(url)
+	if v != "2025.11" || st != "cloud" {
+		t.Errorf("LoadServerInfo = (%q, %q), want (2025.11, cloud)", v, st)
+	}
+
+	// Saving for a different URL must not clobber the existing entry.
+	if err := SaveServerInfo("https://other.example.com", "2024.12", "on_prem"); err != nil {
+		t.Fatalf("SaveServerInfo other: %v", err)
+	}
+	v, st = LoadServerInfo(url)
+	if v != "2025.11" || st != "cloud" {
+		t.Errorf("entry overwritten by sibling: got (%q, %q)", v, st)
+	}
+}

--- a/internal/analytics/session.go
+++ b/internal/analytics/session.go
@@ -1,0 +1,79 @@
+package analytics
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+)
+
+const SessionWindow = 30 * time.Minute
+
+type Session struct {
+	ID         string    `json:"id"`
+	LastActive time.Time `json:"last_active"`
+	IsNew      bool      `json:"-"`
+}
+
+// LoadOrCreateSession reads or rotates the application session file at ~/.config/tc/.session.
+func LoadOrCreateSession(now time.Time) (*Session, error) {
+	path, err := SessionFilePath()
+	if err != nil {
+		return nil, err
+	}
+	return loadOrCreateSessionAt(path, now)
+}
+
+func loadOrCreateSessionAt(path string, now time.Time) (*Session, error) {
+	s, err := readSession(path)
+	if err != nil || s == nil || now.Sub(s.LastActive) >= SessionWindow {
+		id, err := newSessionID()
+		if err != nil {
+			return nil, err
+		}
+		s = &Session{ID: id, IsNew: true}
+	}
+	s.LastActive = now
+	if err := writeSession(path, s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func readSession(path string) (*Session, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var s Session
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, err
+	}
+	if s.ID == "" {
+		return nil, nil
+	}
+	return &s, nil
+}
+
+func writeSession(path string, s *Session) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return err
+	}
+	return atomicWrite(path, data)
+}
+
+func newSessionID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}

--- a/internal/analytics/session_test.go
+++ b/internal/analytics/session_test.go
@@ -1,0 +1,96 @@
+package analytics
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestSession_FreshCreatesNew(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".session")
+	now := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+
+	s, err := loadOrCreateSessionAt(path, now)
+	if err != nil {
+		t.Fatalf("loadOrCreateSession: %v", err)
+	}
+	if !s.IsNew {
+		t.Error("expected IsNew=true on cold start")
+	}
+	if s.ID == "" {
+		t.Error("expected non-empty session ID")
+	}
+	if !s.LastActive.Equal(now) {
+		t.Errorf("LastActive = %v, want %v", s.LastActive, now)
+	}
+}
+
+func TestSession_ReusedWithinWindow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".session")
+	t0 := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+
+	first, err := loadOrCreateSessionAt(path, t0)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+
+	// 10 minutes later — well inside the 30-min window.
+	t1 := t0.Add(10 * time.Minute)
+	second, err := loadOrCreateSessionAt(path, t1)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	if second.ID != first.ID {
+		t.Errorf("session ID changed within window: %q -> %q", first.ID, second.ID)
+	}
+	if second.IsNew {
+		t.Error("second invocation in same window should not be marked new")
+	}
+	if !second.LastActive.Equal(t1) {
+		t.Errorf("LastActive not bumped: got %v, want %v", second.LastActive, t1)
+	}
+}
+
+func TestSession_RotatesAfterWindow(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".session")
+	t0 := time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+
+	first, err := loadOrCreateSessionAt(path, t0)
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+
+	// Exactly the inactivity window — should rotate (>= comparison).
+	t1 := t0.Add(SessionWindow)
+	second, err := loadOrCreateSessionAt(path, t1)
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	if second.ID == first.ID {
+		t.Error("session ID should rotate after inactivity window")
+	}
+	if !second.IsNew {
+		t.Error("rotated session should be marked new")
+	}
+}
+
+func TestNewSessionID_Format(t *testing.T) {
+	for range 5 {
+		id, err := newSessionID()
+		if err != nil {
+			t.Fatalf("newSessionID: %v", err)
+		}
+		if len(id) != 36 {
+			t.Errorf("id length = %d, want 36 (got %q)", len(id), id)
+		}
+		if id[8] != '-' || id[13] != '-' || id[18] != '-' || id[23] != '-' {
+			t.Errorf("id %q missing dashes", id)
+		}
+		// version 4
+		if id[14] != '4' {
+			t.Errorf("id %q version nibble = %c, want 4", id, id[14])
+		}
+	}
+}

--- a/internal/analytics/staging_send_test.go
+++ b/internal/analytics/staging_send_test.go
@@ -37,6 +37,7 @@ func TestStagingRealSend(t *testing.T) {
 
 	dir := t.TempDir()
 	logger, err := fus.NewLogger(
+		t.Context(),
 		fus.RecorderConfig{
 			RecorderID:        RecorderID,
 			RecorderVersion:   RecorderVersion,

--- a/internal/analytics/staging_send_test.go
+++ b/internal/analytics/staging_send_test.go
@@ -1,0 +1,70 @@
+//go:build staging
+
+package analytics
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	fus "github.com/JetBrains/fus-reporting-api-go"
+)
+
+// TestStagingRealSend posts every declared event to the FUS staging endpoint.
+// Gated by build tag `staging`; run with:
+//
+//	go test -tags=staging -count=1 -run TestStagingRealSend ./internal/analytics/...
+func TestStagingRealSend(t *testing.T) {
+	stagingCfg, err := fus.FetchTestConfig(RecorderID, ProductCode)
+	if err != nil {
+		t.Logf("FetchTestConfig: %v — falling back to direct send URL", err)
+		stagingCfg = &fus.FUSConfig{SendEndpoint: "https://stgn.fus-stgn.aws.intellij.net/tcx/v4/send/"}
+	}
+	t.Logf("staging endpoint: %s", stagingCfg.SendEndpoint)
+
+	salt := os.Getenv(EnvSalt)
+	if salt == "" {
+		salt = "tcx-staging-probe-placeholder"
+		t.Logf("using placeholder salt; set %s to override", EnvSalt)
+	}
+
+	validator, err := fus.NewValidator(Scheme)
+	if err != nil {
+		t.Fatalf("NewValidator: %v", err)
+	}
+
+	dir := t.TempDir()
+	logger, err := fus.NewLogger(
+		fus.RecorderConfig{
+			RecorderID:        RecorderID,
+			RecorderVersion:   RecorderVersion,
+			ProductCode:       ProductCode,
+			BuildVersion:      "0.0.1-staging-probe",
+			DataDir:           dir,
+			AnonymizationSalt: salt,
+		},
+		fus.WithFUSConfig(stagingCfg),
+		fus.WithValidator(validator),
+	)
+	if err != nil {
+		t.Fatalf("NewLogger: %v", err)
+	}
+
+	for _, ev := range SampleEvents() {
+		logger.Track(ev.Group, ev.Event.ID, ev.Event.Data)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	if err := logger.Flush(ctx); err != nil {
+		t.Fatalf("flush to staging: %v", err)
+	}
+
+	if info, err := os.Stat(dir + "/fus_buffer.jsonl"); err == nil && info.Size() != 0 {
+		t.Errorf("buffer non-empty after flush (%d bytes) — server may have rejected some events", info.Size())
+	}
+
+	fmt.Printf("\n[staging probe] sent %d events to %s\n", len(SampleEvents()), stagingCfg.SendEndpoint)
+}

--- a/internal/analytics/validate.go
+++ b/internal/analytics/validate.go
@@ -1,0 +1,167 @@
+package analytics
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	fus "github.com/JetBrains/fus-reporting-api-go"
+)
+
+// SchemeFinding is a single client-side-validation diagnostic against a sample event.
+type SchemeFinding struct {
+	Group string
+	Event string
+	Field string // empty when the diagnostic is on event.id
+	Got   string // a "validation.*" sentinel
+}
+
+func (f SchemeFinding) String() string {
+	loc := f.Group + "/" + f.Event
+	if f.Field != "" {
+		loc += "." + f.Field
+	}
+	return loc + " → " + f.Got
+}
+
+// SampleEvents returns one canonical event per (group, event_id) covering every declared field.
+func SampleEvents() []fus.LogEvent {
+	build := "0.0.1"
+	now := time.Now().UnixMilli()
+	mk := func(group, eventID string, state bool, data map[string]any) fus.LogEvent {
+		return fus.LogEvent{
+			Recorder: fus.Recorder{ID: RecorderID, Version: RecorderVersion},
+			Product:  ProductCode,
+			Build:    build,
+			Time:     now,
+			Group:    fus.EventGroup{ID: group, Version: groupVersion, State: state},
+			Event:    fus.EventAction{ID: eventID, Data: data, Count: 1},
+		}
+	}
+	const sid = "00000000-0000-4000-8000-000000000000"
+	return []fus.LogEvent{
+		mk(GroupSession, EventInvoked, true, map[string]any{
+			"session_id":         sid,
+			"cli_version":        "0.0.1",
+			"server_version":     "2024.12",
+			"os":                 "darwin",
+			"arch":               "arm64",
+			"server_type":        ServerTypeCloud,
+			"ci_system":          CINone,
+			"auth_source":        AuthSourceNone,
+			"ai_agent":           "claude_code",
+			"has_linked_project": true,
+		}),
+		mk(GroupCommand, EventExecuted, false, map[string]any{
+			"session_id":       sid,
+			"command":          "run.start",
+			"source":           SourceAgent,
+			"has_json":         true,
+			"has_git_context":  false,
+			"has_link_context": true,
+			"flag_count":       3,
+			"exit_code":        "0",
+			"duration_ms":      1234,
+			"error_type":       ErrorNone,
+		}),
+		mk(GroupAPI, EventInvoked, false, map[string]any{
+			"method": "GET", "resource": "builds", "status_code": 200,
+			"is_paginated": false, "is_slurp": false, "had_fields": false, "had_input": false,
+		}),
+		mk(GroupAuth, EventLoginCompleted, false, map[string]any{
+			"method": AuthMethodToken, "is_success": true, "error_type": ErrorNone,
+		}),
+		mk(GroupAuth, EventLoginAbandoned, false, map[string]any{
+			"method": AuthMethodToken, "failed_step": AuthStepVerify,
+		}),
+		mk(GroupAuth, EventTokenLoaded, false, map[string]any{
+			"source": AuthSourceKeyring, "is_expired": false,
+		}),
+		mk(GroupBuild, EventStarted, false, map[string]any{
+			"is_personal": true, "has_local_changes": true, "has_branch": false,
+			"has_revision": false, "param_count": 0, "is_watched": true, "is_dry_run": false,
+		}),
+		mk(GroupBuild, EventWatchFinished, false, map[string]any{
+			"duration_seconds": 60, "final_status": BuildStatusSuccess, "had_logs": true, "is_timed_out": false,
+		}),
+		mk(GroupBuild, EventLogViewed, false, map[string]any{
+			"mode": LogModeFailed, "is_from_job": false,
+		}),
+		mk(GroupBuild, EventTestsViewed, false, map[string]any{
+			"filter": TestsFilterFailed, "is_from_job": false,
+		}),
+		mk(GroupBuild, EventDiffViewed, false, map[string]any{
+			"had_log_diff": true,
+		}),
+		mk(GroupAgent, EventTerminalClosed, false, map[string]any{
+			"duration_seconds": 30, "exit_reason": AgentExitUser,
+		}),
+		mk(GroupAgent, EventExecFinished, false, map[string]any{
+			"duration_seconds": 5, "exit_code": 0, "had_timeout": false,
+		}),
+		mk(GroupAgent, EventStateChanged, false, map[string]any{
+			"action": AgentActionEnable,
+		}),
+		mk(GroupPipeline, EventValidated, false, map[string]any{
+			"error_count": 0, "warning_count": 1, "is_from_file": true, "used_cached_schema": true,
+		}),
+		mk(GroupPipeline, EventCreated, false, map[string]any{
+			"is_from_file": true,
+		}),
+		mk(GroupPipeline, EventSynced, false, map[string]any{
+			"action": PipelineActionPush,
+		}),
+		mk(GroupSkill, EventManaged, false, map[string]any{
+			"action": SkillActionInstall, "agent": "claude_code", "scope": SkillScopeProject,
+			"is_auto_detected": true, "is_success": true,
+		}),
+	}
+}
+
+// LintScheme runs every SampleEvents entry through the Scheme validator and returns any sentinels emitted.
+func LintScheme() ([]SchemeFinding, error) {
+	v, err := fus.NewValidator(Scheme)
+	if err != nil {
+		return nil, fmt.Errorf("build validator: %w", err)
+	}
+	var findings []SchemeFinding
+	for _, e := range SampleEvents() {
+		validated, drop := v.Validate(e)
+		if drop {
+			findings = append(findings, SchemeFinding{
+				Group: e.Group.ID, Event: e.Event.ID,
+				Got: "dropped (build/version filter)",
+			})
+			continue
+		}
+		if isSentinel(validated.Event.ID) {
+			findings = append(findings, SchemeFinding{
+				Group: e.Group.ID, Event: e.Event.ID, Got: validated.Event.ID,
+			})
+		}
+		keys := make([]string, 0, len(validated.Event.Data))
+		for k := range validated.Event.Data {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			if isSentinel(k) {
+				findings = append(findings, SchemeFinding{
+					Group: e.Group.ID, Event: e.Event.ID, Field: "(unknown key)", Got: k,
+				})
+				continue
+			}
+			if s, ok := validated.Event.Data[k].(string); ok && isSentinel(s) {
+				findings = append(findings, SchemeFinding{
+					Group: e.Group.ID, Event: e.Event.ID, Field: k, Got: s,
+				})
+			}
+		}
+	}
+	return findings, nil
+}
+
+func isSentinel(s string) bool {
+	return strings.HasPrefix(s, "validation.")
+}

--- a/internal/analytics/validate_test.go
+++ b/internal/analytics/validate_test.go
@@ -1,0 +1,14 @@
+package analytics
+
+import "testing"
+
+// TestLintScheme asserts every reference event in SampleEvents passes the client-side validator with no sentinels.
+func TestLintScheme(t *testing.T) {
+	findings, err := LintScheme()
+	if err != nil {
+		t.Fatalf("LintScheme: %v", err)
+	}
+	for _, f := range findings {
+		t.Errorf("scheme drift: %s", f)
+	}
+}

--- a/internal/cmd/agent/agent_reboot.go
+++ b/internal/cmd/agent/agent_reboot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -43,6 +44,7 @@ func runAgentMove(f *cmdutil.Factory, nameOrID string, poolID int) error {
 		return fmt.Errorf("failed to move agent: %w", err)
 	}
 
+	f.Analytics.Track(analytics.GroupAgent, analytics.EventStateChanged, map[string]any{"action": analytics.AgentActionMove})
 	f.Printer.Success("Moved agent %s to pool %d", agentName, poolID)
 	return nil
 }
@@ -114,6 +116,8 @@ func runAgentReboot(f *cmdutil.Factory, ctx context.Context, nameOrID string, op
 	if err := client.RebootAgent(ctx, agentID, opts.graceful); err != nil {
 		return fmt.Errorf("failed to reboot agent: %w", err)
 	}
+
+	f.Analytics.Track(analytics.GroupAgent, analytics.EventStateChanged, map[string]any{"action": analytics.AgentActionReboot})
 
 	if opts.graceful {
 		f.Printer.Success("Reboot scheduled for %s", agentName)

--- a/internal/cmd/agent/agent_state.go
+++ b/internal/cmd/agent/agent_state.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +48,7 @@ func newAgentActionCmd(f *cmdutil.Factory, a agentAction) *cobra.Command {
 			if err := a.execute(client, agentID); err != nil {
 				return fmt.Errorf("failed to %s agent: %w", a.use, err)
 			}
+			f.Analytics.Track(analytics.GroupAgent, analytics.EventStateChanged, map[string]any{"action": a.use})
 			f.Printer.Success("%s agent %s", a.verb, agentName)
 			return nil
 		},

--- a/internal/cmd/agent/terminal.go
+++ b/internal/cmd/agent/terminal.go
@@ -2,11 +2,13 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
@@ -33,9 +35,27 @@ or the connection drops.`,
 			if err != nil {
 				return err
 			}
-			return conn.RunInteractive(cmd.Context())
+			start := time.Now()
+			termErr := conn.RunInteractive(cmd.Context())
+			f.Analytics.Track(analytics.GroupAgent, analytics.EventTerminalClosed, map[string]any{
+				"duration_seconds": int(time.Since(start).Seconds()),
+				"exit_reason":      terminalExitReason(termErr, cmd.Context().Err()),
+			})
+			return termErr
 		},
 	}
+}
+
+func terminalExitReason(termErr, ctxErr error) string {
+	switch {
+	case termErr == nil:
+		return analytics.AgentExitUser
+	case errors.Is(ctxErr, context.DeadlineExceeded):
+		return analytics.AgentExitTimeout
+	case errors.Is(ctxErr, context.Canceled):
+		return analytics.AgentExitUser
+	}
+	return analytics.AgentExitError
 }
 
 func newAgentExecCmd(f *cmdutil.Factory) *cobra.Command {
@@ -61,7 +81,21 @@ agent-side commands from teamcity flags.`,
 			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
 			defer cancel()
 
-			return conn.Exec(ctx, strings.Join(args[1:], " "))
+			start := time.Now()
+			execErr := conn.Exec(ctx, strings.Join(args[1:], " "))
+			exitCode := 0
+			if execErr != nil {
+				exitCode = 1
+				if ee, ok := errors.AsType[*cmdutil.ExitError](execErr); ok {
+					exitCode = ee.Code
+				}
+			}
+			f.Analytics.Track(analytics.GroupAgent, analytics.EventExecFinished, map[string]any{
+				"duration_seconds": int(time.Since(start).Seconds()),
+				"exit_code":        exitCode,
+				"had_timeout":      errors.Is(ctx.Err(), context.DeadlineExceeded),
+			})
+			return execErr
 		},
 	}
 

--- a/internal/cmd/analytics.go
+++ b/internal/cmd/analytics.go
@@ -1,0 +1,192 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/JetBrains/teamcity-cli/internal/version"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// setupAnalytics computes opt-out, prints first-run notice, opens the session, and attaches a Client to f.
+// f.Analytics stays nil when opted out — every Track* method is nil-safe.
+func setupAnalytics(f *cmdutil.Factory) {
+	enabled, reason := analytics.IsEnabled(config.IsAnalyticsEnabled())
+
+	if enabled && !config.IsAnalyticsNoticeShown() {
+		if analytics.PrintFirstRunNotice(f.Printer.ErrOut, false, false, f.Quiet, f.NoInput) {
+			_ = config.MarkAnalyticsNoticeShown()
+		}
+	}
+
+	if !enabled {
+		f.Printer.Debug("analytics: disabled (%s)", reason)
+		return
+	}
+
+	session, err := analytics.LoadOrCreateSession(time.Now())
+	if err != nil {
+		f.Printer.Debug("analytics: disabled (session error: %v)", err)
+		return
+	}
+
+	env := analytics.DetectEnvironment()
+	authSource := detectAuthSourceForAnalytics()
+	serverVersion, serverType := analytics.LoadServerInfo(config.GetServerURL())
+	f.Analytics = analytics.New(analytics.Config{
+		CLIVersion:       version.String(),
+		AuthSource:       authSource,
+		Session:          session,
+		Environment:      env,
+		ServerVersion:    serverVersion,
+		ServerType:       serverType,
+		HasLinkedProject: false,
+		Staging:          analytics.IsStaging(),
+		Salt:             analytics.Salt(),
+		Debug:            f.Printer.Debug,
+	})
+	f.Printer.Debug("analytics: enabled (session=%s new=%v source=%s ai_agent=%s ci=%s staging=%v)",
+		session.ID, session.IsNew, analytics.ClassifySource(env), env.AIAgent, env.CISystem, analytics.IsStaging())
+	f.Analytics.TrackSession()
+	if session.IsNew && authSource != analytics.AuthSourceNone {
+		f.Analytics.Track(analytics.GroupAuth, analytics.EventTokenLoaded, map[string]any{
+			"source":     authSource,
+			"is_expired": isTokenExpired(),
+		})
+	}
+}
+
+func isTokenExpired() bool {
+	exp := config.GetTokenExpiry()
+	if exp == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, exp)
+	if err != nil {
+		return false
+	}
+	return time.Now().After(t)
+}
+
+// trackAndFlushAnalytics emits the per-command counter event and flushes the FUS buffer.
+func trackAndFlushAnalytics(f *cmdutil.Factory, executedCmd *cobra.Command, runErr error) {
+	if f.Analytics == nil {
+		return
+	}
+	defer func() { _ = f.Analytics.Close() }()
+
+	if executedCmd == nil {
+		return
+	}
+
+	f.Analytics.TrackCommand(analytics.CommandEvent{
+		Command:        commandPathForAnalytics(executedCmd),
+		HasJSON:        flagBool(executedCmd, "json"),
+		HasGitContext:  detectGitContext(executedCmd),
+		HasLinkContext: false,
+		FlagCount:      countSetFlags(executedCmd),
+		ExitCode:       exitCodeFromError(runErr),
+		DurationMS:     time.Since(f.StartTime).Milliseconds(),
+		ErrorType:      errorTypeFromError(runErr),
+	})
+}
+
+// commandPathForAnalytics joins the cobra command path with dots, dropping the binary name.
+func commandPathForAnalytics(cmd *cobra.Command) string {
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) <= 1 {
+		return "other"
+	}
+	return strings.Join(parts[1:], ".")
+}
+
+func exitCodeFromError(err error) int {
+	if err == nil {
+		return 0
+	}
+	if ee, ok := errors.AsType[*cmdutil.ExitError](err); ok {
+		return ee.Code
+	}
+	return 1
+}
+
+// errorTypeFromError reuses output.ClassifyError's walk so the analytics enum always tracks the user-facing classification.
+func errorTypeFromError(err error) string {
+	if err == nil {
+		return analytics.ErrorNone
+	}
+	code, _, _ := output.ClassifyError(err)
+	switch code {
+	case output.ErrCodeReadOnly:
+		return analytics.ErrorReadOnly
+	case output.ErrCodeAuth:
+		return analytics.ErrorAuth
+	case output.ErrCodePermission:
+		return analytics.ErrorPermission
+	case output.ErrCodeNotFound:
+		return analytics.ErrorNotFound
+	case output.ErrCodeNetwork:
+		return analytics.ErrorNetwork
+	case output.ErrCodeValidation:
+		return analytics.ErrorValidation
+	default:
+		return analytics.ErrorInternal
+	}
+}
+
+func flagBool(cmd *cobra.Command, name string) bool {
+	f := cmd.Flags().Lookup(name)
+	if f == nil || !f.Changed {
+		return false
+	}
+	if f.Value.Type() == "bool" {
+		return f.Value.String() == "true"
+	}
+	return f.Value.String() != ""
+}
+
+// detectGitContext reports whether the command was invoked with --local-changes, --branch=@this, or --revision=@head.
+func detectGitContext(cmd *cobra.Command) bool {
+	if flagBool(cmd, "local-changes") {
+		return true
+	}
+	for _, name := range []string{"branch", "revision"} {
+		f := cmd.Flags().Lookup(name)
+		if f == nil || !f.Changed {
+			continue
+		}
+		v := strings.ToLower(strings.TrimSpace(f.Value.String()))
+		if v == "@this" || v == "@head" {
+			return true
+		}
+	}
+	return false
+}
+
+func countSetFlags(cmd *cobra.Command) int {
+	n := 0
+	cmd.Flags().Visit(func(_ *pflag.Flag) { n++ })
+	return n
+}
+
+// detectAuthSourceForAnalytics maps the existing config token-source string to the wire enum.
+func detectAuthSourceForAnalytics() string {
+	if config.IsGuestAuth() {
+		return analytics.AuthSourceGuest
+	}
+	_, source, _ := config.GetTokenWithSource()
+	switch source {
+	case "env":
+		return analytics.AuthSourceEnv
+	case "keyring", "config":
+		return analytics.AuthSourceKeyring
+	default:
+		return analytics.AuthSourceNone
+	}
+}

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -158,15 +159,48 @@ func runAPI(f *cmdutil.Factory, endpoint string, opts *apiOptions) error {
 	}
 
 	if opts.paginate {
-		return runAPIPaginated(f.Printer, client, endpoint, headers, opts)
+		err := runAPIPaginated(f.Printer, client, endpoint, headers, opts)
+		f.Analytics.TrackAPI(analytics.APIEvent{
+			Method:     opts.method,
+			Endpoint:   endpoint,
+			StatusCode: statusCodeForTracking(err, http.StatusOK),
+			Paginated:  true,
+			Slurp:      opts.slurp,
+			HadFields:  len(opts.fields) > 0,
+			HadInput:   opts.input != "",
+		})
+		return err
 	}
 
 	resp, err := client.RawRequest(context.Background(), opts.method, endpoint, body, headers)
+	f.Analytics.TrackAPI(analytics.APIEvent{
+		Method:     opts.method,
+		Endpoint:   endpoint,
+		StatusCode: statusCodeForTracking(err, statusCodeOf(resp)),
+		Paginated:  false,
+		Slurp:      false,
+		HadFields:  len(opts.fields) > 0,
+		HadInput:   opts.input != "",
+	})
 	if err != nil {
 		return err
 	}
 
 	return outputAPIResponse(f.Printer, resp.Body, resp.StatusCode, resp.Headers, opts)
+}
+
+func statusCodeOf(r *api.RawResponse) int {
+	if r == nil {
+		return 0
+	}
+	return r.StatusCode
+}
+
+func statusCodeForTracking(err error, observed int) int {
+	if err != nil && observed == 0 {
+		return 0
+	}
+	return observed
 }
 
 func runAPIPaginated(p *output.Printer, client api.ClientInterface, endpoint string, headers map[string]string, opts *apiOptions) error {

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -3,11 +3,15 @@ package auth
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
@@ -72,7 +76,9 @@ build-level credentials from the build properties file.`,
 	return cmd
 }
 
-func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage bool, noBrowser bool) error {
+func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage bool, noBrowser bool) (err error) {
+	defer func() { trackLoginOutcome(f, analytics.AuthMethodToken, err) }()
+
 	isInteractive := f.IsInteractive()
 
 	p := f.Printer
@@ -185,6 +191,8 @@ func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage b
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 
+	cacheServerInfo(serverURL, client)
+
 	p.Success("Logged in as %s", output.Cyan(user.Name))
 	if insecureFallback {
 		_, _ = fmt.Fprintf(p.Out, "%s Token stored in plain text at %s\n", output.Yellow("!"), config.ConfigPath())
@@ -200,7 +208,9 @@ func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage b
 	return nil
 }
 
-func runAuthLoginGuest(f *cmdutil.Factory, serverURL, token string) error {
+func runAuthLoginGuest(f *cmdutil.Factory, serverURL, token string) (err error) {
+	defer func() { trackLoginOutcome(f, analytics.AuthMethodGuest, err) }()
+
 	if token != "" {
 		return api.Validation(
 			"cannot use --guest with --token",
@@ -244,6 +254,8 @@ func runAuthLoginGuest(f *cmdutil.Factory, serverURL, token string) error {
 	if err := config.SetGuestServer(serverURL); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
+
+	_ = analytics.SaveServerInfo(serverURL, formatServerVersion(server), classifyServerType(server))
 
 	p.Success("Guest access to %s", output.Cyan(serverURL))
 	_, _ = fmt.Fprintf(p.Out, "  Server: TeamCity %d.%d (build %s)\n", server.VersionMajor, server.VersionMinor, server.BuildNumber)
@@ -298,4 +310,64 @@ func runPkceLogin(p *output.Printer, serverURL string) (*api.TokenResponse, erro
 	case <-time.After(authCodeLifetime):
 		return nil, fmt.Errorf("timeout waiting for callback (exceeded %v)", authCodeLifetime)
 	}
+}
+
+// trackLoginOutcome emits one login.completed event (and login.abandoned on user interrupt).
+func trackLoginOutcome(f *cmdutil.Factory, method string, err error) {
+	if errors.Is(err, terminal.InterruptErr) {
+		f.Analytics.Track(analytics.GroupAuth, analytics.EventLoginAbandoned, map[string]any{
+			"method":      method,
+			"failed_step": analytics.AuthStepToken,
+		})
+		return
+	}
+	f.Analytics.Track(analytics.GroupAuth, analytics.EventLoginCompleted, map[string]any{
+		"method":     method,
+		"is_success": err == nil,
+		"error_type": loginErrorType(err),
+	})
+}
+
+// cacheServerInfo best-effort persists TC version + cloud/on-prem for the analytics session event.
+// Failures are silently ignored — telemetry must never block login.
+func cacheServerInfo(serverURL string, client *api.Client) {
+	server, err := client.GetServer()
+	if err != nil {
+		return
+	}
+	_ = analytics.SaveServerInfo(serverURL, formatServerVersion(server), classifyServerType(server))
+}
+
+func formatServerVersion(s *api.Server) string {
+	if s.VersionMajor == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d", s.VersionMajor, s.VersionMinor)
+}
+
+func classifyServerType(s *api.Server) string {
+	if strings.HasPrefix(s.InternalID, "cloud-") {
+		return analytics.ServerTypeCloud
+	}
+	return analytics.ServerTypeOnPrem
+}
+
+func loginErrorType(err error) string {
+	if err == nil {
+		return analytics.ErrorNone
+	}
+	var ue api.UserError
+	if errors.As(err, &ue) {
+		switch ue.Category() {
+		case api.CatAuth:
+			return analytics.ErrorAuth
+		case api.CatNetwork:
+			return analytics.ErrorNetwork
+		case api.CatPermission:
+			return analytics.ErrorPermission
+		case api.CatValidation:
+			return analytics.ErrorValidation
+		}
+	}
+	return analytics.ErrorInternal
 }

--- a/internal/cmd/pipeline/create.go
+++ b/internal/cmd/pipeline/create.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -64,6 +65,7 @@ func runPipelineCreate(f *cmdutil.Factory, name string, opts *createOptions) err
 		return fmt.Errorf("failed to create pipeline: %w", err)
 	}
 
+	f.Analytics.Track(analytics.GroupPipeline, analytics.EventCreated, map[string]any{"is_from_file": true})
 	f.Printer.Success("Created pipeline %q (%s)", pipeline.Name, pipeline.ID)
 	if pipeline.WebURL != "" {
 		_, _ = fmt.Fprintf(f.Printer.Out, "  %s\n", pipeline.WebURL)

--- a/internal/cmd/pipeline/pull.go
+++ b/internal/cmd/pipeline/pull.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -50,6 +51,8 @@ func runPipelinePull(f *cmdutil.Factory, id string, opts *pullOptions) error {
 			"Edit .teamcity.yml in your repo directly",
 		)
 	}
+
+	f.Analytics.Track(analytics.GroupPipeline, analytics.EventSynced, map[string]any{"action": analytics.PipelineActionPull})
 
 	if opts.output != "" {
 		if err := os.WriteFile(opts.output, []byte(yaml), 0644); err != nil {

--- a/internal/cmd/pipeline/push.go
+++ b/internal/cmd/pipeline/push.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/spf13/cobra"
 )
@@ -55,6 +56,7 @@ func runPipelinePush(f *cmdutil.Factory, id, file string) error {
 		return fmt.Errorf("failed to update pipeline %s: %w", id, err)
 	}
 
+	f.Analytics.Track(analytics.GroupPipeline, analytics.EventSynced, map[string]any{"action": analytics.PipelineActionPush})
 	f.Printer.Success("Updated pipeline %s", id)
 	return nil
 }

--- a/internal/cmd/pipeline/schema.go
+++ b/internal/cmd/pipeline/schema.go
@@ -68,21 +68,22 @@ func saveSchemaCache(serverURL string, schema []byte) error {
 	return os.WriteFile(path, schema, 0600)
 }
 
-func fetchOrCacheSchema(client *api.Client, refresh bool) ([]byte, error) {
+// fetchOrCacheSchema returns the schema and reports whether it came from the on-disk cache.
+func fetchOrCacheSchema(client *api.Client, refresh bool) ([]byte, bool, error) {
 	if !refresh {
 		if cached, err := loadCachedSchema(client.BaseURL); err == nil {
-			return cached, nil
+			return cached, true, nil
 		}
 	}
 
 	schema, err := client.GetPipelineSchema()
 	if err == nil {
 		_ = saveSchemaCache(client.BaseURL, schema)
-		return schema, nil
+		return schema, false, nil
 	}
 
 	if !refresh {
-		return embeddedSchema, nil
+		return embeddedSchema, false, nil
 	}
-	return nil, fmt.Errorf("failed to fetch pipeline schema from server: %w", err)
+	return nil, false, fmt.Errorf("failed to fetch pipeline schema from server: %w", err)
 }

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/santhosh-tekuri/jsonschema/v6"
@@ -63,7 +64,7 @@ func runPipelineValidate(f *cmdutil.Factory, file string, opts *validateOptions)
 		return fmt.Errorf("invalid YAML in %s: %w", file, err)
 	}
 
-	schemaData, err := loadSchema(f, opts)
+	schemaData, usedCache, err := loadSchema(f, opts)
 	if err != nil {
 		return err
 	}
@@ -72,6 +73,13 @@ func runPipelineValidate(f *cmdutil.Factory, file string, opts *validateOptions)
 	if err != nil {
 		return fmt.Errorf("schema validation failed: %w", err)
 	}
+
+	f.Analytics.Track(analytics.GroupPipeline, analytics.EventValidated, map[string]any{
+		"error_count":        len(validationErrs),
+		"warning_count":      0,
+		"is_from_file":       true,
+		"used_cached_schema": usedCache,
+	})
 
 	if len(validationErrs) == 0 {
 		f.Printer.Success("%s is valid", file)
@@ -95,19 +103,20 @@ func runPipelineValidate(f *cmdutil.Factory, file string, opts *validateOptions)
 	return &cmdutil.ExitError{Code: 1}
 }
 
-func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, error) {
+func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, bool, error) {
 	if opts.schemaPath != "" {
-		return os.ReadFile(opts.schemaPath)
+		data, err := os.ReadFile(opts.schemaPath)
+		return data, false, err
 	}
 
 	client, err := f.Client()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	c, ok := client.(*api.Client)
 	if !ok {
-		return nil, fmt.Errorf("schema caching requires a real API client")
+		return nil, false, fmt.Errorf("schema caching requires a real API client")
 	}
 
 	return fetchOrCacheSchema(c, opts.refreshSchema)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -88,6 +88,7 @@ Report issues:  https://jb.gg/tc/issues`,
 		if cmd.Name() != "update" && f.UpdateNotice == nil {
 			f.UpdateNotice = update.CheckInBackground(f.Printer.ErrOut, f.Quiet)
 		}
+		setupAnalytics(f)
 	}
 
 	addGrouped(cmd, "core", run.NewCmd(f), job.NewCmd(f), project.NewCmd(f), pipeline.NewCmd(f))
@@ -109,6 +110,7 @@ Report issues:  https://jb.gg/tc/issues`,
 
 func Execute() error {
 	f := cmdutil.NewFactory()
+	f.StartTime = time.Now()
 	rootCmd := buildRootCmd(f)
 
 	RegisterAliases(rootCmd, f)
@@ -118,6 +120,7 @@ func Execute() error {
 	if f.UpdateNotice != nil {
 		f.UpdateNotice()
 	}
+	defer trackAndFlushAnalytics(f, executedCmd, err)
 	if !f.JSONOutput && executedCmd != nil {
 		if jsonFlag := executedCmd.Flags().Lookup("json"); jsonFlag != nil && jsonFlag.Changed {
 			if jsonFlag.Value.Type() != "bool" || jsonFlag.Value.String() != "false" {

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/dustin/go-humanize/english"
@@ -192,6 +193,15 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	if err != nil {
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
+
+	filter := analytics.TestsFilterAll
+	if opts.failed {
+		filter = analytics.TestsFilterFailed
+	}
+	f.Analytics.Track(analytics.GroupBuild, analytics.EventTestsViewed, map[string]any{
+		"filter":      filter,
+		"is_from_job": opts.job != "",
+	})
 
 	tests, err := client.GetBuildTests(context.Background(), runID, opts.failed, opts.limit)
 	if err != nil {

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -90,6 +91,10 @@ func runRunDiff(f *cmdutil.Factory, args []string, opts *runDiffOptions) error {
 	if err != nil {
 		return err
 	}
+
+	f.Analytics.Track(analytics.GroupBuild, analytics.EventDiffViewed, map[string]any{
+		"had_log_diff": opts.log,
+	})
 
 	if opts.web {
 		b1, err1 := client.GetBuild(context.Background(), id1)

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
@@ -228,6 +229,20 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 		}
 		return browser.OpenURL(build.WebURL + "?buildTab=buildLog")
 	}
+
+	mode := analytics.LogModeFull
+	switch {
+	case opts.failed:
+		mode = analytics.LogModeFailed
+	case opts.follow:
+		mode = analytics.LogModeFollow
+	case opts.raw:
+		mode = analytics.LogModeRaw
+	}
+	f.Analytics.Track(analytics.GroupBuild, analytics.EventLogViewed, map[string]any{
+		"mode":        mode,
+		"is_from_job": opts.job != "",
+	})
 
 	if opts.failed {
 		return runLogFailed(f, client, runID, opts.json)

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -263,6 +264,15 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		if opts.agent > 0 {
 			_, _ = fmt.Fprintf(p.Out, "  Agent ID: %d\n", opts.agent)
 		}
+		f.Analytics.Track(analytics.GroupBuild, analytics.EventStarted, map[string]any{
+			"is_personal":       opts.personal,
+			"has_local_changes": opts.localChanges != "",
+			"has_branch":        opts.branch != "",
+			"has_revision":      opts.revision != "",
+			"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
+			"is_watched":        false,
+			"is_dry_run":        true,
+		})
 		return nil
 	}
 
@@ -339,6 +349,16 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 	if err != nil {
 		return err
 	}
+
+	f.Analytics.Track(analytics.GroupBuild, analytics.EventStarted, map[string]any{
+		"is_personal":       opts.personal,
+		"has_local_changes": opts.localChanges != "",
+		"has_branch":        opts.branch != "",
+		"has_revision":      opts.revision != "",
+		"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
+		"is_watched":        opts.watch,
+		"is_dry_run":        false,
+	})
 
 	if opts.json {
 		if opts.watch {

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -6,8 +6,11 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"time"
 
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmd/run/tui"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
@@ -60,7 +63,7 @@ For a simpler, pipe-friendly log stream, use "teamcity run log --follow" instead
 	return cmd
 }
 
-func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
+func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) (err error) {
 	p := f.Printer
 	if f.Quiet {
 		opts.quiet = true
@@ -85,10 +88,42 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 
 	if opts.logs && !opts.quiet {
 		if watchHasTTYFn() {
-			return runWatchTUIFn(ctx, client, runID, opts.interval)
+			tuiStart := time.Now()
+			tuiErr := runWatchTUIFn(ctx, client, runID, opts.interval)
+			f.Analytics.Track(analytics.GroupBuild, analytics.EventWatchFinished, map[string]any{
+				"duration_seconds": int(time.Since(tuiStart).Seconds()),
+				"final_status":     watchExitStatus(tuiErr),
+				"had_logs":         true,
+				"is_timed_out":     false,
+			})
+			return tuiErr
 		}
 		p.Warn("--logs requires a TTY; falling back to standard watch mode")
 	}
+
+	watchStart := time.Now()
+	var lastBuild *api.Build
+	watchCtx := ctx
+	defer func() {
+		status := analytics.BuildStatusError
+		timedOut := false
+		switch {
+		case watchCtx != nil && errors.Is(watchCtx.Err(), context.DeadlineExceeded):
+			timedOut = true
+			status = analytics.BuildStatusCanceled
+		case lastBuild != nil && lastBuild.State == "finished":
+			status = buildFinalStatus(lastBuild.Status)
+		case err == nil || errors.Is(err, context.Canceled):
+			status = analytics.BuildStatusCanceled
+		}
+		f.Analytics.Track(analytics.GroupBuild, analytics.EventWatchFinished, map[string]any{
+			"duration_seconds": int(time.Since(watchStart).Seconds()),
+			"final_status":     status,
+			"had_logs":         false,
+			"is_timed_out":     timedOut,
+		})
+	}()
+
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt)
@@ -114,6 +149,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 	if err != nil {
 		return err
 	}
+	lastBuild = build
 
 	switch {
 	case opts.json:
@@ -146,6 +182,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 		if err != nil {
 			return err
 		}
+		lastBuild = build
 
 		jobName := build.BuildTypeID
 		if build.BuildType != nil {
@@ -243,4 +280,37 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 		case <-time.After(time.Duration(opts.interval) * time.Second):
 		}
 	}
+}
+
+// buildFinalStatus maps the TeamCity build Status string to the analytics wire enum.
+func buildFinalStatus(s string) string {
+	switch strings.ToLower(s) {
+	case "success":
+		return analytics.BuildStatusSuccess
+	case "failure":
+		return analytics.BuildStatusFailure
+	case "unknown":
+		return analytics.BuildStatusCanceled
+	default:
+		return analytics.BuildStatusError
+	}
+}
+
+// watchExitStatus maps the TUI's return error to a final-status enum (TUI doesn't expose the build state).
+func watchExitStatus(err error) string {
+	var ee *cmdutil.ExitError
+	switch {
+	case err == nil:
+		return analytics.BuildStatusSuccess
+	case errors.Is(err, context.Canceled):
+		return analytics.BuildStatusCanceled
+	case errors.As(err, &ee):
+		switch ee.Code {
+		case cmdutil.ExitFailure:
+			return analytics.BuildStatusFailure
+		case cmdutil.ExitCancelled:
+			return analytics.BuildStatusCanceled
+		}
+	}
+	return analytics.BuildStatusError
 }

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	teamcitycli "github.com/JetBrains/teamcity-cli"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
-	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/tiulpin/instill"
 )
@@ -82,7 +82,7 @@ Auto-detects installed agents when --agent is not specified.`,
   teamcity skill install --agent claude-code --agent cursor
   teamcity skill install --project`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSkillInstall(f.Printer, opts, args, false)
+			return runSkillInstall(f, opts, args, false)
 		},
 	}
 
@@ -107,7 +107,7 @@ Auto-detects installed agents when --agent is not specified.`,
   teamcity skill update --agent claude-code
   teamcity skill update --project`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSkillInstall(f.Printer, opts, args, true)
+			return runSkillInstall(f, opts, args, true)
 		},
 	}
 
@@ -121,7 +121,17 @@ func addSkillFlags(cmd *cobra.Command, opts *skillOptions) {
 	cmd.Flags().BoolVar(&opts.project, "project", false, "Install to current project instead of globally")
 }
 
-func runSkillInstall(p *output.Printer, opts *skillOptions, args []string, checkVersion bool) error {
+func runSkillInstall(f *cmdutil.Factory, opts *skillOptions, args []string, checkVersion bool) error {
+	p := f.Printer
+	action := analytics.SkillActionInstall
+	if checkVersion {
+		action = analytics.SkillActionUpdate
+	}
+	scope := analytics.SkillScopeGlobal
+	if opts.project {
+		scope = analytics.SkillScopeProject
+	}
+	autoDetected := len(opts.agents) == 0
 	agents, err := resolveSkillAgents(opts.agents, !opts.project)
 	if err != nil {
 		return err
@@ -173,11 +183,15 @@ func runSkillInstall(p *output.Printer, opts *skillOptions, args []string, check
 
 	results, err := instill.Install(teamcitycli.SkillsFS, instillOpts)
 	if err != nil {
+		for _, ag := range agents {
+			trackSkill(f, action, ag, scope, autoDetected, false)
+		}
 		return err
 	}
 
 	for _, r := range results {
 		bundled := versions[r.Skill]
+		trackSkill(f, action, r.Agent, scope, autoDetected, true)
 		switch {
 		case !r.Existed:
 			p.Success("Installed %s for %s (%s)", r.Skill, r.Agent, bundled)
@@ -207,7 +221,7 @@ Use --all to remove every bundled skill.`,
   teamcity skill remove --agent claude-code
   teamcity skill remove --project`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSkillRemove(f.Printer, opts, args)
+			return runSkillRemove(f, opts, args)
 		},
 	}
 
@@ -215,7 +229,13 @@ Use --all to remove every bundled skill.`,
 	return cmd
 }
 
-func runSkillRemove(p *output.Printer, opts *skillOptions, args []string) error {
+func runSkillRemove(f *cmdutil.Factory, opts *skillOptions, args []string) error {
+	p := f.Printer
+	scope := analytics.SkillScopeGlobal
+	if opts.project {
+		scope = analytics.SkillScopeProject
+	}
+	autoDetected := len(opts.agents) == 0
 	agents, err := resolveSkillAgents(opts.agents, !opts.project)
 	if err != nil {
 		return err
@@ -244,6 +264,7 @@ func runSkillRemove(p *output.Printer, opts *skillOptions, args []string) error 
 		}
 
 		for _, r := range results {
+			trackSkill(f, analytics.SkillActionRemove, r.Agent, scope, autoDetected, r.Existed)
 			if r.Existed {
 				p.Success("Removed %s from %s", name, r.Agent)
 			} else {
@@ -309,4 +330,14 @@ func formatAgentList() string {
 			names[0], names[1], names[2], len(names))
 	}
 	return fmt.Sprintf("%v", names)
+}
+
+func trackSkill(f *cmdutil.Factory, action, agent, scope string, autoDetected, success bool) {
+	f.Analytics.Track(analytics.GroupSkill, analytics.EventManaged, map[string]any{
+		"action":           action,
+		"agent":            analytics.NormalizeAIAgent(agent),
+		"scope":            scope,
+		"is_auto_detected": autoDetected,
+		"is_success":       success,
+	})
 }

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -3,8 +3,10 @@ package cmdutil
 import (
 	"io"
 	"os"
+	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
@@ -46,6 +48,12 @@ type Factory struct {
 
 	// UpdateNotice is called after command execution to print update notices.
 	UpdateNotice func()
+
+	// Analytics is the FUS telemetry client; always nil-safe.
+	Analytics *analytics.Client
+
+	// StartTime captured at PersistentPreRun for duration_ms.
+	StartTime time.Time
 }
 
 // NewFactory creates a Factory with production defaults.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,9 +37,11 @@ type ServerConfig struct {
 }
 
 type Config struct {
-	DefaultServer string                  `mapstructure:"default_server"`
-	Servers       map[string]ServerConfig `mapstructure:"servers"`
-	Aliases       map[string]string       `mapstructure:"aliases"`
+	DefaultServer        string                  `mapstructure:"default_server"`
+	Servers              map[string]ServerConfig `mapstructure:"servers"`
+	Aliases              map[string]string       `mapstructure:"aliases"`
+	Analytics            *bool                   `mapstructure:"analytics,omitempty"`
+	AnalyticsNoticeShown bool                    `mapstructure:"analytics_notice_shown,omitempty"`
 }
 
 var (
@@ -262,6 +264,12 @@ func writeConfig() error {
 	}
 	w.Set("servers", servers)
 	w.Set("aliases", cfg.Aliases)
+	if cfg.Analytics != nil {
+		w.Set("analytics", *cfg.Analytics)
+	}
+	if cfg.AnalyticsNoticeShown {
+		w.Set("analytics_notice_shown", true)
+	}
 
 	data, err := yaml.Marshal(w.AllSettings())
 	if err != nil {
@@ -337,6 +345,34 @@ func RemoveServer(serverURL string) error {
 
 func ConfigPath() string {
 	return configPath
+}
+
+// IsAnalyticsEnabled returns the user's persisted preference; defaults to true.
+func IsAnalyticsEnabled() bool {
+	if cfg == nil || cfg.Analytics == nil {
+		return true
+	}
+	return *cfg.Analytics
+}
+
+func SetAnalyticsEnabled(enabled bool) error {
+	cfg.Analytics = &enabled
+	return writeConfig()
+}
+
+func IsAnalyticsNoticeShown() bool {
+	if cfg == nil {
+		return false
+	}
+	return cfg.AnalyticsNoticeShown
+}
+
+func MarkAnalyticsNoticeShown() error {
+	if cfg.AnalyticsNoticeShown {
+		return nil
+	}
+	cfg.AnalyticsNoticeShown = true
+	return writeConfig()
 }
 
 // IsGuestAuth returns true if guest authentication is enabled via env var or server config

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-var validKeys = []string{"default_server", "guest", "ro", "token_expiry"}
+var validKeys = []string{"default_server", "guest", "ro", "token_expiry", "analytics"}
 
 func IsValidKey(key string) bool {
 	return slices.Contains(validKeys, key)
@@ -22,6 +22,9 @@ func GetField(key, serverURL string) (string, error) {
 	}
 	if key == "default_server" {
 		return Get().DefaultServer, nil
+	}
+	if key == "analytics" {
+		return fmt.Sprintf("%t", IsAnalyticsEnabled()), nil
 	}
 	serverURL, err := resolveServerForConfig(serverURL)
 	if err != nil {
@@ -56,6 +59,13 @@ func SetField(key, value, serverURL string) error {
 		}
 		cfg.DefaultServer = normalized
 		return writeConfig()
+	}
+	if key == "analytics" {
+		b, err := parseBoolValue(value)
+		if err != nil {
+			return err
+		}
+		return SetAnalyticsEnabled(b)
 	}
 	serverURL, err := resolveServerForConfig(serverURL)
 	if err != nil {

--- a/scripts/generate-fus-schema.go
+++ b/scripts/generate-fus-schema.go
@@ -1,10 +1,13 @@
 //go:build ignore
 
-// Script to generate internal/analytics/schema.json from the in-Go FUS scheme.
+// Script to generate FUS schema files from the in-Go FUS scheme.
 //
-// The output is the file the AP team registers in the metadata repo. The same
-// Scheme value is used at runtime by fus.NewValidator, so there is no drift
-// between the registered schema and the collector code.
+// Produces two files:
+//   - internal/analytics/schema.json: the AP metadata format (EventGroupRemoteDescriptors),
+//     used at runtime by fus.NewValidator as the embedded fallback scheme.
+//   - internal/analytics/events-scheme.json: the events scheme format (EventsScheme),
+//     used by the FUS metadata team to generate metadata entries. Attach this to
+//     YT issues in the FUS project when requesting metadata changes.
 //
 // Run with:
 //
@@ -17,24 +20,48 @@ import (
 
 	fus "github.com/JetBrains/fus-reporting-api-go"
 	"github.com/JetBrains/teamcity-cli/internal/analytics"
+	"github.com/JetBrains/teamcity-cli/internal/version"
 )
-
-const outPath = "internal/analytics/schema.json"
 
 func main() {
 	if _, err := fus.NewValidator(analytics.Scheme); err != nil {
 		fmt.Fprintf(os.Stderr, "scheme failed validator construction: %v\n", err)
 		os.Exit(1)
 	}
-	f, err := os.Create(outPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "create %s: %v\n", outPath, err)
+
+	if err := writeFile("internal/analytics/schema.json", func(f *os.File) error {
+		return fus.WriteSchemeJSON(analytics.Scheme, f)
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "schema.json: %v\n", err)
 		os.Exit(1)
+	}
+
+	es, err := fus.BuildEventsScheme(analytics.Scheme, fus.RecorderConfig{
+		RecorderID:      analytics.RecorderID,
+		RecorderVersion: analytics.RecorderVersion,
+		ProductCode:     analytics.ProductCode,
+	}, version.String())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "build events scheme: %v\n", err)
+		os.Exit(1)
+	}
+	if err := writeFile("internal/analytics/events-scheme.json", func(f *os.File) error {
+		return fus.WriteEventsSchemeJSON(es, f)
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "events-scheme.json: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func writeFile(path string, write func(*os.File) error) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
 	}
 	defer f.Close()
-	if err := fus.WriteSchemeJSON(analytics.Scheme, f); err != nil {
-		fmt.Fprintf(os.Stderr, "write scheme: %v\n", err)
-		os.Exit(1)
+	if err := write(f); err != nil {
+		return err
 	}
-	fmt.Printf("wrote %s\n", outPath)
+	fmt.Printf("wrote %s\n", path)
+	return nil
 }

--- a/scripts/generate-fus-schema.go
+++ b/scripts/generate-fus-schema.go
@@ -1,0 +1,40 @@
+//go:build ignore
+
+// Script to generate internal/analytics/schema.json from the in-Go FUS scheme.
+//
+// The output is the file the AP team registers in the metadata repo. The same
+// Scheme value is used at runtime by fus.NewValidator, so there is no drift
+// between the registered schema and the collector code.
+//
+// Run with:
+//
+//	go run scripts/generate-fus-schema.go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	fus "github.com/JetBrains/fus-reporting-api-go"
+	"github.com/JetBrains/teamcity-cli/internal/analytics"
+)
+
+const outPath = "internal/analytics/schema.json"
+
+func main() {
+	if _, err := fus.NewValidator(analytics.Scheme); err != nil {
+		fmt.Fprintf(os.Stderr, "scheme failed validator construction: %v\n", err)
+		os.Exit(1)
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create %s: %v\n", outPath, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+	if err := fus.WriteSchemeJSON(analytics.Scheme, f); err != nil {
+		fmt.Fprintf(os.Stderr, "write scheme: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("wrote %s\n", outPath)
+}


### PR DESCRIPTION
## Summary

Adds an `internal/analytics` package wired into every command that emits anonymous usage statistics via `github.com/JetBrains/fus-reporting-api-go`. Opt-out by default, GDPR-compliant. Client-side validation runs as part of `go test ./...`; an acceptance script exercises every documented opt-out path; a build-tagged probe verifies real delivery to the FUS staging endpoint (18/18 events accepted).

## Changes

**New package `internal/analytics`**

- `scheme.go` — single source of truth for the FUS scheme (8 groups). Same value passed to `fus.NewValidator` at runtime and serialized to `schema.json` on demand for AP metadata registration via `just analytics-schema` (output gitignored).
- `client.go` — nil-safe `Client` (nil receiver = disabled, every Track method noops). `Client.Track(group, event, data)` is the generic emitter; `TrackSession`/`TrackCommand`/`TrackAPI` keep classification logic that needs typing. FUS logger boots lazily on first Track and silently noops on failure — telemetry never blocks the hot path.
- `optout.go` — priority chain `DO_NOT_TRACK=1` > `TEAMCITY_ANALYTICS=0` > config `analytics: false` > on. `TEAMCITY_ANALYTICS_STAGING=1` routes to the FUS staging endpoint; `TEAMCITY_ANALYTICS_SALT` supplies the anonymization salt.
- `session.go` — 30-minute inactivity window persisted to `~/.config/tc/.session`.
- `detect.go` — OS/arch normalization, CI detection via well-known env vars, AI-agent detection via `github.com/tiulpin/instill`.
- `notice.go` — first-run notice printed to stderr (with link to data-collection terms); suppressed by `--quiet`, `--no-input`, or any opt-out. Dismissal recorded in CLI config.
- `validate.go` + `validate_test.go` — `SampleEvents()` covers every (group, event_id, field). `LintScheme()` runs them through the validator and fails on any `validation.*` sentinel. `TestLintScheme` runs in the default `go test ./...` suite — no build tag, no opt-in.
- `server_info.go` — telemetry-only cache of TC `server_version` + `server_type` at `~/.config/tc/.analytics/server-info.json` (sibling of the FUS event buffer). Isolated from user-facing `config.yml`; deletable without breaking auth.
- `staging_send_test.go` (build-tag `staging`) — sends one event per group to the real staging endpoint. Verified 18/18 accepted.

**Event groups + events emitted**

| Group | Events | Wired in |
|---|---|---|
| `teamcity.cli.session` (state) | `invoked` | `setupAnalytics` (PersistentPreRun) |
| `teamcity.cli.command` (counter) | `executed` | deferred from `Execute()` |
| `teamcity.cli.api` (counter) | `invoked` | `internal/cmd/api/api.go` |
| `teamcity.cli.auth` | `login.completed`, `login.abandoned`, `token.loaded` | `internal/cmd/auth/login.go`, `setupAnalytics` |
| `teamcity.cli.build` | `started`, `watch.finished`, `log.viewed`, `tests.viewed`, `diff.viewed` | `internal/cmd/run/{start,watch,log,analysis,diff}.go` |
| `teamcity.cli.agent` | `terminal.closed`, `exec.finished`, `state.changed` | `internal/cmd/agent/*.go` |
| `teamcity.cli.pipeline` | `validated`, `created`, `synced` | `internal/cmd/pipeline/{validate,create,push,pull}.go` |
| `teamcity.cli.skill` | `managed` | `internal/cmd/skill/skill.go` |

`workspace` and `migrate` groups deferred — no `teamcity link` / `teamcity migrate` commands yet.

**Wire-up**

- `internal/cmdutil/factory.go` — `Factory.Analytics *analytics.Client` (nilable) + `StartTime time.Time`.
- `internal/cmd/root.go` + `internal/cmd/analytics.go` — install in PersistentPreRun, emit `command.executed` + flush in `Execute()`'s deferred path. Mirrors existing `classifyError` for the `error_type` enum.
- `internal/cmd/auth/login.go` — best-effort `cacheServerInfo()` after successful login persists TC version + cloud/on-prem to `server-info.json`.
- `internal/config/` — new `analytics` config key, `analytics_notice_shown` flag.
- `api/types.go` — added `InternalID` field to `Server` (one line).

**Tooling + verification**

- `scripts/generate-fus-schema.go` — validates `Scheme` then writes `schema.json` (`just analytics-schema`). Output gitignored — Go is the source of truth.
- `acceptance/testdata/analytics/optout.txtar` — 10-scenario script that exercises every opt-out path + priority order via the `[debug] analytics:` log line.
- Run any command with `--debug` to see the analytics lifecycle (enabled/disabled state + reason, boot success/failure, per-event emit, flush outcome).

## Design Decisions

- **Scheme is Go code, not JSON.** The `fus.Scheme` value is the single source of truth; `schema.json` is regenerated from it when the AP team needs it, so the registered JSON cannot drift from the collector code.
- **`schema.json` not checked in.** It is a derived artifact; regenerate via `just analytics-schema` before uploading to the AP metadata repo.
- **Generic `Track` over per-event methods.** After comparing both shapes, the typed-events approach was ~200 lines of struct definitions + wrappers that just shuffled the same field name twice. The single `Track(group, event, data)` is identical at the call site and ~180 lines lighter. `TestLintScheme` catches field-name drift at test time, so the type-safety floor is the same.
- **`Factory.Analytics` is nilable.** All Track methods are nil-safe; nil = disabled. Removed the `Disabled()` constructor + `disabled` field — same shape as `slog`/`zap`, simpler contract.
- **Server context cached outside `config.yml`.** TC `server_version` + `server_type` live in `~/.config/tc/.analytics/server-info.json`, sibling of the FUS buffer. Telemetry-derived metadata doesn't pollute the user-visible `teamcity config list` view, and wiping `.analytics/` clears all telemetry state without breaking auth.
- **Caller-supplied salt.** The public CDN config endpoint does not expose `options.id_salt` for any recorder. Salt comes from `RecorderConfig.AnonymizationSalt`, same design as the JVM SDK's `FusClientConfig.anonymizationSalt`. Fix landed in `fus-reporting-api-go`.
- **Deferred boot.** `fus.NewLogger` fetches a salt and runs an HTTPS call; doing that on every CLI invocation would add latency. We defer it to the first `Track*` call and fail silently (no-op) if init fails — the CLI never blocks on telemetry.
- **Build tag for staging probe.** `TestStagingRealSend` hits the network, so it is gated by `//go:build staging` to keep `go test ./...` fully offline.
- **Client-side validation in the default test suite.** `TestLintScheme` is not build-tagged; any divergence between `scheme.go` and the actual tracker call sites fails CI immediately, no waiting on staging ingestion.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`), including the new `analytics/optout` script
- [x] `TestLintScheme` — 0 sentinels across the reference events (runs with default `go test ./...`)
- [x] Staging probe — 18/18 events accepted by `https://stgn.fus-stgn.aws.intellij.net/tcx/v4/send/`
- [x] First-run notice renders, marks dismissal, and respects `--quiet` / `--no-input` / `DO_NOT_TRACK` / `TEAMCITY_ANALYTICS=0`
- [x] `--debug` surfaces the full analytics lifecycle (enabled/disabled + reason, boot, per-event emit, flush)
- [x] `auth login` (token + guest) caches `server_version` + `server_type` to `.analytics/server-info.json` without touching `config.yml`
- [ ] GDPR review (follow-up FUS ticket)
- [ ] AP team reviews generated `schema.json` and registers it in the metadata repo (follow-up)

## Notes for review

- Spec gaps that intentionally remain in this PR:
  - `session.has_linked_project` and `command.has_link_context` — depend on `teamcity link`, hardcoded to `false` until that command lands.
  - `workspace` and `migrate` groups — deferred until their commands exist.
  - `auth.login.abandoned` only fires on user `Ctrl-C` (`survey.InterruptErr`); other abandonment paths bubble out as `login.completed{success=false}`