### PR TITLE
feat(link): bind repo to TeamCity projects via teamcity.toml

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -92,6 +92,7 @@ func TestAcceptance(t *testing.T) {
 		"api",
 		"queue",
 		"alias",
+		"link",
 		"skill",
 	}
 

--- a/acceptance/testdata/link/link-help.txtar
+++ b/acceptance/testdata/link/link-help.txtar
@@ -1,0 +1,13 @@
+# `teamcity link` help surface and validation.
+
+exec teamcity link --help
+stdout 'teamcity\.toml'
+stdout '--server'
+stdout '--project'
+stdout '--job'
+stdout '--jobs'
+! stderr 'Error'
+
+# Refuses with no field flags
+! exec teamcity link --server https://x.example --no-input
+stderr 'at least one of --project'

--- a/acceptance/testdata/link/link-paths.txtar
+++ b/acceptance/testdata/link/link-paths.txtar
@@ -1,0 +1,35 @@
+# Path-scoped: cwd relative to teamcity.toml's dir is the implicit scope.
+
+mkdir services/api
+mkdir services/web
+
+# Top-level scope at root
+exec teamcity link --server https://x.example --project Mono --job Mono_Build --no-input
+grep 'project = "Mono"' teamcity.toml
+grep 'job = "Mono_Build"' teamcity.toml
+
+# Path scope from a subdirectory upserts under [server.paths."<rel>"]
+cd services/api
+exec teamcity link --server https://x.example --project API --job API_Build --no-input
+stdout 'services/api'
+cd ../..
+grep '\[server.paths."services/api"\]' teamcity.toml
+grep 'project = "API"' teamcity.toml
+grep 'job = "API_Build"' teamcity.toml
+
+# Top-level scope is preserved
+grep 'project = "Mono"' teamcity.toml
+grep 'job = "Mono_Build"' teamcity.toml
+
+# Explicit --scope override works from the root too
+exec teamcity link --server https://x.example --scope services/web --project Web --jobs Web_Build,Web_Deploy --no-input
+grep '\[server.paths."services/web"\]' teamcity.toml
+grep 'project = "Web"' teamcity.toml
+grep 'jobs = \["Web_Build", "Web_Deploy"\]' teamcity.toml
+
+# `--scope=` (empty) writes to the top-level scope from anywhere
+mkdir docs
+cd docs
+exec teamcity link --server https://x.example --scope= --project Mono2 --job Mono2_Build --no-input
+cd ..
+grep 'project = "Mono2"' teamcity.toml

--- a/acceptance/testdata/link/link-resolves-into-commands.txtar
+++ b/acceptance/testdata/link/link-resolves-into-commands.txtar
@@ -1,0 +1,34 @@
+# A configured link is consumed by downstream commands so callers don't repeat
+# --project / job-id everywhere. The cascade matches the active TC server URL.
+
+[!has_token] skip 'requires authentication token to call project view'
+
+exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
+extract '"id":"([^"]+)"' PROJECT_ID
+exec teamcity api '/app/rest/buildTypes?locator=project:'$PROJECT_ID',count:1&fields=buildType(id)' --raw --no-input
+extract '"id":"([^"]+)"' JOB_ID
+
+exec teamcity link --project $PROJECT_ID --job $JOB_ID --no-input
+exists teamcity.toml
+
+# project view with no positional arg uses the linked project for active server
+exec teamcity project view --no-input
+stdout $PROJECT_ID
+! stderr 'Error'
+
+# run start --dry-run with no positional arg uses the linked job
+exec teamcity run start --dry-run --no-input
+stdout 'Would trigger run for'
+stdout $JOB_ID
+! stderr 'Error'
+
+# TEAMCITY_PROJECT overrides the file
+env TEAMCITY_PROJECT=NonExistent_OverrideTest
+! exec teamcity project view --no-input
+stderr 'NonExistent_OverrideTest'
+
+# Explicit positional arg wins over env + file
+env TEAMCITY_PROJECT=
+exec teamcity project view $PROJECT_ID --no-input
+stdout $PROJECT_ID
+! stderr 'Error'

--- a/acceptance/testdata/link/link-write.txtar
+++ b/acceptance/testdata/link/link-write.txtar
@@ -1,0 +1,27 @@
+# `teamcity link` upserts [[server]] entries in teamcity.toml.
+
+# Single server
+exec teamcity link --server https://primary.example --project Acme --job Acme_Build --no-input
+stdout 'Linked'
+stdout 'Project: Acme'
+stdout 'Default job: Acme_Build'
+stdout 'Wrote:'
+exists teamcity.toml
+grep 'url = "https://primary.example"' teamcity.toml
+grep 'project = "Acme"' teamcity.toml
+grep 'job = "Acme_Build"' teamcity.toml
+
+# Add a second server with multiple jobs
+exec teamcity link --server https://nightly.example --project Nightly --jobs Nightly_Release,Nightly_Eval --no-input
+stdout 'Jobs: Nightly_Release, Nightly_Eval'
+grep 'url = "https://nightly.example"' teamcity.toml
+grep 'project = "Nightly"' teamcity.toml
+grep '"Nightly_Release"' teamcity.toml
+grep '"Nightly_Eval"' teamcity.toml
+# Original entry is still there
+grep 'url = "https://primary.example"' teamcity.toml
+
+# Re-linking the same server replaces the entry
+exec teamcity link --server https://primary.example --project Acme2 --job Acme2_Build --no-input
+grep 'project = "Acme2"' teamcity.toml
+! grep 'project = "Acme"$' teamcity.toml

