### PR TITLE
ci: switch test output to gotestsum for cleaner CI logs

### DIFF
--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -7,8 +7,10 @@ jobs:
       env.PATH: '%env.GOBIN%:%env.PATH%'
     steps:
       - type: script
-        name: Install gotestsum
-        script-content: go install gotest.tools/gotestsum@latest
+        name: Setup
+        script-content: |-
+          go mod download
+          go install gotest.tools/gotestsum@latest
       - type: script
         name: Unit Tests
         script-content: >-
@@ -31,8 +33,10 @@ jobs:
       env.PATH: '%env.GOBIN%;%env.PATH%'
     steps:
       - type: script
-        name: Install gotestsum
-        script-content: go install gotest.tools/gotestsum@latest
+        name: Setup
+        script-content: |-
+          go mod download
+          go install gotest.tools/gotestsum@latest
       - type: script
         name: Unit Tests
         script-content: >-
@@ -71,8 +75,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y golang-1.26-go
       - type: script
-        name: Install gotestsum
-        script-content: go install gotest.tools/gotestsum@latest
+        name: Setup
+        script-content: |-
+          go mod download
+          go install gotest.tools/gotestsum@latest
       - type: script
         name: Integration Tests
         script-content: >-
@@ -123,8 +129,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y golang-1.26-go
       - type: script
-        name: Install gotestsum
-        script-content: go install gotest.tools/gotestsum@latest
+        name: Setup
+        script-content: |-
+          go mod download
+          go install gotest.tools/gotestsum@latest
       - type: script
         name: Integration Tests
         script-content: >-

--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -3,6 +3,8 @@ jobs:
   test_macos:
     name: Test macOS
     runs-on: macOS-14-Sonoma-Medium-Arm64
+    parameters:
+      env.PATH: '%env.GOBIN%:%env.PATH%'
     steps:
       - type: script
         name: Install gotestsum
@@ -25,6 +27,8 @@ jobs:
   test_windows:
     name: Test Windows
     runs-on: Windows-Medium
+    parameters:
+      env.PATH: '%env.GOBIN%;%env.PATH%'
     steps:
       - type: script
         name: Install gotestsum
@@ -58,7 +62,7 @@ jobs:
     runs-on: Ubuntu-24.04-Large
     parameters:
       env.GOROOT: /usr/lib/go-1.26
-      env.PATH: /usr/lib/go-1.26/bin:%env.PATH%
+      env.PATH: /usr/lib/go-1.26/bin:%env.GOBIN%:%env.PATH%
     steps:
       - type: script
         name: Install Go
@@ -110,7 +114,7 @@ jobs:
     runs-on: Ubuntu-24.04-Large-Arm64
     parameters:
       env.GOROOT: /usr/lib/go-1.26
-      env.PATH: /usr/lib/go-1.26/bin:%env.PATH%
+      env.PATH: /usr/lib/go-1.26/bin:%env.GOBIN%:%env.PATH%
     steps:
       - type: script
         name: Install Go
@@ -170,4 +174,5 @@ parameters:
   env.TC_INSECURE_SKIP_WARN: '1'
   env.GOPROXY: https://proxy.golang.org,direct
   env.GOFLAGS: '-buildvcs=false'
+  env.GOBIN: '%system.teamcity.build.checkoutDir%/.gobin'
   env.BRANCH_NAME: '%teamcity.build.branch%'

--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -5,30 +5,40 @@ jobs:
     runs-on: macOS-14-Sonoma-Medium-Arm64
     steps:
       - type: script
+        name: Install gotestsum
+        script-content: go install gotest.tools/gotestsum@latest
+      - type: script
         name: Unit Tests
-        script-content: go test -race -count=1 -shuffle=on -v ./... -timeout 15m
+        script-content: >-
+          gotestsum --format pkgname-and-test-fails --
+          -race -count=1 -shuffle=on ./... -timeout 15m
       - type: script
         name: Acceptance Tests
         script-content: >-
-          go test -count=1 -shuffle=on -v -tags=acceptance ./acceptance -timeout
-          10m
+          gotestsum --format pkgname-and-test-fails --
+          -count=1 -shuffle=on -tags=acceptance ./acceptance -timeout 10m
       - type: script
         name: Sandbox Tests
         script-content: |-
           HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_ENV_HINTS=1 brew install -q ripgrep
