### PR TITLE
fix(terminal): redact token, fix PowerShell exec, recover hung term sessions

### DIFF
--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -388,6 +388,7 @@ func (tc *Conn) copyFromReader(r io.Reader, errChan chan<- error) {
 			return
 		default:
 		}
+		normalizeEnterKeystroke(buf[:n])
 		if err := tc.writeMessage(websocket.TextMessage, buf[:n]); err != nil {
 			select {
 			case errChan <- err:
@@ -395,6 +396,15 @@ func (tc *Conn) copyFromReader(r io.Reader, errChan chan<- error) {
 			}
 			return
 		}
+	}
+}
+
+// Some Windows consoles deliver LF for Enter under raw/VT input mode; PSReadLine
+// reads that as Shift+Enter and never submits. Rewrite only single-byte reads
+// (interactive keystrokes) so pastes containing LF survive.
+func normalizeEnterKeystroke(buf []byte) {
+	if len(buf) == 1 && buf[0] == '\n' {
+		buf[0] = '\r'
 	}
 }
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -264,12 +264,12 @@ func (tc *Conn) Exec(ctx context.Context, command string) error {
 
 	time.Sleep(100 * time.Millisecond)
 
-	if err := tc.writeMessage(websocket.TextMessage, []byte("stty -echo\n")); err != nil {
+	if err := tc.writeMessage(websocket.TextMessage, []byte("stty -echo\r")); err != nil {
 		return fmt.Errorf("failed to send stty: %w", err)
 	}
 	time.Sleep(100 * time.Millisecond)
 
-	fullCmd := fmt.Sprintf("echo %s; %s; echo; echo %s; exit\n", execMarker, command, execMarker)
+	fullCmd := fmt.Sprintf("echo %s; %s; echo \"\"; echo %s; exit\r", execMarker, command, execMarker)
 	if err := tc.writeMessage(websocket.TextMessage, []byte(fullCmd)); err != nil {
 		return fmt.Errorf("failed to send command: %w", err)
 	}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -28,6 +28,11 @@ const (
 	// writeTimeout is the maximum time to wait for a WebSocket write to complete.
 	// 10s is generous for small control messages; prevents hanging on network issues.
 	writeTimeout = 10 * time.Second
+
+	// readTimeout caps how long we tolerate silence on the socket before giving up.
+	// 2.5x pingInterval allows one missed pong; recovers from the case where the
+	// server never sends a close frame (e.g. when the remote shell dies uncleanly).
+	readTimeout = pingInterval*2 + pingInterval/2
 )
 
 // Session holds the session token and node ID from TeamCity's agent terminal plugin
@@ -151,6 +156,11 @@ func (c *Client) Connect(session *Session, cols, rows int) (*Conn, error) {
 		return nil, fmt.Errorf("WebSocket connection failed: %w", err)
 	}
 
+	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
+	conn.SetPongHandler(func(string) error {
+		return conn.SetReadDeadline(time.Now().Add(readTimeout))
+	})
+
 	return &Conn{conn: conn, done: make(chan struct{}), debugf: c.debugf}, nil
 }
 
@@ -238,6 +248,7 @@ func (tc *Conn) Exec(ctx context.Context, command string) error {
 				}
 				return
 			}
+			_ = tc.conn.SetReadDeadline(time.Now().Add(readTimeout))
 
 			buf.Write(msg)
 
@@ -351,6 +362,7 @@ func (tc *Conn) copyToWriterWithReady(w io.Writer, errChan chan<- error, readyCh
 			}
 			return
 		}