--- a/acceptance/testdata/run/run-validation.txtar
+++ b/acceptance/testdata/run/run-validation.txtar
@@ -1,8 +1,8 @@
 # Test run subcommand input validation and error handling.
 
-# start without args
+# start without args (no link configured)
 ! exec teamcity run start --no-input
-stderr 'accepts 1 arg'
+stderr 'job id is required'
 
 # cancel without args
 ! exec teamcity run cancel --no-input

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/AlecAivazis/survey/v2 v2.3.7 h1:6I/u8FvytdGsgonrYsVn2t8t4QiRnh6QSTqkk
 github.com/AlecAivazis/survey/v2 v2.3.7/go.mod h1:xUTIdE4KCOIjsBAE1JYsUPoCqYdZ1reCfTwbto0Fduo=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -35,6 +35,7 @@ them alongside classic build configurations.`,
   teamcity job list --plain
   teamcity job list --plain --no-header`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.project = f.ResolveProject(opts.project)
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.BuildTypeFields, opts.fetch)
 		},
 	}

--- a/internal/cmd/link/link.go
+++ b/internal/cmd/link/link.go
@@ -1,0 +1,173 @@
+// Package link implements `teamcity link`: upsert a [[server]] entry (or a
+// per-path scope inside one) in teamcity.toml.
+package link
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/link"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd(f *cmdutil.Factory) *cobra.Command {
+	var server, project, job, scope string
+	var jobs []string
+	var scopeSet bool
+
+	cmd := &cobra.Command{
+		Use:   "link",
+		Short: "Bind this repository to a TeamCity project",
+		Long: `Upsert a [[server]] entry in teamcity.toml binding this repo to a TeamCity
+instance. Per-path scopes (monorepo) are upserted under [server.paths."<path>"].
+
+Resolution cascade (highest to lowest):
+  --flag → TEAMCITY_* env → matching [[server]] entry, deepest matching path scope`,
+		Example: `  # Bind the repo (uses active server, top-level scope)
+  teamcity link --project Acme_Backend --job Acme_Backend_Build
+
+  # Add a second server's pipelines to the same teamcity.toml
+  teamcity link --server https://nightly.example --project Acme_Nightly \
+      --jobs Acme_Nightly_Release,Acme_Nightly_Eval
+
+  # Path-scoped: cwd relative to teamcity.toml's dir is the implicit scope
+  cd services/api && teamcity link --project Acme_API --job Acme_API_Build
+
+  # Inspect or remove the file directly:
+  cat teamcity.toml
+  rm  teamcity.toml`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scopeSet = cmd.Flags().Changed("scope")
+			serverURL := normalizeServerURL(cmp.Or(server, config.GetServerURL()))
+			if serverURL == "" {
+				return api.Validation(
+					"--server is required when no active TeamCity server is configured",
+					"Pass --server <url> or run 'teamcity auth login' first",
+				)
+			}
+			if project == "" && job == "" && len(jobs) == 0 {
+				return api.Validation(
+					"at least one of --project, --job, or --jobs is required",
+					"Pass --project <id> (and optionally --job <id> or --jobs A,B,C)",
+				)
+			}
+
+			path, err := writePath()
+			if err != nil {
+				return err
+			}
+			scopePath, err := resolveScopePath(scope, scopeSet, path)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := loadOrEmpty(path)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", path, err)
+			}
+			cfg.UpsertScope(serverURL, scopePath, link.PathScope{
+				Project: project,
+				Job:     job,
+				Jobs:    jobs,
+			})
+			if err := link.Save(path, cfg); err != nil {
+				return fmt.Errorf("write %s: %w", path, err)
+			}
+
+			label := scopePath
+			if label == "" {
+				label = "(top-level)"
+			}
+			f.Printer.Success("Linked %s — %s", output.Cyan(serverURL), label)
+			if project != "" {
+				f.Printer.Info("  Project: %s", project)
+			}
+			if job != "" {
+				f.Printer.Info("  Default job: %s", job)
+			}
+			if len(jobs) > 0 {
+				f.Printer.Info("  Jobs: %s", strings.Join(jobs, ", "))
+			}
+			f.Printer.Info("  Wrote: %s", path)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&server, "server", "", "TeamCity server URL (default: active server)")
+	cmd.Flags().StringVarP(&project, "project", "p", "", "TeamCity project ID for this scope")
+	cmd.Flags().StringVarP(&job, "job", "j", "", "Default job/pipeline ID for this scope")
+	cmd.Flags().StringSliceVar(&jobs, "jobs", nil, "Additional job/pipeline IDs (comma-separated or repeated)")
+	cmd.Flags().StringVar(&scope, "scope", "", "Path scope inside the server entry (default: cwd relative to teamcity.toml's dir; pass --scope= for top-level)")
+
+	return cmd
+}
+
+// loadOrEmpty returns the parsed config, or an empty one if path doesn't exist.
+// Any other error (malformed/unreadable) is returned so we don't overwrite the user's file.
+func loadOrEmpty(path string) (*link.Config, error) {
+	c, err := link.Load(path)
+	if err == nil {
+		return c, nil
+	}
+	if os.IsNotExist(err) {
+		return &link.Config{}, nil
+	}
+	return nil, err
+}
+
+// resolveScopePath returns the path key for the upsert: explicit --scope wins; otherwise cwd-rel-to-toml-dir.
+func resolveScopePath(override string, overrideSet bool, tomlPath string) (string, error) {
+	if overrideSet {
+		return strings.Trim(override, "/"), nil
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return link.RelPath(filepath.Dir(tomlPath), cwd), nil
+}
+
+// writePath chooses where teamcity.toml goes: existing file wins, else git root, else cwd.
+func writePath() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	if path, ok := link.Find(cwd); ok {
+		return path, nil
+	}
+	if root, ok := gitRoot(); ok {
+		return filepath.Join(root, link.FileName), nil
+	}
+	return filepath.Join(cwd, link.FileName), nil
+}
+
+func gitRoot() (string, bool) {
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
+}
+
+// normalizeServerURL trims whitespace and prepends https:// when no scheme is
+// given, so the stored URL matches the active server URL later.
+func normalizeServerURL(u string) string {
+	u = strings.TrimSpace(u)
+	if u == "" {
+		return ""
+	}
+	if !strings.Contains(u, "://") {
+		u = "https://" + u
+	}
+	return strings.TrimRight(u, "/")
+}