-          go test -count=1 -v -tags=sandbox ./api -run TestSandbox -timeout 2m
+          gotestsum --format pkgname-and-test-fails -- -count=1 -tags=sandbox ./api -run TestSandbox -timeout 2m
   test_windows:
     name: Test Windows
     runs-on: Windows-Medium
     steps:
       - type: script
+        name: Install gotestsum
+        script-content: go install gotest.tools/gotestsum@latest
+      - type: script
         name: Unit Tests
-        script-content: go test -race -count=1 -shuffle=on -v ./... -timeout 15m
+        script-content: >-
+          gotestsum --format pkgname-and-test-fails --
+          -race -count=1 -shuffle=on ./... -timeout 15m
       - type: script
         name: Acceptance Tests
         script-content: >-
-          go test -count=1 -shuffle=on -v -tags=acceptance ./acceptance -timeout
-          10m
+          gotestsum --format pkgname-and-test-fails --
+          -count=1 -shuffle=on -tags=acceptance ./acceptance -timeout 10m
       - type: script
         name: Verify install.ps1
         script-content: |-
@@ -57,28 +67,31 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y golang-1.26-go
       - type: script
+        name: Install gotestsum
+        script-content: go install gotest.tools/gotestsum@latest
+      - type: script
         name: Integration Tests
         script-content: >-
-          go test -race -count=1 -shuffle=on -v ./... -tags=integration -timeout
-          15m \
-            -coverpkg=./... -coverprofile=coverage-integration.out
+          gotestsum --format pkgname-and-test-fails --
+          -race -count=1 -shuffle=on ./... -tags=integration -timeout 15m
+          -coverpkg=./... -coverprofile=coverage-integration.out
       - type: script
         name: Guest Auth Tests
         script-content: >-
-          TEAMCITY_GUEST=1 go test -race -count=1 -shuffle=on -v ./api/...
-          -tags=guest -timeout 15m \
-            -coverpkg=./... -coverprofile=coverage-guest.out
+          TEAMCITY_GUEST=1 gotestsum --format pkgname-and-test-fails --
+          -race -count=1 -shuffle=on ./api/... -tags=guest -timeout 15m
+          -coverpkg=./... -coverprofile=coverage-guest.out
       - type: script
         name: Acceptance Tests
         script-content: >-
-          go test -count=1 -shuffle=on -v -tags=acceptance ./acceptance -timeout
-          10m
+          gotestsum --format pkgname-and-test-fails --
+          -count=1 -shuffle=on -tags=acceptance ./acceptance -timeout 10m
       - type: script
         name: Sandbox Tests
         script-content: |-
           sudo apt-get install -y bubblewrap socat ripgrep
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          go test -count=1 -v -tags=sandbox ./api -run TestSandbox -timeout 2m
+          gotestsum --format pkgname-and-test-fails -- -count=1 -tags=sandbox ./api -run TestSandbox -timeout 2m
       - type: script
         name: Merge Coverage
         script-content: |-
@@ -106,28 +119,31 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y golang-1.26-go
       - type: script
+        name: Install gotestsum
+        script-content: go install gotest.tools/gotestsum@latest
+      - type: script
         name: Integration Tests
         script-content: >-
-          go test -race -count=1 -shuffle=on -v ./... -tags=integration -timeout
-          15m \
-            -coverpkg=./... -coverprofile=coverage-integration.out
+          gotestsum --format pkgname-and-test-fails --
+          -race -count=1 -shuffle=on ./... -tags=integration -timeout 15m
+          -coverpkg=./... -coverprofile=coverage-integration.out
       - type: script
         name: Guest Auth Tests
         script-content: >-
-          TEAMCITY_GUEST=1 go test -race -count=1 -shuffle=on -v ./api/...
-          -tags=guest -timeout 15m \
-            -coverpkg=./... -coverprofile=coverage-guest.out
+          TEAMCITY_GUEST=1 gotestsum --format pkgname-and-test-fails --
+          -race -count=1 -shuffle=on ./api/... -tags=guest -timeout 15m
+          -coverpkg=./... -coverprofile=coverage-guest.out
       - type: script
         name: Acceptance Tests
         script-content: >-
