### PR TITLE
fix: make just recipes work on Windows without Git Bash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ cd teamcity-cli
 just build
 ```
 
+On Windows, `just build`, `just install`, `just lint`, and the other simple Go recipes work in PowerShell with no extra setup. A handful of recipes use bash shebangs (`clean`, `docs-build`, `docs-deploy`, `install-choco`, `install-codesign`, `eval`, `eval-diff`) and require Git Bash or WSL.
+
 ## Architecture
 
 ```

--- a/justfile
+++ b/justfile
@@ -1,6 +1,13 @@
 # TeamCity CLI
 
 set quiet
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
+# Environment variables for recipes — exported via justfile syntax so they work
+# under any shell (sh on macOS/Linux, PowerShell on Windows).
+export TC_INSECURE_SKIP_WARN := "1"
+export SIGN := "true"
+export FINGERPRINT := "B46DC71E03FEEB7F89D1F2491F7A8F87B9D8F501"
 
 # Build the CLI binary
 build:
@@ -18,15 +25,15 @@ install:
 
 # Run unit tests
 unit:
-    TC_INSECURE_SKIP_WARN=1 go test -race -shuffle=on -v ./internal/config ./internal/errors ./internal/output ./internal/cmd
+    go test -race -shuffle=on -v ./internal/config ./internal/errors ./internal/output ./internal/cmd
 
 # Run all tests with coverage
 test:
-    TC_INSECURE_SKIP_WARN=1 go test -race -shuffle=on -v ./... -timeout 15m -tags=integration -coverprofile=coverage.out -coverpkg=./...
+    go test -race -shuffle=on -v ./... -timeout 15m -tags=integration -coverprofile=coverage.out -coverpkg=./...
 
 # Run acceptance tests against cli.teamcity.com (guest auth)
 acceptance:
-    TC_INSECURE_SKIP_WARN=1 go test -v -tags=acceptance ./acceptance -timeout 10m
+    go test -v -tags=acceptance ./acceptance -timeout 10m
 
 # Run sandbox integration tests (requires npx, bubblewrap+socat on Linux)
 sandbox:
@@ -68,7 +75,7 @@ release-dry-run:
 # Create and publish a signed release
 [confirm]
 release:
-    SIGN=true FINGERPRINT=B46DC71E03FEEB7F89D1F2491F7A8F87B9D8F501 goreleaser release --clean
+    goreleaser release --clean
 
 # Record all documentation GIFs (both light and dark themes)
 record-gifs *args:


### PR DESCRIPTION
## Summary

Simple `just` recipes (`build`, `install`, `lint`, `unit`, `test`, `acceptance`, `release`) failed on Windows without Git Bash because just defaults to `sh` and the recipes used sh-only `VAR=value cmd` prefixes. This PR makes them work in PowerShell out of the box.

Closes JetBrains/teamcity-cli#241.

## Changes

- `justfile`: added `set windows-shell := [\"powershell.exe\", \"-NoLogo\", \"-Command\"]` so just uses PowerShell on Windows.
- `justfile`: moved `TC_INSECURE_SKIP_WARN`, `SIGN`, and `FINGERPRINT` into `export VAR := \"value\"` assignments (justfile-native, shell-agnostic) and dropped the inline sh-style prefixes from `unit`, `test`, `acceptance`, and `release`.
- `CONTRIBUTING.md`: documented that the shebang recipes (`clean`, `docs-build`, `docs-deploy`, `install-choco`, `install-codesign`, `eval`, `eval-diff`) still need Git Bash or WSL on Windows — they bypass `windows-shell` by design.

## Design Decisions

Shebang recipes are intentionally left alone. They invoke bash directly, so they remain bash-only regardless of `windows-shell`. Rewriting them in PowerShell would duplicate non-trivial logic (docker invocation, gh-pages deploy, JetBrains codesign install) for a platform where these tasks aren't the common developer path. Documenting the constraint is the right tradeoff.

`export` assignments in the justfile are portable across shells, unlike the `VAR=value cmd` prefix which only works in POSIX shells.

## Test Plan

- [x] `just --list` parses cleanly
- [x] `just --evaluate` shows the three exported variables
- [x] `just build` succeeds on macOS
- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Verified on Windows 11 + just 1.46.0 + PowerShell (no Git Bash on PATH)