+		_ = tc.conn.SetReadDeadline(time.Now().Add(readTimeout))
 
 		if !signalledReady && readyCh != nil {
 			signalledReady = true
@@ -407,6 +419,13 @@ func (tc *Conn) sendResize() {
 }
 
 func (tc *Conn) sendPing() {
+	// WS-level ping: server's underlying stack auto-responds with pong, which
+	// refreshes the read deadline via SetPongHandler even when the plugin has
+	// no app-level data to emit.
+	if err := tc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeTimeout)); err != nil {
+		tc.debugf("terminal: failed to send WS ping: %v", err)
+	}
+	// App-level ping preserved for the plugin's own keepalive accounting.
 	tc.sendJSON("ping", map[string]string{
 		"ts": strconv.FormatInt(time.Now().UnixMilli(), 10),
 	})

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -138,7 +138,7 @@ func (c *Client) Connect(session *Session, cols, rows int) (*Conn, error) {
 		header.Set("Cookie", strings.Join(cookies, "; "))
 	}
 
-	c.debugf("WebSocket URL: %s", wsURL)
+	c.debugf("WebSocket URL: %s://%s/app/agentTerminal/terminal/<redacted>?cols=%d&rows=%d", scheme, u.Host, cols, rows)
 
 	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
 	if err != nil {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -388,7 +388,6 @@ func (tc *Conn) copyFromReader(r io.Reader, errChan chan<- error) {
 			return
 		default:
 		}
-		normalizeEnterKeystroke(buf[:n])
 		if err := tc.writeMessage(websocket.TextMessage, buf[:n]); err != nil {
 			select {
 			case errChan <- err:
@@ -396,15 +395,6 @@ func (tc *Conn) copyFromReader(r io.Reader, errChan chan<- error) {
 			}
 			return
 		}
-	}
-}
-
-// Some Windows consoles deliver LF for Enter under raw/VT input mode; PSReadLine
-// reads that as Shift+Enter and never submits. Rewrite only single-byte reads
-// (interactive keystrokes) so pastes containing LF survive.
-func normalizeEnterKeystroke(buf []byte) {
-	if len(buf) == 1 && buf[0] == '\n' {
-		buf[0] = '\r'
 	}
 }
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -29,9 +29,7 @@ const (
 	// 10s is generous for small control messages; prevents hanging on network issues.
 	writeTimeout = 10 * time.Second
 
-	// readTimeout caps how long we tolerate silence on the socket before giving up.
-	// 2.5x pingInterval allows one missed pong; recovers from the case where the
-	// server never sends a close frame (e.g. when the remote shell dies uncleanly).
+	// readTimeout: 2.5x pingInterval — tolerates one missed pong.
 	readTimeout = pingInterval*2 + pingInterval/2
 )
 
@@ -260,7 +258,6 @@ func (tc *Conn) Exec(ctx context.Context, command string) error {
 				}
 			}
 