--- a/internal/cmd/link/link_test.go
+++ b/internal/cmd/link/link_test.go
@@ -1,0 +1,149 @@
+package link_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/link"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func TestLinkUpsertSingleServer(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	ts := cmdtest.SetupMockClient(t)
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://x.example", "--project", "Acme", "--job", "Acme_Build")
+
+	cfg, err := link.Load(filepath.Join(dir, link.FileName))
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 1)
+	assert.Equal(t, "https://x.example", cfg.Servers[0].URL)
+	assert.Equal(t, "Acme", cfg.Servers[0].Project)
+	assert.Equal(t, "Acme_Build", cfg.Servers[0].Job)
+}
+
+func TestLinkAddsSecondServer(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	ts := cmdtest.SetupMockClient(t)
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://primary.example", "--project", "P", "--job", "P_Build")
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://nightly.example", "--project", "N", "--jobs", "N_Release,N_Eval")
+
+	cfg, err := link.Load(filepath.Join(dir, link.FileName))
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 2)
+	assert.Equal(t, "P_Build", cfg.Servers[0].Job)
+	assert.Equal(t, []string{"N_Release", "N_Eval"}, cfg.Servers[1].Jobs)
+}
+
+func TestLinkUpsertReplacesExistingEntry(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	ts := cmdtest.SetupMockClient(t)
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://x.example", "--project", "Old")
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://x.example", "--project", "New", "--job", "New_Build")
+
+	cfg, err := link.Load(filepath.Join(dir, link.FileName))
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 1)
+	assert.Equal(t, "New", cfg.Servers[0].Project)
+	assert.Equal(t, "New_Build", cfg.Servers[0].Job)
+}
+
+func TestLinkRequiresAtLeastOneFieldFlag(t *testing.T) {
+	chdir(t, t.TempDir())
+	ts := cmdtest.SetupMockClient(t)
+	err := cmdtest.CaptureErr(t, ts.Factory, "link", "--server", "https://x.example")
+	assert.Contains(t, err.Error(), "at least one of --project")
+}
+
+func TestLinkPathScopedFromSubdir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "services", "api")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+
+	chdir(t, dir)
+	ts := cmdtest.SetupMockClient(t)
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://x.example", "--project", "Mono", "--job", "Mono_Build")
+
+	chdir(t, sub)
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://x.example", "--project", "API", "--job", "API_Build")
+
+	cfg, err := link.Load(filepath.Join(dir, link.FileName))
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 1)
+	srv := cfg.Servers[0]
+	assert.Equal(t, "Mono", srv.Project, "top-level scope preserved")
+	require.Contains(t, srv.Paths, "services/api")
+	assert.Equal(t, "API", srv.Paths["services/api"].Project)
+	assert.Equal(t, "API_Build", srv.Paths["services/api"].Job)
+}
+
+func TestLinkAddsHTTPSSchemeWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	ts := cmdtest.SetupMockClient(t)
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "x.example", "--project", "Acme", "--job", "Acme_Build")
+
+	cfg, err := link.Load(filepath.Join(dir, link.FileName))
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 1)
+	assert.Equal(t, "https://x.example", cfg.Servers[0].URL,
+		"schemeless --server is stored with an https:// prefix so Match() can find it")
+}
+
+func TestLinkRefusesToOverwriteMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	path := filepath.Join(dir, link.FileName)
+	require.NoError(t, os.WriteFile(path, []byte("this is = not valid toml ]]"), 0o644))
+
+	ts := cmdtest.SetupMockClient(t)
+	err := cmdtest.CaptureErr(t, ts.Factory, "link",
+		"--server", "https://x.example", "--project", "Acme")
+	require.Error(t, err)
+
+	data, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(data), "not valid toml", "existing file must not be overwritten on parse error")
+}
+
+func TestLinkExplicitScopeOverride(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+
+	ts := cmdtest.SetupMockClient(t)
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "link",
+		"--server", "https://x.example", "--scope", "services/web",
+		"--project", "Web", "--job", "Web_Build")
+
+	cfg, err := link.Load(filepath.Join(dir, link.FileName))
+	require.NoError(t, err)
+	require.Len(t, cfg.Servers, 1)
+	require.Contains(t, cfg.Servers[0].Paths, "services/web")
+	assert.Equal(t, "Web", cfg.Servers[0].Paths["services/web"].Project)
+}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -112,14 +112,27 @@ func (opts *projectListOptions) fetch(client api.ClientInterface, fields []strin
 func newProjectViewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &cmdutil.ViewOptions{}
 	cmd := &cobra.Command{
-		Use:     "view <project-id>",
+		Use:     "view [project-id]",
 		Short:   "View project details",
+		Long:    `View details of a TeamCity project. With no argument, uses the linked project from teamcity.toml.`,
 		Aliases: []string{"show"},
-		Args:    cobra.ExactArgs(1),
+		Args:    cobra.MaximumNArgs(1),
 		Example: `  teamcity project view Falcon
-  teamcity project view Falcon --web`,
+  teamcity project view Falcon --web
+  teamcity project view              # uses linked project (see 'teamcity link')`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runProjectView(f, args[0], opts)
+			explicit := ""
+			if len(args) > 0 {
+				explicit = args[0]
+			}
+			projectID := f.ResolveProject(explicit)
+			if projectID == "" {
+				return api.Validation(
+					"project id is required",
+					"Pass <project-id> or run 'teamcity link' to bind this repository to a project",
+				)
+			}
+			return runProjectView(f, projectID, opts)
 		},
 	}
 	cmdutil.AddViewFlags(cmd, opts)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -12,6 +12,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/cmd/auth"
 	configcmd "github.com/JetBrains/teamcity-cli/internal/cmd/config"
 	"github.com/JetBrains/teamcity-cli/internal/cmd/job"
