### PR TITLE
fix(tests): resolve sandbox proxy IPv4/IPv6 mismatch on macOS

### DIFF
--- a/api/sandbox_test.go
+++ b/api/sandbox_test.go
@@ -49,8 +49,17 @@ func TestSandboxGuestAuth(T *testing.T) {
 		}
 	}`), 0o644))
 
+	// sandbox-runtime sets HTTPS_PROXY=localhost but may bind IPv4-only → force 127.0.0.1
+	wrapper := filepath.Join(T.TempDir(), "proxy-fix.sh")
+	require.NoError(T, os.WriteFile(wrapper, []byte(`#!/bin/sh
+HTTPS_PROXY=$(echo "$HTTPS_PROXY" | sed 's/localhost/127.0.0.1/g; s/\[::1\]/127.0.0.1/g')
+HTTP_PROXY=$(echo "$HTTP_PROXY" | sed 's/localhost/127.0.0.1/g; s/\[::1\]/127.0.0.1/g')
+export HTTPS_PROXY HTTP_PROXY
+exec "$@"
+`), 0o755))
+
 	sandboxCmd := func(env []string, args ...string) *exec.Cmd {
-		full := []string{"@anthropic-ai/sandbox-runtime", "-s", settings}
+		full := []string{"@anthropic-ai/sandbox-runtime", "-s", settings, wrapper}
 		full = append(full, args...)
 		cmd := exec.Command(npx, full...)
 		cmd.Env = append(os.Environ(), env...)


### PR DESCRIPTION
## Summary

Fix flaky `TestSandboxGuestAuth` on macOS agents.

## Changes

- Wrapper script rewrites `localhost`/`[::1]` to `127.0.0.1` in proxy env vars before exec'ing the CLI binary

## Design Decisions

sandbox-runtime's proxy binds to `127.0.0.1` (IPv4) but sets `HTTPS_PROXY=localhost`, which Go resolves to `[::1]` (IPv6) on some macOS agents → connection refused. A retry wouldn't help since DNS resolution is deterministic per host.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Sandbox test passes on macOS CI agents that previously flaked