-			// marker+"\n" (not "\n"+marker): the echoed input has markers followed by `;`, not \n.
 			content := normalizeLineEndings(stripANSI(buf.String()))
 			if strings.Count(content, execMarker+"\n") >= 2 {
 				resultCh <- result{output: extractExecOutput(content)}
@@ -307,7 +304,6 @@ func normalizeLineEndings(s string) string {
 	return s
 }
 
-// Strips ANSI escapes so PSReadLine cursor-positioning doesn't break marker detection.
 var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\a\x1b]*(?:\a|\x1b\\)|\x1b[A-Z@\\^_]`)
 
 func stripANSI(s string) string {
@@ -419,13 +415,9 @@ func (tc *Conn) sendResize() {
 }
 
 func (tc *Conn) sendPing() {
-	// WS-level ping: server's underlying stack auto-responds with pong, which
-	// refreshes the read deadline via SetPongHandler even when the plugin has
-	// no app-level data to emit.
 	if err := tc.conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(writeTimeout)); err != nil {
 		tc.debugf("terminal: failed to send WS ping: %v", err)
 	}
-	// App-level ping preserved for the plugin's own keepalive accounting.
 	tc.sendJSON("ping", map[string]string{
 		"ts": strconv.FormatInt(time.Now().UnixMilli(), 10),
 	})

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -154,11 +154,6 @@ func (c *Client) Connect(session *Session, cols, rows int) (*Conn, error) {
 		return nil, fmt.Errorf("WebSocket connection failed: %w", err)
 	}
 
-	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
-	conn.SetPongHandler(func(string) error {
-		return conn.SetReadDeadline(time.Now().Add(readTimeout))
-	})
-
 	return &Conn{conn: conn, done: make(chan struct{}), debugf: c.debugf}, nil
 }
 
@@ -188,6 +183,11 @@ func (tc *Conn) RunInteractive(ctx context.Context) error {
 		return fmt.Errorf("failed to set raw terminal mode: %w", err)
 	}
 	defer func() { _ = term.RestoreTerminal(fd, oldState) }()
+
+	_ = tc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+	tc.conn.SetPongHandler(func(string) error {
+		return tc.conn.SetReadDeadline(time.Now().Add(readTimeout))
+	})
 
 	errChan := make(chan error, 2)
 	go tc.copyToWriter(stdout, errChan)
@@ -246,7 +246,6 @@ func (tc *Conn) Exec(ctx context.Context, command string) error {
 				}
 				return
 			}
-			_ = tc.conn.SetReadDeadline(time.Now().Add(readTimeout))
 
 			buf.Write(msg)
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -248,8 +249,9 @@ func (tc *Conn) Exec(ctx context.Context, command string) error {
 				}
 			}
 
-			content := normalizeLineEndings(buf.String())
-			if strings.Count(content, "\n"+execMarker) >= 2 {
+			// marker+"\n" (not "\n"+marker): the echoed input has markers followed by `;`, not \n.
+			content := normalizeLineEndings(stripANSI(buf.String()))
+			if strings.Count(content, execMarker+"\n") >= 2 {
 				resultCh <- result{output: extractExecOutput(content)}
 				return
 			}
@@ -294,8 +296,15 @@ func normalizeLineEndings(s string) string {
 	return s
 }
 
+// Strips ANSI escapes so PSReadLine cursor-positioning doesn't break marker detection.
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;?]*[a-zA-Z]|\x1b\][^\a\x1b]*(?:\a|\x1b\\)|\x1b[A-Z@\\^_]`)
+
+func stripANSI(s string) string {
+	return ansiEscapeRE.ReplaceAllString(s, "")
+}
+
 func extractExecOutput(raw string) string {
-	raw = normalizeLineEndings(raw)
+	raw = normalizeLineEndings(stripANSI(raw))
 	startPattern := execMarker + "\n"
 	startIdx := strings.Index(raw, startPattern)
 	if startIdx == -1 {

--- a/internal/terminal/terminal_unit_test.go
+++ b/internal/terminal/terminal_unit_test.go
@@ -104,3 +104,30 @@ func TestStripANSI(T *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeEnterKeystroke(T *testing.T) {
+	T.Parallel()
+
+	tests := []struct {
+		name string
+		in   []byte
+		want []byte
+	}{
+		{"solitary LF becomes CR (broken-console Enter)", []byte("\n"), []byte("\r")},
+		{"solitary CR unchanged (conformant Enter)", []byte("\r"), []byte("\r")},
+		{"solitary printable char unchanged", []byte("a"), []byte("a")},
+		{"solitary Ctrl+C unchanged", []byte{0x03}, []byte{0x03}},
+		{"CRLF pair not rewritten (paste or combined read)", []byte("\r\n"), []byte("\r\n")},
+		{"LF inside multi-byte paste left as LF", []byte("line1\nline2"), []byte("line1\nline2")},
+		{"escape sequence for arrow unchanged", []byte{0x1b, '[', 'A'}, []byte{0x1b, '[', 'A'}},
+	}
+
+	for _, tc := range tests {
+		T.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			buf := append([]byte(nil), tc.in...)
+			normalizeEnterKeystroke(buf)
+			assert.Equal(t, tc.want, buf)
+		})
+	}
+}

--- a/internal/terminal/terminal_unit_test.go
+++ b/internal/terminal/terminal_unit_test.go
@@ -104,30 +104,3 @@ func TestStripANSI(T *testing.T) {
 		})
 	}
 }