+	"github.com/JetBrains/teamcity-cli/internal/cmd/link"
 	"github.com/JetBrains/teamcity-cli/internal/cmd/pipeline"
 	"github.com/JetBrains/teamcity-cli/internal/cmd/pool"
 	"github.com/JetBrains/teamcity-cli/internal/cmd/project"
@@ -95,6 +96,7 @@ Report issues:  https://jb.gg/tc/issues`,
 	addGrouped(cmd, "config",
 		auth.NewCmd(f),
 		configcmd.NewCmd(f),
+		link.NewCmd(f),
 		alias.NewCmd(f),
 		apicmd.NewCmd(f),
 		skill.NewCmd(f),

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -98,6 +99,18 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 	client, err := f.Client()
 	if err != nil {
 		return err
+	}
+
+	// Explicit --job (or TEAMCITY_JOB) suppresses inferred project filter, since
+	// the job's buildType may live outside the linked project.
+	if opts.job == "" {
+		opts.job = os.Getenv(config.EnvJob)
+	}
+	if opts.job == "" {
+		opts.project = f.ResolveProject(opts.project)
+	}
+	if opts.job == "" && opts.project == "" {
+		opts.job = f.ResolveDefaultJob("")
 	}
 
 	request, err := resolveRunListRequest(client, opts, jsonResult.Fields)

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -155,10 +155,11 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "start <job-id>",
+		Use:   "start [job-id]",
 		Short: "Start a new run",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		Example: `  teamcity run start Falcon_Build
+  teamcity run start                              # uses linked default (see 'teamcity link')
   teamcity run start Falcon_Build --branch feature/test
   teamcity run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
   teamcity run start Falcon_Build --comment "Release build" --tag release --tag v1.0
@@ -169,7 +170,18 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run start Falcon_Build --revision abc123def --branch main
   teamcity run start Falcon_Build --dry-run`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRunStart(f, args[0], opts)
+			explicit := ""
+			if len(args) > 0 {
+				explicit = args[0]
+			}
+			jobID := f.ResolveDefaultJob(explicit)
+			if jobID == "" {
+				return api.Validation(
+					"job id is required",
+					"Pass <job-id> or run 'teamcity link' to bind a default job to this repository",
+				)
+			}
+			return runRunStart(f, jobID, opts)
 		},
 	}
 

