### PR TITLE
feat(run): show compatible/incompatible agents for queued builds

### DIFF
--- a/api/agents.go
+++ b/api/agents.go
@@ -129,7 +129,7 @@ func (c *Client) GetAgentCompatibleBuildTypes(id int) (*BuildTypeList, error) {
 
 // GetAgentIncompatibleBuildTypes returns build types incompatible with an agent and reasons
 func (c *Client) GetAgentIncompatibleBuildTypes(id int) (*CompatibilityList, error) {
-	fields := "count,compatibility(buildType(id,name,projectName),incompatibleReasons(reason))"
+	fields := "count,compatibility(buildType(id,name,projectName),incompatibleReasons(reason),unmetRequirements(description))"
 	path := fmt.Sprintf("/app/rest/agents/id:%d/incompatibleBuildTypes?fields=%s", id, url.QueryEscape(fields))
 
 	var result CompatibilityList
@@ -138,6 +138,55 @@ func (c *Client) GetAgentIncompatibleBuildTypes(id int) (*CompatibilityList, err
 	}
 
 	return &result, nil
+}
+
+const buildAgentsFields = "count,agent(id,name,pool(id,name),connected,enabled,authorized)"
+
+// GetBuildCompatibleAgents returns agents compatible with the given build, including disconnected ones.
+func (c *Client) GetBuildCompatibleAgents(buildID int) (*AgentList, error) {
+	locator := fmt.Sprintf("compatible:(build:(id:%d)),defaultFilter:false", buildID)
+	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(buildAgentsFields))
+
+	var result AgentList
+	if err := c.get(path, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetBuildIncompatibleAgents returns agents incompatible with the given build.
+func (c *Client) GetBuildIncompatibleAgents(buildID int) (*AgentList, error) {
+	locator := fmt.Sprintf("incompatible:(build:(id:%d)),defaultFilter:false", buildID)
+	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(buildAgentsFields))
+
+	var result AgentList
+	if err := c.get(path, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetAgentBuildTypeCompatibility finds the (agent, buildType) entry in incompatibleBuildTypes, scanning at most maxScan.
+func (c *Client) GetAgentBuildTypeCompatibility(agentID int, buildTypeID string, maxScan int) (*Compatibility, error) {
+	if maxScan <= 0 {
+		maxScan = 5000
+	}
+	fields := "count,compatibility(buildType(id),compatible,incompatibleReasons(reason),unmetRequirements(description))"
+	locator := fmt.Sprintf("id:%s,count:%d", buildTypeID, maxScan)
+	path := fmt.Sprintf("/app/rest/agents/id:%d/incompatibleBuildTypes?locator=%s&fields=%s",
+		agentID, url.QueryEscape(locator), url.QueryEscape(fields))
+
+	var result CompatibilityList
+	if err := c.get(path, &result); err != nil {
+		return nil, err
+	}
+	for i := range result.Compatibility {
+		bt := result.Compatibility[i].BuildType
+		if bt != nil && bt.ID == buildTypeID {
+			return &result.Compatibility[i], nil
+		}
+	}
+	return nil, nil
 }
 
 // RebootAgent requests a reboot of the specified agent.

--- a/api/agents.go
+++ b/api/agents.go
@@ -148,7 +148,7 @@ func (c *Client) GetBuildCompatibleAgents(buildID int) (*AgentList, error) {
 	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(buildAgentsFields))
 
 	var result AgentList
-	if err := c.get(path, &result); err != nil {
+	if err := c.get(context.Background(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -160,7 +160,7 @@ func (c *Client) GetBuildIncompatibleAgents(buildID int) (*AgentList, error) {
 	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(buildAgentsFields))
 
 	var result AgentList
-	if err := c.get(path, &result); err != nil {
+	if err := c.get(context.Background(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -177,7 +177,7 @@ func (c *Client) GetAgentBuildTypeCompatibility(agentID int, buildTypeID string,
 		agentID, url.QueryEscape(locator), url.QueryEscape(fields))
 
 	var result CompatibilityList
-	if err := c.get(path, &result); err != nil {
+	if err := c.get(context.Background(), path, &result); err != nil {
 		return nil, err
 	}
 	for i := range result.Compatibility {

--- a/api/agents_test.go
+++ b/api/agents_test.go
@@ -143,6 +143,76 @@ func TestGetAgentIncompatibleBuildTypes(t *testing.T) {
 	assert.Equal(t, 0, result.Count)
 }
 
+func TestGetBuildCompatibleAgents(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "compatible%3A%28build%3A%28id%3A99%29%29")
+		assert.Contains(t, r.URL.RawQuery, "defaultFilter%3Afalse")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(AgentList{
+			Count:  1,
+			Agents: []Agent{{ID: 7, Name: "compat-agent", Pool: &Pool{Name: "Linux"}}},
+		})
+	})
+	result, err := client.GetBuildCompatibleAgents(99)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.Count)
+	assert.Equal(t, "compat-agent", result.Agents[0].Name)
+}
+
+func TestGetBuildIncompatibleAgents(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.RawQuery, "incompatible%3A%28build%3A%28id%3A99%29%29")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(AgentList{Count: 0})
+	})
+	result, err := client.GetBuildIncompatibleAgents(99)
+	require.NoError(t, err)
+	assert.Equal(t, 0, result.Count)
+}
+
+func TestGetAgentBuildTypeCompatibility_match(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/app/rest/agents/id:5/incompatibleBuildTypes")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(CompatibilityList{
+			Count: 2,
+			Compatibility: []Compatibility{
+				{BuildType: &BuildType{ID: "Other_BT"}},
+				{BuildType: &BuildType{ID: "Target_BT"}, UnmetRequirements: &UnmetRequirements{Description: "Missing: docker"}},
+			},
+		})
+	})
+	c, err := client.GetAgentBuildTypeCompatibility(5, "Target_BT", 100)
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	assert.Equal(t, "Target_BT", c.BuildType.ID)
+	assert.Equal(t, []string{"Missing: docker"}, c.ReasonsList())
+}
+
+func TestGetAgentBuildTypeCompatibility_noMatch(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(CompatibilityList{Count: 1, Compatibility: []Compatibility{{BuildType: &BuildType{ID: "Other_BT"}}}})
+	})
+	c, err := client.GetAgentBuildTypeCompatibility(5, "Target_BT", 100)
+	require.NoError(t, err)
+	assert.Nil(t, c)
+}
+
+func TestReasonsListMergesLegacyAndUnmet(t *testing.T) {
+	t.Parallel()
+	c := Compatibility{
+		Reasons:           &IncompatibleReasons{Reasons: []string{"old-style reason"}},
+		UnmetRequirements: &UnmetRequirements{Description: "Unmet requirements:\n\tline A\n\tline B"},
+	}
+	reasons := c.ReasonsList()
+	assert.Equal(t, []string{"old-style reason", "Unmet requirements:", "line A", "line B"}, reasons)
+}
+
 func TestRebootAgent(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -104,6 +104,9 @@ type ClientInterface interface {
 	RebootAgent(ctx context.Context, id int, afterBuild bool) error
 	GetAgentCompatibleBuildTypes(id int) (*BuildTypeList, error)
 	GetAgentIncompatibleBuildTypes(id int) (*CompatibilityList, error)
+	GetBuildCompatibleAgents(buildID int) (*AgentList, error)
+	GetBuildIncompatibleAgents(buildID int) (*AgentList, error)
+	GetAgentBuildTypeCompatibility(agentID int, buildTypeID string, maxScan int) (*Compatibility, error)
 
 	// Agent Pools
 	GetAgentPools(fields []string) (*PoolList, error)

--- a/api/types.go
+++ b/api/types.go
@@ -134,10 +134,11 @@ type PoolList struct {
 
 // Compatibility represents build type compatibility info
 type Compatibility struct {
-	Compatible bool                 `json:"compatible"`
-	BuildType  *BuildType           `json:"buildType,omitempty"`
-	Agent      *Agent               `json:"agent,omitempty"`
-	Reasons    *IncompatibleReasons `json:"incompatibleReasons,omitempty"`
+	Compatible        bool                 `json:"compatible"`
+	BuildType         *BuildType           `json:"buildType,omitempty"`
+	Agent             *Agent               `json:"agent,omitempty"`
+	Reasons           *IncompatibleReasons `json:"incompatibleReasons,omitempty"`
+	UnmetRequirements *UnmetRequirements   `json:"unmetRequirements,omitempty"`
 }
 
 // CompatibilityList represents a list of compatibility entries
@@ -149,6 +150,27 @@ type CompatibilityList struct {
 // IncompatibleReasons contains reasons why an agent can't run a build type
 type IncompatibleReasons struct {
 	Reasons []string `json:"reason,omitempty"`
+}
+
+// UnmetRequirements holds the human-readable incompatibility description (may be multi-line).
+type UnmetRequirements struct {
+	Description string `json:"description,omitempty"`
+}
+
+// ReasonsList merges the legacy incompatibleReasons.reason array with unmetRequirements.description.
+func (c *Compatibility) ReasonsList() []string {
+	var out []string
+	if c.Reasons != nil {
+		out = append(out, c.Reasons.Reasons...)
+	}
+	if c.UnmetRequirements != nil && c.UnmetRequirements.Description != "" {
+		for line := range strings.SplitSeq(c.UnmetRequirements.Description, "\n") {
+			if trimmed := strings.TrimSpace(line); trimmed != "" {
+				out = append(out, trimmed)
+			}
+		}
+	}
+	return out
 }
 
 // QueuedBuild represents a build in the queue

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -486,6 +486,82 @@ func TestRunView_waitReason(t *testing.T) {
 	})
 	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "view", "60")
 	assert.Contains(t, got, "Wait reason: No compatible agents available")
+	assert.Contains(t, got, "Compatible agents")
+	assert.Contains(t, got, "Incompatible agents")
+}
+
+func TestRunView_waitReason_nonCompatibility_skipsAgentQuery(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/builds/id:65", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Build{
+			ID: 65, State: "queued", BuildTypeID: "TestProject_Build",
+			BuildType:  &api.BuildType{ID: "TestProject_Build", Name: "Build"},
+			WebURL:     "https://ci.example.com/viewLog.html?buildId=65",
+			Triggered:  &api.Triggered{Type: "user", User: &api.User{Name: "Bob"}},
+			WaitReason: "Build dependencies have not been built yet",
+		})
+	})
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "view", "65")
+	assert.Contains(t, got, "Wait reason: Build dependencies have not been built yet")
+	assert.NotContains(t, got, "Compatible agents")
+	assert.NotContains(t, got, "Incompatible agents")
+}
+
+func TestRunView_compatibilityDetails(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/builds/id:71", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Build{
+			ID:          71,
+			Number:      "12",
+			State:       "queued",
+			BuildTypeID: "Target_BT",
+			BuildType:   &api.BuildType{ID: "Target_BT", Name: "Target"},
+			BranchName:  "main",
+			WebURL:      "https://ci.example.com/viewLog.html?buildId=71",
+			Triggered:   &api.Triggered{Type: "user", User: &api.User{Name: "Bob"}},
+			WaitReason:  "There are no idle compatible agents which can run this build",
+		})
+	})
+	// agents endpoint is shared for compatible/incompatible locators via the default handler;
+	// override it so compatible returns empty and incompatible returns one agent grouped by pool.
+	ts.Handle("GET /app/rest/agents", func(w http.ResponseWriter, r *http.Request) {
+		locator := r.URL.Query().Get("locator")
+		if strings.Contains(locator, "incompatible:") {
+			cmdtest.JSON(w, api.AgentList{
+				Count: 1,
+				Agents: []api.Agent{
+					{ID: 42, Name: "linux-agent-bad", Connected: true, Enabled: true, Authorized: true,
+						Pool: &api.Pool{ID: 3, Name: "Linux Pool"}},
+				},
+			})
+			return
+		}
+		if strings.Contains(locator, "compatible:") {
+			cmdtest.JSON(w, api.AgentList{Count: 0})
+			return
+		}
+		cmdtest.JSON(w, api.AgentList{Count: 0})
+	})
+	ts.Handle("GET /app/rest/agents/id:42/incompatibleBuildTypes", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.CompatibilityList{
+			Count: 1,
+			Compatibility: []api.Compatibility{
+				{
+					Compatible:        false,
+					BuildType:         &api.BuildType{ID: "Target_BT"},
+					UnmetRequirements: &api.UnmetRequirements{Description: "Incompatible runner: Docker"},
+				},
+			},
+		})
+	})
+
+	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "view", "71")
+	assert.Contains(t, got, "Wait reason: There are no idle compatible agents which can run this build")
+	assert.Contains(t, got, "Compatible agents (0)")
+	assert.Contains(t, got, "Incompatible agents (1)")
+	assert.Contains(t, got, "[Linux Pool]")
+	assert.Contains(t, got, "linux-agent-bad")
+	assert.Contains(t, got, "Incompatible runner: Docker")
 }
 
 func TestRunStart_reused(t *testing.T) {

--- a/internal/cmd/run/compatibility.go
+++ b/internal/cmd/run/compatibility.go
@@ -1,0 +1,164 @@
+package run
+
+import (
+	"cmp"
+	"fmt"
+	"io"
+	"slices"
+	"strings"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+)
+
+// agentListInlineLimit is the max agents listed before we collapse to a pool summary.
+const agentListInlineLimit = 20
+
+// reasonProbeLimit caps how many incompatibleBuildTypes entries to scan per agent when fetching reasons.
+const reasonProbeLimit = 20000
+
+// reasonProbeAgents caps how many incompatible agents we probe for reasons to avoid long waits.
+const reasonProbeAgents = 5
+
+// compatibilityWaitKeywords identifies wait reasons that hint at agent compatibility issues.
+var compatibilityWaitKeywords = []string{
+	"compatible agents",
+	"outdated, waiting for upgrade",
+}
+
+// waitReasonIsCompatibility returns true when the wait reason suggests an agent compatibility problem.
+func waitReasonIsCompatibility(waitReason string) bool {
+	lower := strings.ToLower(waitReason)
+	return slices.ContainsFunc(compatibilityWaitKeywords, func(kw string) bool {
+		return strings.Contains(lower, kw)
+	})
+}
+
+// renderBuildCompatibility prints compatible/incompatible agents for a queued build; errors are best-effort.
+func renderBuildCompatibility(w io.Writer, client api.ClientInterface, build *api.Build) {
+	if build.State != "queued" {
+		return
+	}
+
+	compat, errC := client.GetBuildCompatibleAgents(build.ID)
+	incompat, errI := client.GetBuildIncompatibleAgents(build.ID)
+
+	if errC != nil && errI != nil {
+		_, _ = fmt.Fprintf(w, "\n%s %v\n", output.Faint("Could not load agent compatibility:"), errC)
+		return
+	}
+
+	_, _ = fmt.Fprintln(w)
+
+	if compat != nil {
+		renderAgentGroup(w, "Compatible agents", compat.Count, compat.Agents, output.Green)
+	} else if errC != nil {
+		_, _ = fmt.Fprintf(w, "%s %v\n", output.Faint("Compatible agents unavailable:"), errC)
+	}
+
+	if incompat != nil {
+		renderAgentGroup(w, "Incompatible agents", incompat.Count, incompat.Agents, output.Yellow)
+		renderIncompatibilityReasons(w, client, build.BuildTypeID, incompat.Agents)
+	} else if errI != nil {
+		_, _ = fmt.Fprintf(w, "%s %v\n", output.Faint("Incompatible agents unavailable:"), errI)
+	}
+}
+
+// renderAgentGroup prints a header plus either the agent list or a pool-count summary.
+func renderAgentGroup(w io.Writer, title string, total int, agents []api.Agent, colorize func(a ...any) string) {
+	_, _ = fmt.Fprintf(w, "%s (%d)", colorize(title), total)
+	if total == 0 {
+		_, _ = fmt.Fprintln(w)
+		return
+	}
+	_, _ = fmt.Fprintln(w)
+
+	if len(agents) <= agentListInlineLimit {
+		pools := groupAgentsByPool(agents)
+		for _, pool := range pools {
+			_, _ = fmt.Fprintf(w, "  %s\n", output.Faint("["+pool.name+"]"))
+			for _, a := range pool.agents {
+				_, _ = fmt.Fprintf(w, "    %s%s\n", a.Name, agentStatusSuffix(a))
+			}
+		}
+	} else {
+		pools := groupAgentsByPool(agents)
+		for _, pool := range pools {
+			_, _ = fmt.Fprintf(w, "  %s %d\n", output.Faint("["+pool.name+"]"), len(pool.agents))
+		}
+		if total > len(agents) {
+			_, _ = fmt.Fprintf(w, "  %s %d more not shown\n", output.Faint("…"), total-len(agents))
+		}
+	}
+}
+
+// agentStatusSuffix flags listed agents that still can't actually run builds.
+func agentStatusSuffix(a api.Agent) string {
+	var parts []string
+	if !a.Connected {
+		parts = append(parts, "disconnected")
+	}
+	if !a.Enabled {
+		parts = append(parts, "disabled")
+	}
+	if !a.Authorized {
+		parts = append(parts, "unauthorized")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return " " + output.Faint("("+strings.Join(parts, ", ")+")")
+}
+
+type poolAgents struct {
+	name   string
+	agents []api.Agent
+}
+
+// groupAgentsByPool buckets agents by pool name (stable: pool name asc, then agent name asc).
+func groupAgentsByPool(agents []api.Agent) []poolAgents {
+	m := map[string][]api.Agent{}
+	for _, a := range agents {
+		name := "(no pool)"
+		if a.Pool != nil && a.Pool.Name != "" {
+			name = a.Pool.Name
+		}
+		m[name] = append(m[name], a)
+	}
+	out := make([]poolAgents, 0, len(m))
+	for name, as := range m {
+		slices.SortFunc(as, func(a, b api.Agent) int { return cmp.Compare(a.Name, b.Name) })
+		out = append(out, poolAgents{name: name, agents: as})
+	}
+	slices.SortFunc(out, func(a, b poolAgents) int { return cmp.Compare(a.name, b.name) })
+	return out
+}
+
+// renderIncompatibilityReasons probes a few agents for unmet requirements; silently skips agents whose reasons REST can't surface.
+func renderIncompatibilityReasons(w io.Writer, client api.ClientInterface, buildTypeID string, agents []api.Agent) {
+	if buildTypeID == "" || len(agents) == 0 {
+		return
+	}
+	printedHeader := false
+	limit := min(reasonProbeAgents, len(agents))
+	for i := range limit {
+		a := agents[i]
+		compat, err := client.GetAgentBuildTypeCompatibility(a.ID, buildTypeID, reasonProbeLimit)
+		if err != nil || compat == nil {
+			continue
+		}
+		reasons := compat.ReasonsList()
+		if len(reasons) == 0 {
+			continue
+		}
+		if !printedHeader {
+			_, _ = fmt.Fprintln(w)
+			_, _ = fmt.Fprintf(w, "%s\n", output.Faint("Sample incompatibility reasons:"))
+			printedHeader = true
+		}
+		_, _ = fmt.Fprintf(w, "  %s\n", a.Name)
+		for _, r := range reasons {
+			_, _ = fmt.Fprintf(w, "    %s %s\n", output.Red("•"), r)
+		}
+	}
+}

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -456,6 +456,9 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 
 	if build.State == "queued" && build.WaitReason != "" {
 		_, _ = fmt.Fprintf(p.Out, "\nWait reason: %s\n", output.Yellow(build.WaitReason))
+		if waitReasonIsCompatibility(build.WaitReason) {
+			renderBuildCompatibility(p.Out, client, build)
+		}
 	}
 
 	if build.State == "running" && build.PercentageComplete > 0 {


### PR DESCRIPTION
## Summary

Closes #252.

When a build is queued with an agent-compatibility wait reason, `teamcity run view` now shows compatible and incompatible agents grouped by pool:

- Small lists (≤ 20 agents) are rendered inline with agent names
- Larger lists collapse to per-pool counts
- Disconnected / disabled / unauthorized agents are annotated so users can see why a listed agent still can't pick up the build
- Unmet requirements are probed best-effort for up to 5 agents (bounded by `count:20000` on the incompatibleBuildTypes lookup to avoid blowing up on huge instances where the `id:` locator isn't honored on that sub-resource)
- Only triggers when the wait reason contains `"compatible agents"` or `"outdated, waiting for upgrade"`; other queue reasons (e.g. pending snapshot dependencies) stay unchanged

Left `run watch`, `run log -f`, and `queue list` alone — their line/tabular outputs aren't well-suited to this block of data, and `run view` is the canonical detail view.

## Output shape (queued, no idle compatible agents)

```
◦ <build name> <id>  # · <branch>
Triggered by schedule

Wait reason: All compatible agents are outdated, waiting for upgrade

Compatible agents (1)
  [Pool A]
    agent-01
Incompatible agents (14307)
  [Pool A] 12
  [Pool B] 154
  [Pool C] 75
  ...
```

Small instance (few agents total) inlines everything:

```
Wait reason: There are no idle compatible agents which can run this build

Compatible agents (0)
Incompatible agents (3)
  [Linux Pool]
    linux-agent-bad
    linux-agent-old (disconnected)
  [macOS Pool]
    mac-agent-docker

Sample incompatibility reasons:
  linux-agent-bad
    • Incompatible runner: Docker
```

## API additions

- `GetBuildCompatibleAgents(buildID)` — `/app/rest/agents?locator=compatible:(build:(id:X)),defaultFilter:false`
- `GetBuildIncompatibleAgents(buildID)` — `/app/rest/agents?locator=incompatible:(build:(id:X)),defaultFilter:false`
- `GetAgentBuildTypeCompatibility(agentID, buildTypeID, maxScan)` — bounded client-side scan of the agent's `incompatibleBuildTypes` list for the entry matching the target build type
- New `UnmetRequirements` type + `Compatibility.ReasonsList()` helper that merges legacy `incompatibleReasons.reason` with the modern `unmetRequirements.description`

## Test plan

- [x] `go test ./...` passes
- [x] New unit tests cover: compatible/incompatible agent fetching, build-type compatibility lookup (match + no-match), reason merging, and `run view` rendering for compat wait reason, non-compat wait reason, and the full compatibility output
- [x] Verified end-to-end against a live TeamCity instance with a queued build that has 0 compatible / 14k+ incompatible agents — falls back to per-pool counts
- [x] Verified against a queued build with 1 compatible and 14k+ incompatible — compatible list inline, incompatible collapsed