-
-func TestNormalizeEnterKeystroke(T *testing.T) {
-	T.Parallel()
-
-	tests := []struct {
-		name string
-		in   []byte
-		want []byte
-	}{
-		{"solitary LF becomes CR (broken-console Enter)", []byte("\n"), []byte("\r")},
-		{"solitary CR unchanged (conformant Enter)", []byte("\r"), []byte("\r")},
-		{"solitary printable char unchanged", []byte("a"), []byte("a")},
-		{"solitary Ctrl+C unchanged", []byte{0x03}, []byte{0x03}},
-		{"CRLF pair not rewritten (paste or combined read)", []byte("\r\n"), []byte("\r\n")},
-		{"LF inside multi-byte paste left as LF", []byte("line1\nline2"), []byte("line1\nline2")},
-		{"escape sequence for arrow unchanged", []byte{0x1b, '[', 'A'}, []byte{0x1b, '[', 'A'}},
-	}
-
-	for _, tc := range tests {
-		T.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			buf := append([]byte(nil), tc.in...)
-			normalizeEnterKeystroke(buf)
-			assert.Equal(t, tc.want, buf)
-		})
-	}
-}

--- a/internal/terminal/terminal_unit_test.go
+++ b/internal/terminal/terminal_unit_test.go
@@ -63,8 +63,6 @@ func TestExtractExecOutput(T *testing.T) {
 			want:  "result",
 		},
 		{
-			// PSReadLine uses absolute cursor positioning between command output and
-			// the closing marker instead of \r\n; stripANSI must remove it.
 			name: "powershell absolute cursor positioning between output and closing marker",
 			input: "\x1b[m" + execMarker + "\x1b[?25l\r\nhello_5840" +
 				"\x1b[11;1H" + execMarker + "\r\n\x1b[?25h",

--- a/internal/terminal/terminal_unit_test.go
+++ b/internal/terminal/terminal_unit_test.go
@@ -62,12 +62,45 @@ func TestExtractExecOutput(T *testing.T) {
 			input: "pre\r\n" + execMarker + "\r\nresult\r\n" + execMarker + "\r\npost",
 			want:  "result",
 		},
+		{
+			// PSReadLine uses absolute cursor positioning between command output and
+			// the closing marker instead of \r\n; stripANSI must remove it.
+			name: "powershell absolute cursor positioning between output and closing marker",
+			input: "\x1b[m" + execMarker + "\x1b[?25l\r\nhello_5840" +
+				"\x1b[11;1H" + execMarker + "\r\n\x1b[?25h",
+			want: "hello_5840",
+		},
 	}
 
 	for _, tc := range tests {
 		T.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.want, extractExecOutput(tc.input))
+		})
+	}
+}
+
+func TestStripANSI(T *testing.T) {
+	T.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"plain text unchanged", "hello world", "hello world"},
+		{"CSI color sequence", "\x1b[93mwarn\x1b[m", "warn"},
+		{"CSI cursor hide/show", "\x1b[?25lA\x1b[?25h", "A"},
+		{"CSI absolute cursor positioning", "A\x1b[11;1HB", "AB"},
+		{"OSC window title with BEL terminator", "\x1b]0;title\aX", "X"},
+		{"OSC with ESC \\ terminator", "\x1b]0;title\x1b\\X", "X"},
+		{"preserves CR and LF", "line1\r\nline2\n", "line1\r\nline2\n"},
+	}
+
+	for _, tc := range tests {
+		T.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, stripANSI(tc.input))
 		})
 	}
 }


### PR DESCRIPTION
Fixes #236.

## Summary

Four terminal fixes on one branch. First closes a client-controlled session-token leak in debug output. Next two unblock ``teamcity agent exec`` against PowerShell agents (previously hung indefinitely). Last adds a WebSocket-level liveness mechanism so ``teamcity agent term`` can no longer hang forever if the server fails to close the socket on remote-shell exit — the symptom reported in #236.