-          go test -count=1 -shuffle=on -v -tags=acceptance ./acceptance -timeout
-          10m
+          gotestsum --format pkgname-and-test-fails --
+          -count=1 -shuffle=on -tags=acceptance ./acceptance -timeout 10m
       - type: script
         name: Sandbox Tests
         script-content: |-
           sudo apt-get install -y bubblewrap socat ripgrep
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
-          go test -count=1 -v -tags=sandbox ./api -run TestSandbox -timeout 2m
+          gotestsum --format pkgname-and-test-fails -- -count=1 -tags=sandbox ./api -run TestSandbox -timeout 2m
       - type: script
         name: Merge Coverage
         script-content: |-

--- a/justfile
+++ b/justfile
@@ -23,21 +23,24 @@ lint:
 install:
     go install ./tc
 
+# gotestsum format: "pkgname" locally, override with GOTESTSUM_FORMAT=dots etc.
+gotestsum_format := env("GOTESTSUM_FORMAT", "pkgname")
+
 # Run unit tests
 unit:
-    go test -race -shuffle=on -v ./internal/config ./internal/errors ./internal/output ./internal/cmd
+    gotestsum --format {{gotestsum_format}} -- -race -shuffle=on ./internal/config ./internal/errors ./internal/output ./internal/cmd
 
 # Run all tests with coverage
 test:
-    go test -race -shuffle=on -v ./... -timeout 15m -tags=integration -coverprofile=coverage.out -coverpkg=./...
+    gotestsum --format {{gotestsum_format}} -- -race -shuffle=on ./... -timeout 15m -tags=integration -coverprofile=coverage.out -coverpkg=./...
 
 # Run acceptance tests against cli.teamcity.com (guest auth)
 acceptance:
-    go test -v -tags=acceptance ./acceptance -timeout 10m
+    gotestsum --format {{gotestsum_format}} -- -tags=acceptance ./acceptance -timeout 10m
 
 # Run sandbox integration tests (requires npx, bubblewrap+socat on Linux)
 sandbox:
-    go test -v -tags=sandbox ./api -run TestSandbox -timeout 2m
+    gotestsum --format {{gotestsum_format}} -- -tags=sandbox ./api -run TestSandbox -timeout 2m
 
 # Remove build artifacts
 [confirm]


### PR DESCRIPTION
## Summary

Replace raw `go test -v` with `gotestsum` across CI and local test recipes. This groups output by package and only prints details for failing tests — much less noise in Pipelines build logs.

## Changes

- **`.teamcity.yml`**: Add `go install gotest.tools/gotestsum@latest` step to each job; replace all `go test -v` invocations with `gotestsum --format pkgname-and-test-fails`
- **`justfile`**: Switch `unit`, `test`, `acceptance`, `sandbox` recipes to use `gotestsum --format pkgname`; format is configurable via `GOTESTSUM_FORMAT` env var

## Design Decisions

- **`pkgname-and-test-fails` for CI**: Shows one line per package during progress, then full output only for failing tests. Best signal-to-noise for build logs.
- **`pkgname` for local**: Slightly more compact; devs can override with `GOTESTSUM_FORMAT=dots just unit` etc.
- **No JUnit XML yet**: Pipelines doesn't support test reporting yet; easy to add `--junitfile` later when it does.
- **`go install` per job** (not cached): Simple and reliable. `gotestsum` installs in ~2s, not worth caching complexity.

## Example

Before (every test prints `=== RUN`, `--- PASS`):
```
=== RUN   TestRunList
=== RUN   TestRunList/default
--- PASS: TestRunList/default (0.01s)
=== RUN   TestRunList/with_status
--- PASS: TestRunList/with_status (0.00s)
...hundreds more lines...
```

After:
```
✓  internal/cmd (2.1s)
✓  internal/config (0.3s)
✓  internal/output (1.8s)
✗  api (4.2s)
    === FAIL: TestClientGet (0.01s)
        expected 200, got 404

DONE 342 tests, 1 failure in 4.8s
```

## Test Plan

- [x] Linter passes (`just lint`)
- [x] Verified `gotestsum` output locally with `just unit`
- [ ] CI runs pass on this PR (all platforms)