--- a/internal/cmdtest/testutil.go
+++ b/internal/cmdtest/testutil.go
@@ -76,6 +76,7 @@ func NewTestServer(t *testing.T) *TestServer {
 	ts.Factory.ClientFunc = func() (api.ClientInterface, error) {
 		return api.NewClient(ts.URL, "test-token"), nil
 	}
+	ts.Factory.SkipLinkLookup() // tests must not pick up the host's teamcity.toml
 
 	t.Cleanup(func() {
 		ts.Close()

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -46,6 +46,9 @@ type Factory struct {
 
 	// UpdateNotice is called after command execution to print update notices.
 	UpdateNotice func()
+
+	// link caches teamcity.toml lookup; see link.go.
+	link *linkResolver
 }
 
 // NewFactory creates a Factory with production defaults.

--- a/internal/cmdutil/link.go
+++ b/internal/cmdutil/link.go
@@ -1,0 +1,89 @@
+package cmdutil
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/link"
+)
+
+type linkResolver struct {
+	once  sync.Once
+	scope link.PathScope
+	found bool
+}
+
+// SkipLinkLookup pre-resolves this Factory's link to empty, isolating Resolve* from the host's teamcity.toml.
+func (f *Factory) SkipLinkLookup() {
+	if f.link == nil {
+		f.link = &linkResolver{}
+	}
+	f.link.once.Do(func() {})
+}
+
+func (f *Factory) linkScope() (link.PathScope, bool) {
+	if f.link == nil {
+		f.link = &linkResolver{}
+	}
+	f.link.once.Do(func() {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return
+		}
+		path, ok := link.Find(cwd)
+		if !ok {
+			return
+		}
+		cfg, err := link.Load(path)
+		if err != nil {
+			if f.Printer != nil {
+				f.Printer.Warn("ignoring %s: %v", path, err)
+			}
+			return
+		}
+		srv := cfg.Match(config.GetServerURL())
+		if srv == nil {
+			return
+		}
+		f.link.scope = srv.Resolve(link.RelPath(filepath.Dir(path), cwd))
+		f.link.found = true
+	})
+	return f.link.scope, f.link.found
+}
+
+// ResolveProject returns explicit, then TEAMCITY_PROJECT, then the linked scope's project.
+func (f *Factory) ResolveProject(explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if v := os.Getenv(config.EnvProject); v != "" {
+		return v
+	}
+	if s, ok := f.linkScope(); ok {
+		return s.Project
+	}
+	return ""
+}
+
+// ResolveDefaultJob returns explicit, then TEAMCITY_JOB, then scope.Job, then a single Jobs entry.
+func (f *Factory) ResolveDefaultJob(explicit string) string {
+	if explicit != "" {
+		return explicit
+	}
+	if v := os.Getenv(config.EnvJob); v != "" {
+		return v
+	}
+	s, ok := f.linkScope()
+	if !ok {
+		return ""
+	}
+	if s.Job != "" {
+		return s.Job
+	}
+	if len(s.Jobs) == 1 {
+		return s.Jobs[0]
+	}
+	return ""
+}

--- a/internal/cmdutil/link_test.go
+++ b/internal/cmdutil/link_test.go
@@ -1,0 +1,141 @@
+package cmdutil
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/link"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func chdir(t *testing.T, dir string) {
+	t.Helper()
+	orig, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func writeFile(t *testing.T, dir string, c *link.Config) {
+	t.Helper()
+	require.NoError(t, link.Save(filepath.Join(dir, link.FileName), c))
+}
+
+func TestResolveCascadeMatchesActiveServer(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, dir, &link.Config{Servers: []link.Server{
+		{URL: "https://primary.example", Project: "Primary", Job: "Primary_Build"},
+		{URL: "https://nightly.example", Project: "Nightly", Jobs: []string{"Nightly_Release", "Nightly_Eval"}},
+	}})
+
+	t.Setenv(config.EnvServerURL, "https://primary.example")
+	t.Setenv(config.EnvProject, "")
+	t.Setenv(config.EnvJob, "")
+	assert.Equal(t, "Primary", (&Factory{}).ResolveProject(""))
+	assert.Equal(t, "Primary_Build", (&Factory{}).ResolveDefaultJob(""))
+
+	t.Setenv(config.EnvServerURL, "https://nightly.example")
+	assert.Equal(t, "Nightly", (&Factory{}).ResolveProject(""))
+	assert.Empty(t, (&Factory{}).ResolveDefaultJob(""), "two jobs is ambiguous → no auto-default")
+}
+
+func TestResolveExplicitAndEnvBeatFile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, dir, &link.Config{Servers: []link.Server{
+		{URL: "https://x.example", Project: "FromFile", Job: "FromFile_Build"},
+	}})
+
+	t.Setenv(config.EnvServerURL, "https://x.example")
+	t.Setenv(config.EnvProject, "FromEnv")
+	t.Setenv(config.EnvJob, "FromEnv_Job")
+	assert.Equal(t, "FromExplicit", (&Factory{}).ResolveProject("FromExplicit"))
+	assert.Equal(t, "FromExplicit_Job", (&Factory{}).ResolveDefaultJob("FromExplicit_Job"))
+	assert.Equal(t, "FromEnv", (&Factory{}).ResolveProject(""))
+	assert.Equal(t, "FromEnv_Job", (&Factory{}).ResolveDefaultJob(""))
+}
+
+func TestResolveNoMatchingServer(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, dir, &link.Config{Servers: []link.Server{
+		{URL: "https://only.example", Project: "OnlyOne"},
+	}})
+
+	t.Setenv(config.EnvServerURL, "https://elsewhere.example")
+	t.Setenv(config.EnvProject, "")
+	t.Setenv(config.EnvJob, "")
+	assert.Empty(t, (&Factory{}).ResolveProject(""))
+	assert.Empty(t, (&Factory{}).ResolveDefaultJob(""))
+}
+
+func TestResolveSingleJobsFallback(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, dir, &link.Config{Servers: []link.Server{
+		{URL: "https://x.example", Jobs: []string{"Only_Build"}},
+	}})
+
+	t.Setenv(config.EnvServerURL, "https://x.example")
+	t.Setenv(config.EnvJob, "")
+	assert.Equal(t, "Only_Build", (&Factory{}).ResolveDefaultJob(""))
+}
+
+func TestSkipLinkLookup(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	writeFile(t, dir, &link.Config{Servers: []link.Server{
+		{URL: "https://x.example", Project: "ShouldBeSkipped"},
+	}})
+
+	t.Setenv(config.EnvServerURL, "https://x.example")
+	f := &Factory{}
+	f.SkipLinkLookup()
+	assert.Empty(t, f.ResolveProject(""))
+}
+
+func TestResolveWarnsOnMalformedFile(t *testing.T) {
+	dir := t.TempDir()
+	chdir(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, link.FileName), []byte("not = valid = toml"), 0o644))
+
+	var stderr bytes.Buffer
+	f := &Factory{Printer: &output.Printer{Out: &bytes.Buffer{}, ErrOut: &stderr}}
+	t.Setenv(config.EnvServerURL, "https://x.example")
+	t.Setenv(config.EnvProject, "")
+
+	assert.Empty(t, f.ResolveProject(""))
+	assert.Contains(t, stderr.String(), link.FileName)
+}
+
+func TestResolvePathScopedFromSubdir(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "services", "api")
+	require.NoError(t, os.MkdirAll(sub, 0o755))
+	writeFile(t, dir, &link.Config{Servers: []link.Server{{
+		URL:     "https://x.example",
+		Project: "Mono",
+		Job:     "Mono_Build",
+		Paths: map[string]link.PathScope{
+			"services/api": {Project: "API", Job: "API_Build"},
+		},
+	}}})
+
+	t.Setenv(config.EnvServerURL, "https://x.example")
+	t.Setenv(config.EnvProject, "")
+	t.Setenv(config.EnvJob, "")
+
+	chdir(t, dir)
+	assert.Equal(t, "Mono", (&Factory{}).ResolveProject(""))
+	assert.Equal(t, "Mono_Build", (&Factory{}).ResolveDefaultJob(""))
+
+	chdir(t, sub)
+	assert.Equal(t, "API", (&Factory{}).ResolveProject(""))
+	assert.Equal(t, "API_Build", (&Factory{}).ResolveDefaultJob(""))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ const (
 	EnvGuestAuth = "TEAMCITY_GUEST"
 	EnvReadOnly  = "TEAMCITY_RO"
 	EnvDSLDir    = "TEAMCITY_DSL_DIR"
+	EnvProject   = "TEAMCITY_PROJECT"
+	EnvJob       = "TEAMCITY_JOB"
 
 	DefaultDSLDirTeamCity = ".teamcity"
 	DefaultDSLDirTC       = ".tc"

--- a/internal/link/link.go
+++ b/internal/link/link.go
@@ -1,0 +1,198 @@
+// Package link reads and writes teamcity.toml: a committed file binding a
+// repository to one or more TeamCity servers, with optional per-path overrides
+// inside each server entry.
+package link
+
+import (
+	"cmp"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// FileName is the canonical committed-config filename.
+const FileName = "teamcity.toml"
+
+// PathScope is a per-subdirectory binding inside a server entry.
+type PathScope struct {
+	Project string   `toml:"project,omitempty"`
+	Job     string   `toml:"job,omitempty"`
+	Jobs    []string `toml:"jobs,omitempty"`
+}
+
+// Server is one [[server]] entry: a TC instance with default project/job and
+// optional per-path overrides.
+type Server struct {
+	URL     string               `toml:"url"`
+	Project string               `toml:"project,omitempty"`
+	Job     string               `toml:"job,omitempty"`
+	Jobs    []string             `toml:"jobs,omitempty"`
+	Paths   map[string]PathScope `toml:"paths,omitempty"`
+}
+
+// Resolve returns the effective scope for rel — deepest path match overlaid on server-level defaults.
+func (s *Server) Resolve(rel string) PathScope {
+	rel = strings.Trim(rel, "/")
+	var best PathScope
+	bestLen := -1
+	for path, scope := range s.Paths {
+		if rel == path || strings.HasPrefix(rel, path+"/") {
+			if len(path) > bestLen {
+				best = scope
+				bestLen = len(path)
+			}
+		}
+	}
+	out := PathScope{
+		Project: cmp.Or(best.Project, s.Project),
+		Job:     cmp.Or(best.Job, s.Job),
+	}
+	if len(best.Jobs) > 0 {
+		out.Jobs = best.Jobs
+	} else {
+		out.Jobs = s.Jobs
+	}
+	return out
+}
+
+// Config is the parsed teamcity.toml.
+type Config struct {
+	Servers []Server `toml:"server,omitempty"`
+}
+
+// Match returns the entry for serverURL (compared with normalizeURL), or nil.
+func (c *Config) Match(serverURL string) *Server {
+	want := normalizeURL(serverURL)
+	if want == "" {
+		return nil
+	}
+	for i := range c.Servers {
+		if normalizeURL(c.Servers[i].URL) == want {
+			return &c.Servers[i]
+		}
+	}
+	return nil
+}
+
+// UpsertScope sets the scope for serverURL at path (path="" = server top-level); siblings preserved.
+func (c *Config) UpsertScope(serverURL, path string, scope PathScope) {
+	s := c.findOrCreate(serverURL)
+	if path == "" {
+		s.Project = scope.Project
+		s.Job = scope.Job
+		s.Jobs = scope.Jobs
+		return
+	}
+	if s.Paths == nil {
+		s.Paths = map[string]PathScope{}
+	}
+	s.Paths[path] = scope
+}
+
+func (c *Config) findOrCreate(serverURL string) *Server {
+	norm := normalizeURL(serverURL)
+	for i := range c.Servers {
+		if normalizeURL(c.Servers[i].URL) == norm {
+			return &c.Servers[i]
+		}
+	}
+	c.Servers = append(c.Servers, Server{URL: serverURL})
+	return &c.Servers[len(c.Servers)-1]
+}
+
+// Find walks up from start looking for FileName; returns absolute path + true on hit.
+// If start is inside a git working tree, the walk stops at the repo root so that
+// an unrelated teamcity.toml in an ancestor directory (e.g. $HOME) cannot leak in.
+func Find(start string) (string, bool) {
+	dir, err := filepath.Abs(start)
+	if err != nil {
+		return "", false
+	}
+	if r, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = r
+	}
+	stop := gitRootBoundary(dir)
+	for {
+		candidate := filepath.Join(dir, FileName)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, true
+		}
+		if stop != "" && dir == stop {
+			return "", false
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// gitRootBoundary returns the absolute path of the .git-containing ancestor of dir,
+// or "" if dir is not inside a git working tree. Uses only filesystem stats so it
+// has no dependency on the git binary.
+func gitRootBoundary(dir string) string {
+	for {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// RelPath returns target relative to root using forward slashes ("" at root); resolves symlinks first.
+func RelPath(root, target string) string {
+	root, _ = filepath.Abs(root)
+	target, _ = filepath.Abs(target)
+	if r, err := filepath.EvalSymlinks(root); err == nil {
+		root = r
+	}
+	if t, err := filepath.EvalSymlinks(target); err == nil {
+		target = t
+	}
+	rel, err := filepath.Rel(root, target)
+	if err != nil || rel == "." {
+		return ""
+	}
+	return filepath.ToSlash(rel)
+}
+
+// Load parses path into a Config.
+func Load(path string) (*Config, error) {
+	var c Config
+	if _, err := toml.DecodeFile(path, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+// Save writes c to path.
+func Save(path string, c *Config) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	return toml.NewEncoder(f).Encode(c)
+}
+
+// normalizeURL trims trailing slashes and lowercases scheme+host for stable comparison.
+func normalizeURL(u string) string {
+	u = strings.TrimSpace(u)
+	u = strings.TrimRight(u, "/")
+	if i := strings.Index(u, "://"); i > 0 {
+		head := strings.ToLower(u[:i+3])
+		rest := u[i+3:]
+		if j := strings.IndexAny(rest, "/?#"); j > 0 {
+			return head + strings.ToLower(rest[:j]) + rest[j:]
+		}
+		return head + strings.ToLower(rest)
+	}
+	return strings.ToLower(u)
+}

--- a/internal/link/link_test.go
+++ b/internal/link/link_test.go
@@ -1,0 +1,109 @@
+package link
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoundTripWithPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, FileName)
+	in := &Config{Servers: []Server{
+		{URL: "https://a.example", Project: "A", Job: "A_Build", Paths: map[string]PathScope{
+			"services/api": {Project: "A_API", Job: "A_API_Build"},
+			"services/web": {Project: "A_Web", Jobs: []string{"A_Web_Build", "A_Web_Deploy"}},
+		}},
+		{URL: "https://b.example", Project: "B"},
+	}}
+	require.NoError(t, Save(path, in))
+
+	got, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, in, got)
+}
+
+func TestServerResolveDeepestPath(t *testing.T) {
+	s := &Server{
+		Project: "Mono",
+		Job:     "Mono_Build",
+		Paths: map[string]PathScope{
+			"services/api":    {Project: "API"},
+			"services/api/v2": {Project: "APIv2", Job: "APIv2_Build"},
+			"web":             {Jobs: []string{"Web_Build", "Web_Deploy"}},
+		},
+	}
+
+	assert.Equal(t, PathScope{Project: "Mono", Job: "Mono_Build"}, s.Resolve("docs"))
+	assert.Equal(t, PathScope{Project: "API", Job: "Mono_Build"}, s.Resolve("services/api/handlers"))
+	assert.Equal(t, PathScope{Project: "APIv2", Job: "APIv2_Build"}, s.Resolve("services/api/v2/internal"))
+	assert.Equal(t, PathScope{Project: "Mono", Job: "Mono_Build", Jobs: []string{"Web_Build", "Web_Deploy"}}, s.Resolve("web/components"))
+}
+
+func TestMatchNormalizesURL(t *testing.T) {
+	c := &Config{Servers: []Server{
+		{URL: "https://A.Example.com/", Project: "A"},
+		{URL: "https://b.example", Project: "B"},
+	}}
+	assert.Equal(t, "A", c.Match("https://a.example.com").Project)
+	assert.Equal(t, "B", c.Match("https://b.example/").Project)
+	assert.Nil(t, c.Match("https://other.example"))
+	assert.Nil(t, c.Match(""))
+}
+
+func TestUpsertScopeReplacesAtPath(t *testing.T) {
+	c := &Config{}
+	c.UpsertScope("https://a.example", "", PathScope{Project: "Old"})
+	c.UpsertScope("https://A.example/", "", PathScope{Project: "New", Job: "New_Build"})
+	require.Len(t, c.Servers, 1)
+	assert.Equal(t, "New", c.Servers[0].Project)
+	assert.Equal(t, "New_Build", c.Servers[0].Job)
+}
+
+func TestUpsertScopePreservesSiblings(t *testing.T) {
+	c := &Config{}
+	c.UpsertScope("https://a.example", "", PathScope{Project: "Mono", Job: "Mono_Build"})
+	c.UpsertScope("https://a.example", "services/api", PathScope{Project: "API"})
+	c.UpsertScope("https://a.example", "services/web", PathScope{Project: "Web"})
+	c.UpsertScope("https://b.example", "", PathScope{Project: "B"})
+
+	require.Len(t, c.Servers, 2)
+	a := c.Servers[0]
+	assert.Equal(t, "Mono", a.Project, "top-level scope preserved when upserting paths")
+	assert.Equal(t, "API", a.Paths["services/api"].Project)
+	assert.Equal(t, "Web", a.Paths["services/web"].Project)
+	assert.Equal(t, "B", c.Servers[1].Project)
+}
+
+func TestFindWalksUp(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(root, FileName), []byte(""), 0o644))
+
+	got, ok := Find(deep)
+	require.True(t, ok)
+	want, _ := filepath.EvalSymlinks(filepath.Join(root, FileName))
+	gotResolved, _ := filepath.EvalSymlinks(got)
+	assert.Equal(t, want, gotResolved)
+}
+
+func TestFindMissing(t *testing.T) {
+	_, ok := Find(t.TempDir())
+	assert.False(t, ok)
+}
+
+func TestFindStopsAtGitRoot(t *testing.T) {
+	outer := t.TempDir()
+	repo := filepath.Join(outer, "repo")
+	deep := filepath.Join(repo, "a", "b")
+	require.NoError(t, os.MkdirAll(deep, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(repo, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(outer, FileName), []byte(""), 0o644))
+
+	_, ok := Find(deep)
+	assert.False(t, ok, "Find must not walk past the git root")
+}

--- a/teamcity.toml
+++ b/teamcity.toml
@@ -1,0 +1,9 @@
+[[server]]
+  url = "https://cli.teamcity.com"
+  project = "CLI"
+  job = "CLI_CiCd"
+
+[[server]]
+  url = "https://teamcity-nightly.labs.intellij.net"
+  project = "TeamCity_TeamCityCLI"
+  jobs = ["TeamCity_TeamCityCLI_Release", "TeamCity_TeamCityCLI_SkillEval"]


### PR DESCRIPTION
## Summary

Adds `teamcity link` which upserts `[[server]]` entries (with optional per-path scopes) in a committed `teamcity.toml`. Project- and job-aware commands (`run list`, `run start`, `job list`, `project view`) then resolve their target without explicit flags by matching the active TC server URL against an entry, then the deepest matching `paths."..."` for cwd. Works without git.

Fixes #201

## Schema

```toml
[[server]]
url     = "https://primary.example"
project = "Acme_Mono"
job     = "Acme_Mono_Build"

[server.paths."services/api"]
project = "Acme_API"
job     = "Acme_API_Build"

[server.paths."services/web"]
project = "Acme_Web"
jobs    = ["Acme_Web_Build", "Acme_Web_Deploy"]

[[server]]
url     = "https://nightly.example"
project = "Acme_Nightly"
jobs    = ["Acme_Nightly_Release", "Acme_Nightly_Eval"]
```

The `[[server]]` array supports repos whose CI spans multiple TeamCity instances (matched by normalized URL: trailing slash, scheme/host case). Inside each server, `[server.paths."..."]` overrides the top-level scope for a sub-path. Each empty field in a path scope falls back to the server-level value.

## Resolution cascade

```
explicit --flag   →   TEAMCITY_PROJECT / TEAMCITY_JOB env   →   matching [[server]] entry → deepest path scope
```

Notes:
- `run list --job X` deliberately suppresses the inferred project filter — combining them can hide builds whose `buildType` lives outside the linked project.
- A malformed `teamcity.toml` is surfaced via a one-shot `Warn` to stderr instead of silent fallback.

## Changes

- `internal/link`: `Server` (with `Paths map[string]PathScope`), `Config`, walk-up `Find`, `RelPath`, `Load`, `Save`, normalized-URL `Match`, `UpsertScope(url, path, scope)` that preserves siblings, `Server.Resolve(rel)` returning the effective `PathScope` (deepest match overlaid on server defaults).
- `internal/cmdutil`: `Factory.ResolveProject` / `ResolveDefaultJob` match the active server URL then resolve cwd-rel-to-toml-dir; `SkipLinkLookup()` for tests; `cmdtest.NewTestServer` calls it automatically.
- `internal/cmd/link`: cobra command with `--server`, `--project`, `--job`, `--jobs`, `--scope`. The path scope defaults to cwd-rel-to-toml-dir; `--scope=` writes to the top-level scope explicitly.
- Wired `Resolve*` into `run list`, `job list`, `project view` (zero-arg), `run start` (zero-arg).
- New env vars: `TEAMCITY_PROJECT`, `TEAMCITY_JOB`.
- New dep: `github.com/BurntSushi/toml`.

## Design decisions

- **`teamcity.toml` over `.git/config`** — works without git, can be committed to share defaults across the team, follows `Cargo.toml` / `fly.toml` / `wrangler.toml` precedent. Original issue's `.git/config`-only design (and a brief layered version) were rejected: "CI is one for all" — single source of truth, no overrides.
- **No collision with existing TeamCity files** — `.teamcity.yml` is TeamCity's YAML pipeline default; `.teamcity/` is the Kotlin DSL directory. Top-level `teamcity.toml` (visible, no leading dot, different format) sits in its own namespace.
- **TOML over YAML/JSON** — flat, hand-edited; strict parsing avoids YAML's `country: NO → false` quirks.
- **`[[server]]` array, not single scope** — multi-instance CI is real (we hit it ourselves linking this PR's repo to two servers).
- **`[server.paths."..."]` for monorepos** — per-subdirectory overrides without nesting; deepest match wins, falls back to server-level defaults per field.
- **No `--list` / `--clear`** — `cat teamcity.toml` and `rm teamcity.toml` work.
- **No `Status` / `--status` field** — designed for a `run status <sha>` command that doesn't exist yet. Trivial to add when it lands.

## Example

```bash
$ teamcity link --server https://cli.teamcity.com --project CLI --job CLI_CiCd
✓ Linked https://cli.teamcity.com — (top-level)
  Project: CLI
  Default job: CLI_CiCd
  Wrote: /repo/teamcity.toml

$ cd services/api
$ teamcity link --project Acme_API --job Acme_API_Build
✓ Linked https://cli.teamcity.com — services/api
  Project: Acme_API
  Default job: Acme_API_Build

$ teamcity run start            # uses Acme_API_Build (cwd matches services/api scope)
$ cd .. && teamcity run start   # uses CLI_CiCd (top-level)
```

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass — 4 scripts in `acceptance/testdata/link/` (`link-help`, `link-write`, `link-paths`, `link-resolves-into-commands`); the last is gated on `TC_ACCEPTANCE_TOKEN`
- [x] Updated `acceptance/testdata/run/run-validation.txtar` for the new `run start` zero-arg error message
- [ ] If adding a data-producing command: includes `--json` support — N/A, `link` is configuration
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — follow-up