## Changes

**``fix(terminal): redact session token in WebSocket URL debug log``**
- ``c.debugf("WebSocket URL: %s", wsURL)`` logged the full WS URL including the session token in the path. When users capture debug output for bug reports or pipe it to files, the token leaks. Replaced with a redacted form (``.../terminal/<redacted>?cols=X&rows=Y``). Blast radius of the token is one short-lived terminal session but the leak is fully avoidable on the client side.

**``fix(terminal): use CR line endings and quoted echo for PowerShell exec compatibility``**
- Line terminators in ``Exec()``: ``\n`` → ``\r``. PowerShell/ConPTY only treats ``\r`` as Enter; ``\n`` alone sits in the input buffer and the command never executes. Unix PTYs also accept ``\r`` (that is what a real Enter keypress sends), so the change is cross-platform.
- Command template: ``echo;`` → ``echo "";``. Bare ``echo`` in PowerShell is ``Write-Output`` with no arguments, which prompts interactively for pipeline input (``Supply values for the following parameters: InputObject[0]:``). That prompt is the actual hang once ``\r`` was fixed. Passing an empty string avoids the prompt and is a no-op on bash/sh.

**``fix(terminal): strip ANSI and use marker+LF for robust exec output detection``**
- PSReadLine frames exec output with absolute cursor-positioning escapes (``\x1b[<row>;<col>H``) instead of ``\r\n`` between the command stdout and the closing marker. Without stripping, the marker never matches the ``\n+marker`` pattern and the goroutine waits forever.
- Added ``stripANSI`` over CSI, OSC, and Fe-class two-byte ESC sequences; applied before ``normalizeLineEndings`` / marker count in the Exec goroutine and in ``extractExecOutput``.
- Flipped marker detection from ``"\n"+execMarker`` to ``execMarker+"\n"``. Output markers always end in ``\n`` (echo trailing newline); the echoed input line has markers followed by ``;`` (from the ``;``-chain), so the new direction uniquely matches only the two output occurrences even on framings without ``\r\n`` between output and marker.
- Test coverage: new ``TestStripANSI`` (CSI color, cursor hide/show, absolute positioning, OSC with BEL and ESC\\ terminators, CR/LF preservation) and a new ``TestExtractExecOutput`` case using observed PSReadLine absolute-cursor framing.

**``feat(terminal): add read deadline and WS ping/pong to recover hung sessions``**
- Directly addresses the remaining symptom from #236: ``term`` hangs on ``exit`` and must be killed. Cannot reproduce it from macOS (plugin sends a close frame and our client handles it), but if the plugin ever fails to deliver close — which is what the reporter observes on Windows 10 / TC 2024.03.2 — we previously sat in ``NextReader()`` forever.
- Added WebSocket-level ping via ``WriteControl(PingMessage, …)`` alongside the existing JSON-level app ping.
- Set ``SetReadDeadline`` and ``SetPongHandler``: the server underlying WebSocket stack auto-responds to pings with pongs, and each pong (and each received data message) refreshes the deadline.
- ``readTimeout = 2.5 × pingInterval = 150s``. With a 60s ping cadence, that tolerates one missed pong before giving up. If the server stops responding, ``NextReader()`` returns a timeout error, ``copyToWriter`` returns, ``tc.Close()`` fires, the main loop unblocks, and the process exits normally.
- Verified live: opened ``agent term`` to a PowerShell Windows agent, idled 75 seconds (past one ping interval), then typed a command — session stayed alive, command executed, ``exit`` closed cleanly. Confirms the TeamCity WS stack sends pongs and our deadline refresh works.

## Design Decisions

**Why not move the session token off the URL path entirely (M2 hardening)?** Probed the live ``cli.teamcity.com`` plugin with ``Subprotocols=[token]`` set and the token stripped from the URL:
- Empty path (``/terminal/``) → ``404`` (route does not match).
- Any non-empty path → ``101 Upgrade`` succeeds, but the server does **not** echo back ``Sec-Websocket-Protocol``, meaning the subprotocol is ignored entirely. Socket then hangs because no session is routed.

The TeamCity agent-terminal plugin reads the token strictly from the URL path segment and uses it as a routing key. Moving the token off the path is a server/plugin change. Redacting the debug log closes the one leak wholly under CLI control.

**Why not rewrite lone LF keystrokes to CR (speculative defensive fix)?** An earlier iteration of this branch included a ``normalizeEnterKeystroke`` that rewrote single-byte LF reads in ``copyFromReader`` to CR, aimed at the "Windows console delivers LF for Enter" scenario. The Codex review correctly flagged that ``io.Reader.Read`` gives no guarantee that one read corresponds to one keystroke — a slow paste over SSH or a throttled tty can legitimately deliver a multi-line paste as single-byte reads, which would silently mutate pasted LFs into CRs and corrupt pasted scripts, heredocs, and line-sensitive interactive workflows. That commit was reverted; the correct behavior is what SSH and every other terminal client does — forward stdin byte-for-byte, trust the local terminal emulator to encode Enter correctly. The read-deadline / ping-pong approach addresses the actual observed symptom (``exit`` hang) without mutating user input.

**Why three-layer framing defense instead of just one?** The exec hang had multiple independent triggers that surfaced together: line endings, the ``echo``-no-args prompt, ANSI cursor-positioning in output. Fixing only one would not unblock the reporter. Each commit is independently revertable and each addresses a specific PSReadLine / PowerShell / plugin interaction.

## Example

Debug log before — token leaked:
````
[debug] WebSocket URL: wss://cli.teamcity.com/app/agentTerminal/terminal/f02e2ea9-3c39-4513-90c3-e3fca40fda4a?cols=120&rows=40
````
After:
````
[debug] WebSocket URL: wss://cli.teamcity.com/app/agentTerminal/terminal/<redacted>?cols=120&rows=40
````

PowerShell exec before — hangs indefinitely:
````bash
$ teamcity agent exec <agent> "Write-Host hello"
# no output, must kill process
````
After:
````bash
$ teamcity agent exec <agent> "Write-Host hello"
hello
````

``term`` hang on ``exit`` (from #236): if the server never sends the close frame, the CLI used to wait forever. Now it gives up after ~150s of silence and exits cleanly, so the user gets their terminal back without killing the process.

## Test Plan

- [x] Unit tests pass (``just unit``) — new ``TestStripANSI`` and expanded ``TestExtractExecOutput``
- [x] Linter passes (``just lint``)
- [ ] Acceptance tests pass (``just acceptance``) — not run locally; CI covers
- [x] If adding a new command/flag: added ``.txtar`` test in ``acceptance/testdata/`` — N/A
- [x] If adding a data-producing command: includes ``--json`` support — N/A
- [x] If modifying ``--json`` output: no field removals/renames (additive only) — N/A
- [x] If changing docs-visible behavior: updated ``docs/``, ``skills/``, and ``README.md`` — N/A

**Manual verification (live against ``cli.teamcity.com``):**
- ``agent exec <linux-agent> "echo hello; uname -sr"`` → returns kernel info, debug URL redacted.
- ``agent exec <ps-agent> "Write-Host ps-after-ping-pong"`` → returns ``ps-after-ping-pong`` (previously hung on PowerShell).
- ``agent term <linux-agent>`` via ``expect``: prompt → command → ``exit`` → clean process exit.
- ``agent term <ps-agent>`` via ``expect``: prompt → command → ``exit`` → clean process exit.
- ``agent term <ps-agent>`` with 75-second idle (> ``pingInterval``): session stays alive through idle, post-idle command still executes, ``exit`` still closes cleanly — proves the server responds to WS pings and the pong handler refreshes the read deadline as intended.