### PR TITLE
docs(gallery): cover every CLI command and fix stale manual screens

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,489 +3,1336 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>TeamCity CLI — Screen Gallery</title>
+<title>teamcity cli screen gallery</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains&#43;Mono:wght@400;500;700&amp;display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
 <style>
+:root {
+  --mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  --sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+}
 :root, [data-theme="dark"] {
-  --bg: #0e0e0e; --bg-sidebar: #080808; --surface: #171717; --surface-cmd: #131313;
-  --border: #222; --border-accent: #282828; --text: #c8c8c8; --text-secondary: #4a4a4a;
-  --accent: #07C3F2; --accent-glow: rgba(7,195,242,0.08); --cmd-color: #4EC5B9;
-  --sidebar-w: 200px;
-  --t-black: #444; --t-red: #f47067; --t-green: #57ab5a; --t-yellow: #c69026;
-  --t-blue: #539bf5; --t-magenta: #b083f0; --t-cyan: #39c5cf; --t-white: #c8c8c8;
-  --t-br-black: #636e7b; --t-br-red: #ff938a; --t-br-green: #6bc46d; --t-br-yellow: #daaa3f;
-  --t-br-blue: #6cb6ff; --t-br-magenta: #dcbdfb; --t-br-cyan: #56d4dd; --t-br-white: #f0f0f0;
-  --t-dim-opacity: 0.45;
-  --dot-close: #ff5f57; --dot-min: #febc2e; --dot-max: #28c840;
+  --bg: #0b0d10; --bg-1: #111419; --bg-2: #161a20; --bg-3: #1c2128;
+  --line: #242a33; --line-2: #2f3742;
+  --fg: #e6e8eb; --fg-2: #b6bcc5; --fg-3: #7d8693; --fg-4: #4a525d;
+  --green:  oklch(0.78 0.14 150);
+  --red:    oklch(0.72 0.17 25);
+  --yellow: oklch(0.82 0.15 85);
+  --cyan:   oklch(0.80 0.12 210);
+  --blue:   oklch(0.74 0.14 240);
+  --magenta:oklch(0.74 0.15 330);
+  --accent: oklch(0.82 0.15 85);
 }
 [data-theme="light"] {
-  --bg: #ededed; --bg-sidebar: #e4e4e4; --surface: #fff; --surface-cmd: #f7f7f7;
-  --border: #ccc; --border-accent: #bbb; --text: #1a1a1a; --text-secondary: #888;
-  --accent: #0591b2; --accent-glow: rgba(5,145,178,0.06); --cmd-color: #0e7a6e;
-  --t-black: #1a1a1a; --t-red: #c4302b; --t-green: #1a7f37; --t-yellow: #856d00;
-  --t-blue: #0550ae; --t-magenta: #6639ba; --t-cyan: #0a6e7a; --t-white: #555;
-  --t-br-black: #444; --t-br-red: #a40e26; --t-br-green: #116329; --t-br-yellow: #633c01;
-  --t-br-blue: #0969da; --t-br-magenta: #8250df; --t-br-cyan: #0e7a6e; --t-br-white: #1a1a1a;
-  --t-dim-opacity: 0.5;
-  --dot-close: #ff5f57; --dot-min: #febc2e; --dot-max: #28c840;
+  --bg: #f6f5f1; --bg-1: #ffffff; --bg-2: #ecebe6; --bg-3: #e1dfd8;
+  --line: #d6d4cc; --line-2: #bcb9ae;
+  --fg: #17191c; --fg-2: #2e3238; --fg-3: #5a6069; --fg-4: #8e949d;
+  --green:  oklch(0.55 0.16 145);
+  --red:    oklch(0.55 0.20 25);
+  --yellow: oklch(0.58 0.16 75);
+  --cyan:   oklch(0.52 0.13 220);
+  --blue:   oklch(0.48 0.17 250);
+  --magenta:oklch(0.50 0.18 330);
+  --accent: oklch(0.55 0.16 75);
 }
 
-*, *::before, *::after { margin: 0; padding: 0; box-sizing: border-box; }
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
 html { scroll-behavior: smooth; }
-
 body {
-  font-family: 'JetBrains Mono', monospace;
-  background: var(--bg); color: var(--text);
-  line-height: 1.6; font-size: 14px;
+  background: var(--bg); color: var(--fg);
+  font-family: var(--sans);
+  font-feature-settings: "ss01", "cv11";
   -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  min-height: 100vh;
 }
 
  
-.sidebar {
-  position: fixed; top: 0; left: 0; bottom: 0;
-  width: var(--sidebar-w); background: var(--bg-sidebar);
-  border-right: 1px solid var(--border);
-  overflow-y: auto; padding: 16px 0; z-index: 10;
-  scrollbar-width: thin; scrollbar-color: var(--border) transparent;
+.page {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  max-width: 1440px;
+  margin: 0 auto;
+  min-height: 100vh;
 }
-.sidebar-brand {
-  padding: 0 14px 14px; border-bottom: 1px solid var(--border); margin-bottom: 6px;
-  font-size: 12px; color: var(--text-secondary); letter-spacing: 0.5px;
+@media (min-width: 1441px) {
+  .page { border-left: 1px solid var(--line); border-right: 1px solid var(--line); }
 }
-.sidebar-brand strong {
-  color: var(--accent); font-weight: 700; font-size: 14px; display: block; letter-spacing: 0;
-}
-.sidebar h2 {
-  font-size: 10px; font-weight: 700; color: var(--text-secondary);
-  text-transform: uppercase; letter-spacing: 1.5px;
-  padding: 14px 14px 4px; margin: 0;
-}
-.sidebar h2 .count { opacity: 0.35; font-weight: 400; }
-.sidebar a {
-  display: block; padding: 2px 14px 2px 22px;
-  color: var(--text-secondary); text-decoration: none;
-  font-size: 12px; line-height: 1.8;
-  border-left: 2px solid transparent; transition: all 0.15s;
-}
-.sidebar a:hover { color: var(--text); border-left-color: var(--accent); background: var(--accent-glow); }
-.sidebar a.active { color: var(--accent); border-left-color: var(--accent); }
 
  
-.main { margin-left: var(--sidebar-w); padding: 48px 36px; max-width: none; }
+.side {
+  border-right: 1px solid var(--line);
+  background: var(--bg);
+  position: sticky; top: 0;
+  height: 100vh; overflow-y: auto;
+  padding: 28px 22px 40px;
+   
+  scrollbar-width: none;
+}
+.side::-webkit-scrollbar { display: none; }
+.brand {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 22px;
+}
+.brand-name {
+  font-family: var(--mono); font-weight: 600;
+  font-size: 13px; letter-spacing: 0.01em;
+}
+.brand-ver {
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-4); margin-left: auto;
+}
+.nav-toggle {
+  display: none;
+  align-items: center; gap: 6px;
+  margin-left: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  color: var(--fg-2);
+  font-family: var(--mono); font-size: 11px;
+  padding: 5px 10px;
+  border-radius: 6px;
+  cursor: pointer;
+  min-height: 32px;
+}
+.nav-toggle:hover { color: var(--fg); border-color: var(--line-2); }
+.nav-toggle-icon { font-size: 13px; line-height: 1; }
 
-.main > header {
-  margin-bottom: 64px; display: flex; justify-content: space-between; align-items: flex-start;
-  padding-bottom: 32px;
-  border-bottom: 1px solid var(--border);
-  position: relative;
+.sidebar-meta {
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-4);
+  text-transform: uppercase; letter-spacing: 0.12em;
+  padding-bottom: 10px; border-bottom: 1px solid var(--line); margin-bottom: 10px;
 }
-.main > header::after {
-  content: ""; position: absolute; bottom: -1px; left: 0; width: 120px; height: 2px;
-  background: linear-gradient(90deg, var(--accent), transparent);
-}
-.main > header div p { color: var(--text-secondary); font-size: 12px; margin-top: 8px; }
-.header-title {
-  font-size: 26px; font-weight: 700; color: var(--accent);
-  letter-spacing: -0.5px;
-}
-.header-title span { color: var(--text-secondary); font-weight: 400; }
 
-.header-actions { display: flex; gap: 8px; }
+.search { position: relative; margin-bottom: 16px; }
+.search input {
+  width: 100%;
+  background: var(--bg-2); border: 1px solid var(--line);
+  color: var(--fg);
+  font-family: var(--mono); font-size: 12px;
+  padding: 8px 10px 8px 28px;
+  border-radius: 6px; outline: none;
+}
+.search input:focus { border-color: var(--accent); }
+.search::before {
+  content: "/"; position: absolute;
+  left: 10px; top: 50%; transform: translateY(-50%);
+  color: var(--fg-4); font-family: var(--mono); font-size: 12px;
+}
+.search .clear-k {
+  position: absolute; right: 8px; top: 50%; transform: translateY(-50%);
+  font-family: var(--mono); font-size: 10px; color: var(--fg-4);
+}
+
+.side-nav { list-style: none; padding: 0; margin: 0; }
+.side-nav .grp { margin-top: 14px; }
+.side-nav .grp-title {
+  display: flex; align-items: baseline; gap: 6px;
+  font-family: var(--mono); font-size: 11px;
+  color: var(--fg-2); font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  padding: 6px 0 4px;
+  border-top: 1px solid var(--line);
+}
+.side-nav .grp-title .count { color: var(--fg-4); font-weight: 400; margin-left: auto; }
+.side-nav a {
+  display: flex; align-items: baseline; gap: 8px;
+  font-family: var(--mono); font-size: 11.5px;
+  color: var(--fg-3);
+  text-decoration: none;
+  padding: 3px 0;
+  line-height: 1.4;
+}
+.side-nav a .dot { color: var(--fg-4); font-size: 10px; }
+.side-nav a:hover { color: var(--fg); }
+.side-nav a.active { color: var(--accent); }
+.side-nav a.hidden { display: none; }
+
+.side-foot {
+  margin-top: 28px; padding-top: 14px;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-4); line-height: 1.6;
+}
+.side-foot a { color: var(--fg-3); text-decoration: none; }
+.side-foot a:hover { color: var(--fg); }
+
+ 
+.main { padding: 36px 56px 80px; max-width: 1040px; }
+
+.topbar {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-bottom: 20px; border-bottom: 1px solid var(--line);
+  margin-bottom: 32px;
+}
+.crumbs { font-family: var(--mono); font-size: 11.5px; color: var(--fg-3); }
+.crumbs .sep { color: var(--fg-4); margin: 0 6px; }
+.crumbs .here { color: var(--fg); }
+
 .theme-toggle {
-  background: none; border: 1px solid var(--border); color: var(--text-secondary);
-  padding: 5px 14px; cursor: pointer; font-size: 11px;
-  font-family: 'JetBrains Mono', monospace; letter-spacing: 0.5px;
-  transition: all 0.2s; text-decoration: none;
+  display: inline-flex; border: 1px solid var(--line);
+  border-radius: 999px; overflow: hidden;
+  background: var(--bg-1);
+  font-family: var(--mono); font-size: 10.5px;
 }
-.theme-toggle:hover { color: var(--accent); border-color: var(--accent); box-shadow: 0 0 12px var(--accent-glow); }
+.theme-toggle button {
+  all: unset; cursor: pointer;
+  padding: 5px 12px; color: var(--fg-3);
+}
+.theme-toggle button.active { background: var(--fg); color: var(--bg); }
+[data-theme="light"] .theme-toggle button.active { color: var(--bg-1); }
 
  
-.intro { margin-bottom: 48px; font-size: 12px; color: var(--text-secondary); }
-
- 
-.category { margin-bottom: 64px; }
-.category > h2 {
-  font-size: 12px; font-weight: 700; color: var(--accent);
-  text-transform: uppercase; letter-spacing: 2.5px;
-  margin-bottom: 24px; padding-bottom: 12px;
-  border-bottom: 1px solid var(--border);
+.mast {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 40px; align-items: end;
+  margin-bottom: 40px;
   position: relative;
 }
-.category > h2::before { content: "# "; color: var(--text-secondary); }
-.category > h2::after {
-  content: ""; position: absolute; bottom: -1px; left: 0; width: 60px; height: 1px;
-  background: var(--accent);
+.mast h1 {
+  font-family: var(--mono); font-weight: 600;
+  font-size: 48px; line-height: 1.02;
+  letter-spacing: -0.02em;
+  margin: 0 0 14px; color: var(--fg);
 }
-
-.screens { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; }
-
- 
-.screen {
-  transition: box-shadow 0.2s;
-  min-width: 0;
-  opacity: 0; transform: translateY(8px);
-  animation: cardIn 0.4s ease forwards;
+.mast h1 .slash { color: var(--accent); }
+.mast p.kicker {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--fg-4);
+  text-transform: uppercase; letter-spacing: 0.14em;
+  margin: 0 0 20px;
 }
-.screen:hover {
-  box-shadow: 0 0 24px var(--accent-glow);
+.mast p.lede {
+  font-family: var(--sans);
+  font-size: 16px; line-height: 1.55;
+  color: var(--fg-2);
+  margin: 0; max-width: 560px;
+  text-wrap: pretty;
 }
-
-@keyframes cardIn {
-  to { opacity: 1; transform: translateY(0); }
+.mast .fact {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--fg-4); text-align: right;
+  line-height: 1.6;
 }
-
-.screen-header { padding: 8px 0 4px 14px; }
-.screen-header h3 {
-  font-size: 13px; font-weight: 500; color: var(--text);
-}
-.screen-header h3::before { content: "// "; color: var(--text-secondary); font-weight: 400; }
-.screen-header p {
-  font-size: 10px; color: var(--text-secondary); margin: 0; padding-left: 2.3em;
-}
-
-.screen-cmd {
-  padding: 5px 14px; margin: 4px 0 0;
-  font-size: 11px; color: var(--cmd-color);
-}
-.screen-cmd::before { content: "$ "; color: var(--text-secondary); }
-
- 
-.terminal {
-  margin: 4px 0 0 14px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-left: none;
-  max-height: calc(10 * 1.5em + 44px); overflow: hidden; position: relative; cursor: pointer;
-  transition: max-height 0.3s ease;
-}
-.terminal-chrome {
-  padding: 7px 12px; display: flex; gap: 5px; align-items: center;
-  border-bottom: 1px solid var(--border);
-  background: var(--surface-cmd);
-}
-.terminal-chrome i {
-  width: 8px; height: 8px; border-radius: 50%; display: block;
-}
-.terminal-chrome i:nth-child(1) { background: var(--dot-close); }
-.terminal-chrome i:nth-child(2) { background: var(--dot-min); }
-.terminal-chrome i:nth-child(3) { background: var(--dot-max); }
-.terminal-body { padding: 10px 14px; overflow-x: auto; }
-.terminal.overflows::after {
-  content: ""; position: absolute; bottom: 0; left: 0; right: 0; height: 40px;
-  background: linear-gradient(transparent 0%, var(--surface) 80%);
+.mast .fact b { color: var(--fg-2); font-weight: 500; }
+.mast::before {
+  content: "";
+  position: absolute;
+  right: -40px; top: -40px;
+  width: 360px; height: 360px;
+  border-radius: 50%;
+   
+  background: var(--bloom, radial-gradient(closest-side,
+      color-mix(in srgb, var(--accent) 32%, transparent),
+      color-mix(in srgb, var(--accent) 14%, transparent) 45%,
+      transparent 72%));
+  filter: blur(2px);
   pointer-events: none;
+  z-index: 0;
 }
-.terminal.expanded { max-height: none; }
-.terminal.expanded::after { display: none; }
-.terminal pre {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 12px; line-height: 1.5; color: var(--text);
-  margin: 0; white-space: pre; tab-size: 8;
+.mast > * { position: relative; z-index: 1; }
+
+ 
+.section { margin-bottom: 72px; }
+.section-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 16px; align-items: baseline;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--line);
+  margin-bottom: 28px;
+}
+.section-num {
+  font-family: var(--mono); font-size: 11px;
+  color: var(--fg-4); letter-spacing: 0.1em;
+}
+.section-name {
+  font-family: var(--mono); font-weight: 600;
+  font-size: 24px; letter-spacing: -0.01em; color: var(--fg);
+}
+.section-blurb {
+  font-family: var(--sans); font-size: 13px;
+  color: var(--fg-3);
+  max-width: 440px; text-align: right; justify-self: end;
+}
+.section.empty { display: none; }
+
+ 
+.entry {
+  display: grid;
+  grid-template-columns: 180px 1fr;
+  gap: 28px;
+  padding: 24px 0 36px;
+  border-top: 1px dashed var(--line);
+}
+.entry-term { min-width: 0; }  
+.entry:first-child { border-top: 0; padding-top: 8px; }
+.entry-meta .id {
+  font-family: var(--mono); font-size: 10.5px;
+  color: var(--fg-4); letter-spacing: 0.08em;
+  margin-bottom: 8px;
+}
+.entry-meta h4 {
+  font-family: var(--mono); font-weight: 600;
+  font-size: 15px; line-height: 1.25;
+  color: var(--fg); margin: 0 0 8px;
+}
+.entry-meta p {
+  font-family: var(--sans); font-size: 12.5px;
+  line-height: 1.55; color: var(--fg-3);
+  margin: 0 0 10px; text-wrap: pretty;
+}
+.entry-meta .tags {
+  display: flex; flex-wrap: wrap; gap: 4px;
+  font-family: var(--mono); font-size: 10px;
+  color: var(--fg-4);
+}
+.entry-meta .tags span {
+  padding: 2px 6px; border: 1px solid var(--line); border-radius: 3px;
+}
+.entry.hidden { display: none; }
+
+.experimental-pill {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 9.5px; letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--yellow);
+  border: 1px solid var(--yellow);
+  border-radius: 3px;
+  padding: 0 5px; margin-left: 6px; vertical-align: 2px;
 }
 
+ 
+.term {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  font-family: var(--mono);
+  color: var(--fg);
+  overflow: hidden;
+  position: relative;
+}
+.term-head {
+  display: flex; align-items: center;
+  gap: 10px; padding: 10px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--bg-2);
+  font-family: var(--mono);
+  font-size: 11.5px; color: var(--fg-3);
+  letter-spacing: 0.02em;
+}
+.term-dots { display: inline-flex; gap: 6px; }
+.term-dots i {
+  width: 10px; height: 10px; border-radius: 50%;
+  background: var(--line-2); display: inline-block;
+}
+.term-dots i:nth-child(1) { background: oklch(0.70 0.14 25); }
+.term-dots i:nth-child(2) { background: oklch(0.80 0.13 85); }
+.term-dots i:nth-child(3) { background: oklch(0.75 0.13 150); }
+.term-title {
+  flex: 1; text-align: center;
+  font-size: 11px; color: var(--fg-3);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.term-head-pad { width: 42px; }
+.term-prompt {
+  padding: 12px 16px 8px;
+  font-size: 12.5px;
+  color: var(--fg-3);
+  border-bottom: 1px dashed var(--line);
+  margin-bottom: 10px;
+}
+.term-prompt .p { color: var(--green); }
+.term-prompt .cmd { color: var(--fg); }
+.term-body {
+  padding: 4px 16px 16px;
+  font-size: 12.5px; line-height: 1.55;
+  white-space: pre;
+  overflow-x: auto;
+  margin: 0;
+}
+.term-body.no-prompt { padding-top: 14px; }
+
+ 
+.term-bold { font-weight: 600; }
+.term-fg2, .term-dim { color: var(--fg-3); }
+.term-italic { font-style: italic; }
+.term-underline { text-decoration: underline; }
+.term-fg30 { color: var(--fg-4); }
+.term-fg31 { color: var(--red); }
+.term-fg32 { color: var(--green); }
+.term-fg33 { color: var(--yellow); }
+.term-fg34 { color: var(--blue); }
+.term-fg35 { color: var(--magenta); }
+.term-fg36 { color: var(--cyan); }
+.term-fg37 { color: var(--fg-2); }
+.term-fg90 { color: var(--fg-3); }
+.term-fg91 { color: var(--red); }
+.term-fg92 { color: var(--green); }
+.term-fg93 { color: var(--yellow); }
+.term-fg94 { color: var(--blue); }
+.term-fg95 { color: var(--magenta); }
+.term-fg96 { color: var(--cyan); }
+.term-fg97 { color: var(--fg); }
+.term-bg40 { background: var(--fg-4); }
+.term-bg41 { background: var(--red); color: var(--bg); }
+.term-bg42 { background: var(--green); color: var(--bg); }
+.term-bg43 { background: var(--yellow); color: var(--bg); }
+.term-bg44 { background: var(--blue); color: var(--bg); }
+.term-bg45 { background: var(--magenta); color: var(--bg); }
+.term-bg46 { background: var(--cyan); color: var(--bg); }
+.term-bg47 { background: var(--fg-2); color: var(--bg); }
+
+ 
+.notes-panel {
+  border: 1px solid var(--accent);
+  border-left-width: 3px;
+  background: color-mix(in oklch, var(--accent) 6%, var(--bg-1));
+  border-radius: 8px;
+  padding: 18px 22px;
+  margin-bottom: 60px;
+}
+[data-theme="light"] .notes-panel {
+  background: color-mix(in oklch, var(--accent) 10%, var(--bg-1));
+}
+.notes-panel h3 {
+  font-family: var(--mono); font-size: 11px;
+  margin: 0 0 8px;
+  text-transform: uppercase; letter-spacing: 0.14em;
+  color: var(--accent);
+}
+.notes-panel p {
+  font-family: var(--sans); font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--fg-2);
+  margin: 0 0 8px;
+  max-width: 660px;
+  text-wrap: pretty;
+}
+.notes-panel p:last-child { margin-bottom: 0; }
+.notes-panel .mono-hint {
+  font-family: var(--mono); font-size: 11px; color: var(--fg-3);
+}
+.notes-panel .kbd {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-3);
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+
+ 
+.foot {
+  margin-top: 60px; padding-top: 24px;
+  border-top: 1px solid var(--line);
+  display: flex; align-items: baseline; justify-content: space-between;
+  font-family: var(--mono); font-size: 10.5px; color: var(--fg-4);
+}
+.attrib {
+  display: flex; align-items: center; gap: 14px;
+  padding: 18px 0 0;
+  margin-top: 32px;
+  border-top: 1px solid var(--line);
+  font-family: var(--mono); font-size: 11px;
+  color: var(--fg-3);
+  flex-wrap: wrap;
+}
+.attrib .dot { color: var(--fg-4); }
+
+ 
 @media (max-width: 1100px) {
-  .screens { grid-template-columns: repeat(2, 1fr); }
-}
-@media (max-width: 768px) {
-  .sidebar { display: none; }
-  .main { margin-left: 0; padding: 24px 16px; }
-  .main > header { flex-direction: column; gap: 16px; }
-  .header-title { font-size: 20px; }
-  .screens { grid-template-columns: 1fr; }
-  .terminal { margin-left: 0; }
-  .screen-cmd { font-size: 10px; overflow-x: auto; }
+  .page { grid-template-columns: 240px 1fr; }
+  .side { padding: 22px 16px 32px; }
+  .main { padding: 32px 36px 60px; }
+  .mast h1 { font-size: 42px; }
+  .entry { grid-template-columns: 160px 1fr; gap: 22px; }
 }
 
- 
-.term-fg1, .term-bold { font-weight: 700; }
-.term-fg2, .term-dim  { opacity: var(--t-dim-opacity); }
-.term-fg3, .term-italic { font-style: italic; }
-.term-fg4, .term-underline { text-decoration: underline; }
-.term-fg30 { color: var(--t-black); } .term-fg31 { color: var(--t-red); } .term-fg32 { color: var(--t-green); }
-.term-fg33 { color: var(--t-yellow); } .term-fg34 { color: var(--t-blue); } .term-fg35 { color: var(--t-magenta); }
-.term-fg36 { color: var(--t-cyan); } .term-fg37 { color: var(--t-white); }
-.term-fg90 { color: var(--t-br-black); } .term-fg91 { color: var(--t-br-red); } .term-fg92 { color: var(--t-br-green); }
-.term-fg93 { color: var(--t-br-yellow); } .term-fg94 { color: var(--t-br-blue); } .term-fg95 { color: var(--t-br-magenta); }
-.term-fg96 { color: var(--t-br-cyan); } .term-fg97 { color: var(--t-br-white); }
-.term-bg40 { background: var(--t-black); } .term-bg41 { background: var(--t-red); } .term-bg42 { background: var(--t-green); }
-.term-bg43 { background: var(--t-yellow); } .term-bg44 { background: var(--t-blue); } .term-bg45 { background: var(--t-magenta); }
-.term-bg46 { background: var(--t-cyan); } .term-bg47 { background: var(--t-white); }
+@media (max-width: 900px) {
+  .page { grid-template-columns: 1fr; }
+  .side {
+    position: sticky; top: 0; z-index: 15;
+    height: auto;
+    border-right: 0; border-bottom: 1px solid var(--line);
+    padding: 14px 20px 16px;
+    background: var(--bg);
+  }
+  .side-foot { margin-top: 18px; }
+
+   
+  .nav-toggle { display: inline-flex; }
+  .side .side-nav,
+  .side .side-foot { display: none; }
+  .side.nav-open .side-nav { display: block; }
+  .side.nav-open .side-foot { display: block; }
+  .side.nav-open { max-height: 85vh; overflow-y: auto; }
+  .brand { margin-bottom: 12px; }
+  .sidebar-meta { margin-bottom: 10px; }
+  .search { margin-bottom: 0; }
+  .side.nav-open .search { margin-bottom: 14px; }
+  .main { padding: 28px 24px 60px; }
+  .entry { grid-template-columns: 1fr; gap: 14px; padding: 20px 0 28px; }
+  .mast { grid-template-columns: 1fr; gap: 22px; }
+  .mast .fact { text-align: left; }
+  .mast h1 { font-size: 34px; }
+  .mast p.lede { font-size: 15px; }
+  .section-head { grid-template-columns: 1fr; gap: 10px; }
+  .section-blurb { text-align: left; justify-self: start; max-width: none; }
+  .section { margin-bottom: 56px; }
+}
+
+@media (max-width: 600px) {
+  .main { padding: 20px 18px 48px; }
+  .side { padding: 14px 18px 18px; }
+  .brand-name { font-size: 12.5px; }
+  .topbar { flex-wrap: wrap; gap: 10px; padding-bottom: 14px; margin-bottom: 22px; }
+  .crumbs { font-size: 11px; }
+  .theme-toggle button { padding: 7px 14px; font-size: 11px; }
+   
+  .search input { font-size: 16px; padding: 10px 12px 10px 30px; }
+  .search::before { font-size: 14px; }
+  .mast { margin-bottom: 32px; gap: 16px; }
+  .mast h1 { font-size: 28px; letter-spacing: -0.01em; }
+  .mast p.kicker { font-size: 10.5px; margin-bottom: 14px; }
+  .mast p.lede { font-size: 14px; padding-left: 12px; }
+  .mast::before { display: none; }
+  .notes-panel { padding: 14px 16px; margin-bottom: 36px; }
+  .notes-panel p { font-size: 12.5px; }
+  .section { margin-bottom: 44px; }
+  .section-name { font-size: 20px; }
+  .section-head { padding-bottom: 10px; margin-bottom: 18px; }
+  .entry { padding: 16px 0 22px; gap: 10px; }
+  .entry-meta h4 { font-size: 14px; }
+  .entry-meta .id { margin-bottom: 4px; }
+  .entry-meta p { font-size: 12px; }
+  .term { border-radius: 8px; }
+  .term-head { gap: 8px; padding: 8px 12px; font-size: 11px; }
+  .term-head-pad { display: none; }
+  .term-title { font-size: 10.5px; }
+  .term-prompt { padding: 10px 12px 6px; font-size: 12px; }
+  .term-body { font-size: 12px; padding: 4px 12px 14px; }
+  .foot { flex-direction: column; gap: 6px; align-items: flex-start; }
+  .attrib { flex-wrap: wrap; gap: 8px; font-size: 10.5px; padding: 14px 0 0; margin-top: 22px; }
+}
+
+@media (max-width: 420px) {
+  .mast h1 { font-size: 24px; line-height: 1.08; }
+  .section-name { font-size: 18px; }
+  .term-body { font-size: 11.5px; padding: 4px 10px 12px; }
+  .term-prompt { padding: 8px 10px 6px; font-size: 11.5px; }
+  .term-head { padding: 7px 10px; }
+  .entry-meta .tags { gap: 3px; }
+}
 
  
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: var(--text-secondary); }
+:root,[data-theme="dark"]{--bloom:radial-gradient(closest-side, oklch(0.74 0.20 20 / 0.28), oklch(0.78 0.18 45 / 0.16) 45%, transparent 72%)}
+[data-theme="light"]{--bloom:radial-gradient(closest-side, oklch(0.78 0.18 340 / 0.30), oklch(0.82 0.14 60 / 0.18) 45%, transparent 72%)}
 
- 
-:root,[data-theme="dark"]{--accent:#07C3F2;--accent-glow:#07C3F214;--cmd-color:#07C3F2}
-[data-theme="light"]{--accent:#07C3F2;--accent-glow:#07C3F20f;--cmd-color:#07C3F2}
+.mast h1 .slash {
+  background: linear-gradient(135deg, #FE2857 0%, #FF9E2C 45%, #E1309B 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+.attrib .jb-wordmark {
+  font-family: var(--mono);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+  font-size: 12px;
+}
+
 
 
 </style>
 </head>
 <body>
-
-<nav class="sidebar">
-  <div class="sidebar-brand">
-    <strong>termbook</strong>
-    screen gallery
-  </div>
-  <h2>Style Guide <span class="count">5</span></h2>
-  <a href="#colors" data-target="colors">Colors &amp; Text Styles</a>
-  <a href="#status-icons" data-target="status-icons">Status Icons</a>
-  <a href="#messages" data-target="messages">Messages</a>
-  <a href="#table" data-target="table">Table Rendering</a>
-  <a href="#tree" data-target="tree">Tree Rendering</a>
-  <h2>Runs <span class="count">18</span></h2>
-  <a href="#run-list" data-target="run-list">run list</a>
-  <a href="#run-view" data-target="run-view">run view</a>
-  <a href="#run-start" data-target="run-start">run start</a>
-  <a href="#run-restart" data-target="run-restart">run restart</a>
-  <a href="#run-watch" data-target="run-watch">run watch --logs</a>
-  <a href="#run-log" data-target="run-log">run log --tail</a>
-  <a href="#run-diff" data-target="run-diff">run diff</a>
-  <a href="#run-artifacts" data-target="run-artifacts">run artifacts</a>
-  <a href="#run-download" data-target="run-download">run download</a>
-  <a href="#run-changes" data-target="run-changes">run changes</a>
-  <a href="#run-tests" data-target="run-tests">run tests</a>
-  <a href="#run-tree" data-target="run-tree">run tree</a>
-  <a href="#run-cancel" data-target="run-cancel">run cancel</a>
-  <a href="#run-pin" data-target="run-pin">run pin</a>
-  <a href="#run-unpin" data-target="run-unpin">run unpin</a>
-  <a href="#run-tag" data-target="run-tag">run tag</a>
-  <a href="#run-comment" data-target="run-comment">run comment</a>
-  <a href="#run-comment-set" data-target="run-comment-set">run comment (set)</a>
-  <h2>Jobs <span class="count">5</span></h2>
-  <a href="#job-list" data-target="job-list">job list</a>
-  <a href="#job-view" data-target="job-view">job view</a>
-  <a href="#job-tree" data-target="job-tree">job tree</a>
-  <a href="#job-pause" data-target="job-pause">job pause</a>
-  <a href="#job-param" data-target="job-param">job param list</a>
-  <h2>Agents <span class="count">7</span></h2>
-  <a href="#agent-list" data-target="agent-list">agent list</a>
-  <a href="#agent-view" data-target="agent-view">agent view</a>
-  <a href="#agent-jobs" data-target="agent-jobs">agent jobs</a>
-  <a href="#agent-enable" data-target="agent-enable">agent enable</a>
-  <a href="#agent-disable" data-target="agent-disable">agent disable</a>
-  <a href="#agent-term" data-target="agent-term">agent term</a>
-  <a href="#agent-exec" data-target="agent-exec">agent exec</a>
-  <h2>Queue <span class="count">4</span></h2>
-  <a href="#queue-list" data-target="queue-list">queue list</a>
-  <a href="#queue-remove" data-target="queue-remove">queue remove</a>
-  <a href="#queue-top" data-target="queue-top">queue top</a>
-  <a href="#queue-approve" data-target="queue-approve">queue approve</a>
-  <h2>Pools <span class="count">3</span></h2>
-  <a href="#pool-list" data-target="pool-list">pool list</a>
-  <a href="#pool-view" data-target="pool-view">pool view</a>
-  <a href="#pool-link" data-target="pool-link">pool link</a>
-  <h2>Projects <span class="count">27</span></h2>
-  <a href="#project-list" data-target="project-list">project list</a>
-  <a href="#project-view" data-target="project-view">project view</a>
-  <a href="#project-tree" data-target="project-tree">project tree</a>
-  <a href="#project-settings" data-target="project-settings">project settings status</a>
-  <a href="#project-settings-validate" data-target="project-settings-validate">project settings validate</a>
-  <a href="#project-settings-export" data-target="project-settings-export">project settings export</a>
-  <a href="#project-vcs-list" data-target="project-vcs-list">project vcs list</a>
-  <a href="#project-vcs-view" data-target="project-vcs-view">project vcs view</a>
-  <a href="#project-vcs-create" data-target="project-vcs-create">project vcs create</a>
-  <a href="#project-vcs-test" data-target="project-vcs-test">project vcs test</a>
-  <a href="#project-vcs-delete" data-target="project-vcs-delete">project vcs delete</a>
-  <a href="#project-ssh-list" data-target="project-ssh-list">project ssh list</a>
-  <a href="#project-ssh-generate" data-target="project-ssh-generate">project ssh generate</a>
-  <a href="#project-ssh-upload" data-target="project-ssh-upload">project ssh upload</a>
-  <a href="#project-ssh-delete" data-target="project-ssh-delete">project ssh delete</a>
-  <a href="#project-connection-list" data-target="project-connection-list">project connection list</a>
-  <a href="#project-cloud-profile" data-target="project-cloud-profile">project cloud profile list</a>
-  <a href="#project-cloud-profile-view" data-target="project-cloud-profile-view">project cloud profile view</a>
-  <a href="#project-cloud-image" data-target="project-cloud-image">project cloud image list</a>
-  <a href="#project-cloud-image-view" data-target="project-cloud-image-view">project cloud image view</a>
-  <a href="#project-cloud-image-start" data-target="project-cloud-image-start">project cloud image start</a>
-  <a href="#project-cloud-instance" data-target="project-cloud-instance">project cloud instance list</a>
-  <a href="#project-cloud-instance-view" data-target="project-cloud-instance-view">project cloud instance view</a>
-  <a href="#project-cloud-instance-stop" data-target="project-cloud-instance-stop">project cloud instance stop</a>
-  <a href="#project-param" data-target="project-param">project param list</a>
-  <a href="#project-token-put" data-target="project-token-put">project token put</a>
-  <a href="#project-token-get" data-target="project-token-get">project token get</a>
-  <h2>Pipelines <span class="count">6</span></h2>
-  <a href="#pipeline-list" data-target="pipeline-list">pipeline list</a>
-  <a href="#pipeline-view" data-target="pipeline-view">pipeline view</a>
-  <a href="#pipeline-validate" data-target="pipeline-validate">pipeline validate</a>
-  <a href="#pipeline-delete" data-target="pipeline-delete">pipeline delete</a>
-  <a href="#pipeline-push" data-target="pipeline-push">pipeline push</a>
-  <a href="#pipeline-pull" data-target="pipeline-pull">pipeline pull</a>
-  <h2>Auth <span class="count">4</span></h2>
-  <a href="#auth-status" data-target="auth-status">auth status</a>
-  <a href="#auth-status-multi" data-target="auth-status-multi">auth status (multi-server)</a>
-  <a href="#auth-login" data-target="auth-login">auth login</a>
-  <a href="#auth-logout" data-target="auth-logout">auth logout</a>
-  <h2>Config <span class="count">3</span></h2>
-  <a href="#config-list" data-target="config-list">config list</a>
-  <a href="#config-get" data-target="config-get">config get</a>
-  <a href="#config-set" data-target="config-set">config set</a>
-  <h2>Aliases <span class="count">3</span></h2>
-  <a href="#alias-list" data-target="alias-list">alias list</a>
-  <a href="#alias-set" data-target="alias-set">alias set</a>
-  <a href="#alias-delete" data-target="alias-delete">alias delete</a>
-  <h2>Skills <span class="count">4</span></h2>
-  <a href="#skill-list" data-target="skill-list">skill list</a>
-  <a href="#skill-install" data-target="skill-install">skill install</a>
-  <a href="#skill-update" data-target="skill-update">skill update</a>
-  <a href="#skill-remove" data-target="skill-remove">skill remove</a>
-  <h2>API <span class="count">1</span></h2>
-  <a href="#api-get" data-target="api-get">api</a>
-  <h2>Update <span class="count">1</span></h2>
-  <a href="#update" data-target="update">update</a>
-  <h2>Errors <span class="count">6</span></h2>
-  <a href="#error-not-found" data-target="error-not-found">Not Found</a>
-  <a href="#error-auth" data-target="error-auth">Authentication Failed</a>
-  <a href="#error-permission" data-target="error-permission">Permission Denied</a>
-  <a href="#error-network" data-target="error-network">Network Error</a>
-  <a href="#error-readonly" data-target="error-readonly">Read-Only Mode</a>
-  <a href="#error-json" data-target="error-json">JSON Error Format</a>
-  <h2>Help Screens <span class="count">23</span></h2>
-  <a href="#help-root" data-target="help-root">teamcity</a>
-  <a href="#help-run" data-target="help-run">run</a>
-  <a href="#help-job" data-target="help-job">job</a>
-  <a href="#help-agent" data-target="help-agent">agent</a>
-  <a href="#help-queue" data-target="help-queue">queue</a>
-  <a href="#help-pool" data-target="help-pool">pool</a>
-  <a href="#help-project" data-target="help-project">project</a>
-  <a href="#help-pipeline" data-target="help-pipeline">pipeline</a>
-  <a href="#help-auth" data-target="help-auth">auth</a>
-  <a href="#help-config" data-target="help-config">config</a>
-  <a href="#help-alias" data-target="help-alias">alias</a>
-  <a href="#help-skill" data-target="help-skill">skill</a>
-  <a href="#help-project-settings" data-target="help-project-settings">project settings</a>
-  <a href="#help-project-vcs" data-target="help-project-vcs">project vcs</a>
-  <a href="#help-project-ssh" data-target="help-project-ssh">project ssh</a>
-  <a href="#help-project-connection" data-target="help-project-connection">project connection</a>
-  <a href="#help-project-cloud" data-target="help-project-cloud">project cloud</a>
-  <a href="#help-project-cloud-profile" data-target="help-project-cloud-profile">project cloud profile</a>
-  <a href="#help-project-cloud-image" data-target="help-project-cloud-image">project cloud image</a>
-  <a href="#help-project-cloud-instance" data-target="help-project-cloud-instance">project cloud instance</a>
-  <a href="#help-project-token" data-target="help-project-token">project token</a>
-  <a href="#help-project-param" data-target="help-project-param">project param</a>
-  <a href="#help-job-param" data-target="help-job-param">job param</a>
-  
-</nav>
-
-<div class="main">
-  <header>
-    <div>
-      <div class="header-title">TeamCity CLI — Screen Gallery</div>
-      <p>120 screens &middot; generated 2026-04-14 21:49</p>
-    </div>
-    <div class="header-actions">
-      <a class="theme-toggle" href="https://github.com/jetbrains/teamcity-cli/" target="_blank" rel="noopener">[&#9733; github]</a>
-      <button class="theme-toggle" onclick="toggleTheme()">[theme: <span id="theme-label">dark</span>]</button>
-    </div>
-  </header>
-
-  <p class="intro">Auto-generated from real command output. Click terminals to expand. Regenerate with just gallery</p>
-
-  <section class="category" id="style-guide">
-    <h2>Style Guide</h2>
-    <div class="screens">
-    <div class="screen" id="colors">
-      <div class="screen-header"><h3>Colors &amp; Text Styles</h3><p>Standard color palette</p></div>
+<div class="page">
+  <aside class="side" id="side">
+    <div class="brand">
       
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">Green</span> — success, links, positive
+      <div class="brand-name">teamcity cli</div>
+      <div class="brand-ver">v0.9.0</div>
+      <button id="navToggle" class="nav-toggle" type="button" aria-expanded="false" aria-controls="sideNav" aria-label="Toggle navigation">
+        <span class="nav-toggle-icon" aria-hidden="true">☰</span>
+        <span class="nav-toggle-label">menu</span>
+      </button>
+    </div>
+
+    <div class="sidebar-meta">134 screens · 2026-04-18 17:43</div>
+
+    <div class="search">
+      <input id="q" type="text" placeholder="filter commands…" autocomplete="off" />
+      <span class="clear-k">/</span>
+    </div>
+
+    <ul class="side-nav" id="sideNav">
+      <li class="grp" data-grp="style-guide">
+        <div class="grp-title"><span>Style Guide</span><span class="count">5</span></div>
+        <a href="#colors" data-cmd="colors" data-search="colors colors &amp; text styles standard color palette ">
+          <span class="dot">·</span><span>Colors &amp; Text Styles</span>
+        </a>
+        <a href="#status-icons" data-cmd="status-icons" data-search="status-icons status icons status indicators in tables and views ">
+          <span class="dot">·</span><span>Status Icons</span>
+        </a>
+        <a href="#messages" data-cmd="messages" data-search="messages messages info, success, warning, error patterns ">
+          <span class="dot">·</span><span>Messages</span>
+        </a>
+        <a href="#table" data-cmd="table" data-search="table table rendering auto-sized columns with colored cells ">
+          <span class="dot">·</span><span>Table Rendering</span>
+        </a>
+        <a href="#tree" data-cmd="tree" data-search="tree tree rendering hierarchical display with connectors ">
+          <span class="dot">·</span><span>Tree Rendering</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="runs">
+        <div class="grp-title"><span>Runs</span><span class="count">19</span></div>
+        <a href="#run-list" data-cmd="run-list" data-search="run-list run list list recent runs with status, job, branch, and timing teamcity run list">
+          <span class="dot">·</span><span>run list</span>
+        </a>
+        <a href="#run-view" data-cmd="run-view" data-search="run-view run view detail view of a finished run teamcity run view 45231">
+          <span class="dot">·</span><span>run view</span>
+        </a>
+        <a href="#run-start" data-cmd="run-start" data-search="run-start run start trigger a new run teamcity run start myapp_build --no-input">
+          <span class="dot">·</span><span>run start</span>
+        </a>
+        <a href="#run-restart" data-cmd="run-restart" data-search="run-restart run restart re-trigger a completed run teamcity run restart 1 --no-input">
+          <span class="dot">·</span><span>run restart</span>
+        </a>
+        <a href="#run-watch" data-cmd="run-watch" data-search="run-watch run watch --logs full-screen tui with live log streaming (alt-screen) teamcity run watch --logs 45229">
+          <span class="dot">·</span><span>run watch --logs</span>
+        </a>
+        <a href="#run-log" data-cmd="run-log" data-search="run-log run log --tail formatted build log with timestamps teamcity run log 1 --tail 10">
+          <span class="dot">·</span><span>run log --tail</span>
+        </a>
+        <a href="#run-diff" data-cmd="run-diff" data-search="run-diff run diff compare two runs side by side teamcity run diff 45231 45230">
+          <span class="dot">·</span><span>run diff</span>
+        </a>
+        <a href="#run-artifacts" data-cmd="run-artifacts" data-search="run-artifacts run artifacts list downloadable build artifacts teamcity run artifacts 1">
+          <span class="dot">·</span><span>run artifacts</span>
+        </a>
+        <a href="#run-download" data-cmd="run-download" data-search="run-download run download download artifacts to local filesystem teamcity run download 45231">
+          <span class="dot">·</span><span>run download</span>
+        </a>
+        <a href="#run-changes" data-cmd="run-changes" data-search="run-changes run changes vcs changes included in a run teamcity run changes 1">
+          <span class="dot">·</span><span>run changes</span>
+        </a>
+        <a href="#run-tests" data-cmd="run-tests" data-search="run-tests run tests test results summary teamcity run tests 1">
+          <span class="dot">·</span><span>run tests</span>
+        </a>
+        <a href="#run-tree" data-cmd="run-tree" data-search="run-tree run tree snapshot dependency tree of a run teamcity run tree 45229">
+          <span class="dot">·</span><span>run tree</span>
+        </a>
+        <a href="#run-cancel" data-cmd="run-cancel" data-search="run-cancel run cancel cancel a running or queued build teamcity run cancel --yes 45233">
+          <span class="dot">·</span><span>run cancel</span>
+        </a>
+        <a href="#run-pin" data-cmd="run-pin" data-search="run-pin run pin pin a build to prevent cleanup teamcity run pin 1 -m &#34;release candidate&#34;">
+          <span class="dot">·</span><span>run pin</span>
+        </a>
+        <a href="#run-unpin" data-cmd="run-unpin" data-search="run-unpin run unpin unpin a build teamcity run unpin 1">
+          <span class="dot">·</span><span>run unpin</span>
+        </a>
+        <a href="#run-tag" data-cmd="run-tag" data-search="run-tag run tag add tags to a run teamcity run tag 1 release v1.0.0">
+          <span class="dot">·</span><span>run tag</span>
+        </a>
+        <a href="#run-untag" data-cmd="run-untag" data-search="run-untag run untag remove tags from a run teamcity run untag 1 release">
+          <span class="dot">·</span><span>run untag</span>
+        </a>
+        <a href="#run-comment" data-cmd="run-comment" data-search="run-comment run comment view a build comment teamcity run comment 1">
+          <span class="dot">·</span><span>run comment</span>
+        </a>
+        <a href="#run-comment-set" data-cmd="run-comment-set" data-search="run-comment-set run comment (set) set a comment on a run teamcity run comment 1 &#34;ready for prod&#34;">
+          <span class="dot">·</span><span>run comment (set)</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="jobs">
+        <div class="grp-title"><span>Jobs</span><span class="count">9</span></div>
+        <a href="#job-list" data-cmd="job-list" data-search="job-list job list list build configurations teamcity job list">
+          <span class="dot">·</span><span>job list</span>
+        </a>
+        <a href="#job-view" data-cmd="job-view" data-search="job-view job view detail view of a build configuration teamcity job view myapp_build">
+          <span class="dot">·</span><span>job view</span>
+        </a>
+        <a href="#job-tree" data-cmd="job-tree" data-search="job-tree job tree snapshot dependency tree of a job teamcity job tree myapp_build">
+          <span class="dot">·</span><span>job tree</span>
+        </a>
+        <a href="#job-pause" data-cmd="job-pause" data-search="job-pause job pause pause a build configuration teamcity job pause myapp_deploy">
+          <span class="dot">·</span><span>job pause</span>
+        </a>
+        <a href="#job-resume" data-cmd="job-resume" data-search="job-resume job resume resume a paused build configuration teamcity job resume myapp_deploy">
+          <span class="dot">·</span><span>job resume</span>
+        </a>
+        <a href="#job-param" data-cmd="job-param" data-search="job-param job param list list job parameters teamcity job param list myapp_build">
+          <span class="dot">·</span><span>job param list</span>
+        </a>
+        <a href="#job-param-get" data-cmd="job-param-get" data-search="job-param-get job param get get a job parameter value teamcity job param get myapp_build env.java_home">
+          <span class="dot">·</span><span>job param get</span>
+        </a>
+        <a href="#job-param-set" data-cmd="job-param-set" data-search="job-param-set job param set set a job parameter value teamcity job param set myapp_build env.java_home /opt/jdk">
+          <span class="dot">·</span><span>job param set</span>
+        </a>
+        <a href="#job-param-delete" data-cmd="job-param-delete" data-search="job-param-delete job param delete delete a job parameter teamcity job param delete myapp_build env.java_home">
+          <span class="dot">·</span><span>job param delete</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="agents">
+        <div class="grp-title"><span>Agents</span><span class="count">11</span></div>
+        <a href="#agent-list" data-cmd="agent-list" data-search="agent-list agent list list build agents teamcity agent list">
+          <span class="dot">·</span><span>agent list</span>
+        </a>
+        <a href="#agent-view" data-cmd="agent-view" data-search="agent-view agent view detailed view of an agent teamcity agent view 1">
+          <span class="dot">·</span><span>agent view</span>
+        </a>
+        <a href="#agent-jobs" data-cmd="agent-jobs" data-search="agent-jobs agent jobs compatible and incompatible jobs teamcity agent jobs 1">
+          <span class="dot">·</span><span>agent jobs</span>
+        </a>
+        <a href="#agent-enable" data-cmd="agent-enable" data-search="agent-enable agent enable enable an agent teamcity agent enable 1">
+          <span class="dot">·</span><span>agent enable</span>
+        </a>
+        <a href="#agent-disable" data-cmd="agent-disable" data-search="agent-disable agent disable disable an agent teamcity agent disable 1">
+          <span class="dot">·</span><span>agent disable</span>
+        </a>
+        <a href="#agent-authorize" data-cmd="agent-authorize" data-search="agent-authorize agent authorize authorize an agent to accept builds teamcity agent authorize 1">
+          <span class="dot">·</span><span>agent authorize</span>
+        </a>
+        <a href="#agent-deauthorize" data-cmd="agent-deauthorize" data-search="agent-deauthorize agent deauthorize revoke authorization from an agent teamcity agent deauthorize 1">
+          <span class="dot">·</span><span>agent deauthorize</span>
+        </a>
+        <a href="#agent-move" data-cmd="agent-move" data-search="agent-move agent move move an agent to a different pool teamcity agent move 1 2">
+          <span class="dot">·</span><span>agent move</span>
+        </a>
+        <a href="#agent-reboot" data-cmd="agent-reboot" data-search="agent-reboot agent reboot request agent reboot teamcity agent reboot --yes 1">
+          <span class="dot">·</span><span>agent reboot</span>
+        </a>
+        <a href="#agent-term" data-cmd="agent-term" data-search="agent-term agent term interactive terminal session on an agent (websocket) teamcity agent term linux-agent-01">
+          <span class="dot">·</span><span>agent term</span>
+        </a>
+        <a href="#agent-exec" data-cmd="agent-exec" data-search="agent-exec agent exec execute a single command on an agent (websocket) teamcity agent exec linux-agent-01 -- top -bn1 | head -5">
+          <span class="dot">·</span><span>agent exec</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="queue">
+        <div class="grp-title"><span>Queue</span><span class="count">4</span></div>
+        <a href="#queue-list" data-cmd="queue-list" data-search="queue-list queue list list builds in the queue teamcity queue list">
+          <span class="dot">·</span><span>queue list</span>
+        </a>
+        <a href="#queue-remove" data-cmd="queue-remove" data-search="queue-remove queue remove remove a build from the queue teamcity queue remove --yes 100">
+          <span class="dot">·</span><span>queue remove</span>
+        </a>
+        <a href="#queue-top" data-cmd="queue-top" data-search="queue-top queue top move a build to the top of the queue teamcity queue top 100">
+          <span class="dot">·</span><span>queue top</span>
+        </a>
+        <a href="#queue-approve" data-cmd="queue-approve" data-search="queue-approve queue approve approve a queued build teamcity queue approve 100">
+          <span class="dot">·</span><span>queue approve</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="pools">
+        <div class="grp-title"><span>Pools</span><span class="count">4</span></div>
+        <a href="#pool-list" data-cmd="pool-list" data-search="pool-list pool list list agent pools teamcity pool list">
+          <span class="dot">·</span><span>pool list</span>
+        </a>
+        <a href="#pool-view" data-cmd="pool-view" data-search="pool-view pool view detailed pool with agents and projects teamcity pool view 0">
+          <span class="dot">·</span><span>pool view</span>
+        </a>
+        <a href="#pool-link" data-cmd="pool-link" data-search="pool-link pool link link a project to a pool teamcity pool link 0 myapp">
+          <span class="dot">·</span><span>pool link</span>
+        </a>
+        <a href="#pool-unlink" data-cmd="pool-unlink" data-search="pool-unlink pool unlink unlink a project from a pool teamcity pool unlink 0 myapp">
+          <span class="dot">·</span><span>pool unlink</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="projects">
+        <div class="grp-title"><span>Projects</span><span class="count">30</span></div>
+        <a href="#project-list" data-cmd="project-list" data-search="project-list project list list projects teamcity project list">
+          <span class="dot">·</span><span>project list</span>
+        </a>
+        <a href="#project-view" data-cmd="project-view" data-search="project-view project view detailed project view teamcity project view myapp">
+          <span class="dot">·</span><span>project view</span>
+        </a>
+        <a href="#project-tree" data-cmd="project-tree" data-search="project-tree project tree full hierarchy with jobs and pipelines teamcity project tree">
+          <span class="dot">·</span><span>project tree</span>
+        </a>
+        <a href="#project-settings" data-cmd="project-settings" data-search="project-settings project settings status versioned settings sync status teamcity project settings status myapp">
+          <span class="dot">·</span><span>project settings status</span>
+        </a>
+        <a href="#project-settings-validate" data-cmd="project-settings-validate" data-search="project-settings-validate project settings validate validate local dsl settings teamcity project settings validate .teamcity">
+          <span class="dot">·</span><span>project settings validate</span>
+        </a>
+        <a href="#project-settings-export" data-cmd="project-settings-export" data-search="project-settings-export project settings export export dsl settings as a zip archive teamcity project settings export myapp">
+          <span class="dot">·</span><span>project settings export</span>
+        </a>
+        <a href="#project-vcs-list" data-cmd="project-vcs-list" data-search="project-vcs-list project vcs list list vcs roots in a project teamcity project vcs list --project myapp">
+          <span class="dot">·</span><span>project vcs list</span>
+        </a>
+        <a href="#project-vcs-view" data-cmd="project-vcs-view" data-search="project-vcs-view project vcs view view vcs root details teamcity project vcs view myapp_mainrepo">
+          <span class="dot">·</span><span>project vcs view</span>
+        </a>
+        <a href="#project-vcs-create" data-cmd="project-vcs-create" data-search="project-vcs-create project vcs create create a new vcs root (interactive prompts) teamcity project vcs create --project myapp --name &#34;new repo&#34; --url https://github.com/org/new-repo">
+          <span class="dot">·</span><span>project vcs create</span>
+        </a>
+        <a href="#project-vcs-test" data-cmd="project-vcs-test" data-search="project-vcs-test project vcs test test vcs connection teamcity project vcs test myapp_mainrepo">
+          <span class="dot">·</span><span>project vcs test</span>
+        </a>
+        <a href="#project-vcs-delete" data-cmd="project-vcs-delete" data-search="project-vcs-delete project vcs delete delete a vcs root teamcity project vcs delete --yes myapp_repo">
+          <span class="dot">·</span><span>project vcs delete</span>
+        </a>
+        <a href="#project-ssh-list" data-cmd="project-ssh-list" data-search="project-ssh-list project ssh list list ssh keys in a project teamcity project ssh list --project myapp">
+          <span class="dot">·</span><span>project ssh list</span>
+        </a>
+        <a href="#project-ssh-generate" data-cmd="project-ssh-generate" data-search="project-ssh-generate project ssh generate generate a new ssh key teamcity project ssh generate --project myapp --name ci-key">
+          <span class="dot">·</span><span>project ssh generate</span>
+        </a>
+        <a href="#project-ssh-upload" data-cmd="project-ssh-upload" data-search="project-ssh-upload project ssh upload upload an ssh private key teamcity project ssh upload id_ed25519 --project myapp --name deploy-key">
+          <span class="dot">·</span><span>project ssh upload</span>
+        </a>
+        <a href="#project-ssh-delete" data-cmd="project-ssh-delete" data-search="project-ssh-delete project ssh delete delete an ssh key teamcity project ssh delete deploy-key --project myapp">
+          <span class="dot">·</span><span>project ssh delete</span>
+        </a>
+        <a href="#project-connection-list" data-cmd="project-connection-list" data-search="project-connection-list project connection list list project connections teamcity project connection list --project myapp">
+          <span class="dot">·</span><span>project connection list</span>
+        </a>
+        <a href="#project-cloud-profile" data-cmd="project-cloud-profile" data-search="project-cloud-profile project cloud profile list list cloud profiles teamcity project cloud profile list">
+          <span class="dot">·</span><span>project cloud profile list</span>
+        </a>
+        <a href="#project-cloud-profile-view" data-cmd="project-cloud-profile-view" data-search="project-cloud-profile-view project cloud profile view view cloud profile details teamcity project cloud profile view aws-prod">
+          <span class="dot">·</span><span>project cloud profile view</span>
+        </a>
+        <a href="#project-cloud-image" data-cmd="project-cloud-image" data-search="project-cloud-image project cloud image list list cloud images teamcity project cloud image list">
+          <span class="dot">·</span><span>project cloud image list</span>
+        </a>
+        <a href="#project-cloud-image-view" data-cmd="project-cloud-image-view" data-search="project-cloud-image-view project cloud image view view cloud image details teamcity project cloud image view img-1">
+          <span class="dot">·</span><span>project cloud image view</span>
+        </a>
+        <a href="#project-cloud-image-start" data-cmd="project-cloud-image-start" data-search="project-cloud-image-start project cloud image start start a cloud instance from an image teamcity project cloud image start img-1">
+          <span class="dot">·</span><span>project cloud image start</span>
+        </a>
+        <a href="#project-cloud-instance" data-cmd="project-cloud-instance" data-search="project-cloud-instance project cloud instance list list running cloud instances teamcity project cloud instance list">
+          <span class="dot">·</span><span>project cloud instance list</span>
+        </a>
+        <a href="#project-cloud-instance-view" data-cmd="project-cloud-instance-view" data-search="project-cloud-instance-view project cloud instance view view cloud instance details teamcity project cloud instance view i-024...">
+          <span class="dot">·</span><span>project cloud instance view</span>
+        </a>
+        <a href="#project-cloud-instance-stop" data-cmd="project-cloud-instance-stop" data-search="project-cloud-instance-stop project cloud instance stop stop a cloud instance teamcity project cloud instance stop i-024...">
+          <span class="dot">·</span><span>project cloud instance stop</span>
+        </a>
+        <a href="#project-param" data-cmd="project-param" data-search="project-param project param list list project parameters teamcity project param list myapp">
+          <span class="dot">·</span><span>project param list</span>
+        </a>
+        <a href="#project-param-get" data-cmd="project-param-get" data-search="project-param-get project param get get a project parameter value teamcity project param get myapp env.deploy_env">
+          <span class="dot">·</span><span>project param get</span>
+        </a>
+        <a href="#project-param-set" data-cmd="project-param-set" data-search="project-param-set project param set set a project parameter value teamcity project param set myapp env.deploy_env prod">
+          <span class="dot">·</span><span>project param set</span>
+        </a>
+        <a href="#project-param-delete" data-cmd="project-param-delete" data-search="project-param-delete project param delete delete a project parameter teamcity project param delete myapp env.deploy_env">
+          <span class="dot">·</span><span>project param delete</span>
+        </a>
+        <a href="#project-token-put" data-cmd="project-token-put" data-search="project-token-put project token put store a secret and get a secure token reference teamcity project token put myapp &#34;s3cret-db-password&#34;">
+          <span class="dot">·</span><span>project token put</span>
+        </a>
+        <a href="#project-token-get" data-cmd="project-token-get" data-search="project-token-get project token get retrieve the value of a secure token teamcity project token get myapp credentialsjson:abc123">
+          <span class="dot">·</span><span>project token get</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="pipelines">
+        <div class="grp-title"><span>Pipelines</span><span class="count">7</span></div>
+        <a href="#pipeline-list" data-cmd="pipeline-list" data-search="pipeline-list pipeline list list yaml pipelines teamcity pipeline list">
+          <span class="dot">·</span><span>pipeline list</span>
+        </a>
+        <a href="#pipeline-view" data-cmd="pipeline-view" data-search="pipeline-view pipeline view view pipeline details and jobs teamcity pipeline view myapp_ci">
+          <span class="dot">·</span><span>pipeline view</span>
+        </a>
+        <a href="#pipeline-create" data-cmd="pipeline-create" data-search="pipeline-create pipeline create create a new pipeline from yaml teamcity pipeline create onboarding --project myapp --vcs-root myapp_mainrepo --file .teamcity.yml">
+          <span class="dot">·</span><span>pipeline create</span>
+        </a>
+        <a href="#pipeline-validate" data-cmd="pipeline-validate" data-search="pipeline-validate pipeline validate validate pipeline yaml teamcity pipeline validate .teamcity.yml">
+          <span class="dot">·</span><span>pipeline validate</span>
+        </a>
+        <a href="#pipeline-delete" data-cmd="pipeline-delete" data-search="pipeline-delete pipeline delete delete a pipeline teamcity pipeline delete --yes myapp_ci">
+          <span class="dot">·</span><span>pipeline delete</span>
+        </a>
+        <a href="#pipeline-push" data-cmd="pipeline-push" data-search="pipeline-push pipeline push upload yaml to a pipeline teamcity pipeline push myapp_ci .teamcity.yml">
+          <span class="dot">·</span><span>pipeline push</span>
+        </a>
+        <a href="#pipeline-pull" data-cmd="pipeline-pull" data-search="pipeline-pull pipeline pull download pipeline yaml teamcity pipeline pull myapp_ci">
+          <span class="dot">·</span><span>pipeline pull</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="auth">
+        <div class="grp-title"><span>Auth</span><span class="count">4</span></div>
+        <a href="#auth-status" data-cmd="auth-status" data-search="auth-status auth status authentication status teamcity auth status">
+          <span class="dot">·</span><span>auth status</span>
+        </a>
+        <a href="#auth-status-multi" data-cmd="auth-status-multi" data-search="auth-status-multi auth status (multi-server) multi-server authentication status teamcity auth status">
+          <span class="dot">·</span><span>auth status (multi-server)</span>
+        </a>
+        <a href="#auth-login" data-cmd="auth-login" data-search="auth-login auth login interactive authentication flow (browser-based pkce) teamcity auth login">
+          <span class="dot">·</span><span>auth login</span>
+        </a>
+        <a href="#auth-logout" data-cmd="auth-logout" data-search="auth-logout auth logout log out from a server teamcity auth logout">
+          <span class="dot">·</span><span>auth logout</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="config">
+        <div class="grp-title"><span>Config</span><span class="count">3</span></div>
+        <a href="#config-list" data-cmd="config-list" data-search="config-list config list show full cli configuration teamcity config list">
+          <span class="dot">·</span><span>config list</span>
+        </a>
+        <a href="#config-get" data-cmd="config-get" data-search="config-get config get get a config value teamcity config get default_server">
+          <span class="dot">·</span><span>config get</span>
+        </a>
+        <a href="#config-set" data-cmd="config-set" data-search="config-set config set set a config value teamcity config set default_server https://tc.example.com">
+          <span class="dot">·</span><span>config set</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="aliases">
+        <div class="grp-title"><span>Aliases</span><span class="count">3</span></div>
+        <a href="#alias-list" data-cmd="alias-list" data-search="alias-list alias list list configured command aliases teamcity alias list">
+          <span class="dot">·</span><span>alias list</span>
+        </a>
+        <a href="#alias-set" data-cmd="alias-set" data-search="alias-set alias set create or update an alias teamcity alias set mybuilds &#34;run list&#34;">
+          <span class="dot">·</span><span>alias set</span>
+        </a>
+        <a href="#alias-delete" data-cmd="alias-delete" data-search="alias-delete alias delete remove an alias teamcity alias delete mybuilds">
+          <span class="dot">·</span><span>alias delete</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="skills">
+        <div class="grp-title"><span>Skills</span><span class="count">4</span></div>
+        <a href="#skill-list" data-cmd="skill-list" data-search="skill-list skill list list available ai agent skills teamcity skill list">
+          <span class="dot">·</span><span>skill list</span>
+        </a>
+        <a href="#skill-install" data-cmd="skill-install" data-search="skill-install skill install install a skill teamcity skill install teamcity-cli">
+          <span class="dot">·</span><span>skill install</span>
+        </a>
+        <a href="#skill-update" data-cmd="skill-update" data-search="skill-update skill update update installed skills teamcity skill update">
+          <span class="dot">·</span><span>skill update</span>
+        </a>
+        <a href="#skill-remove" data-cmd="skill-remove" data-search="skill-remove skill remove remove an installed skill teamcity skill remove teamcity-cli">
+          <span class="dot">·</span><span>skill remove</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="api">
+        <div class="grp-title"><span>API</span><span class="count">1</span></div>
+        <a href="#api-get" data-cmd="api-get" data-search="api-get api make raw rest api requests teamcity api /app/rest/server">
+          <span class="dot">·</span><span>api</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="update">
+        <div class="grp-title"><span>Update</span><span class="count">1</span></div>
+        <a href="#update" data-cmd="update" data-search="update update check for cli updates teamcity update">
+          <span class="dot">·</span><span>update</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="errors">
+        <div class="grp-title"><span>Errors</span><span class="count">6</span></div>
+        <a href="#error-not-found" data-cmd="error-not-found" data-search="error-not-found not found resource not found with contextual hint ">
+          <span class="dot">·</span><span>Not Found</span>
+        </a>
+        <a href="#error-auth" data-cmd="error-auth" data-search="error-auth authentication failed invalid or expired token ">
+          <span class="dot">·</span><span>Authentication Failed</span>
+        </a>
+        <a href="#error-permission" data-cmd="error-permission" data-search="error-permission permission denied insufficient permissions ">
+          <span class="dot">·</span><span>Permission Denied</span>
+        </a>
+        <a href="#error-network" data-cmd="error-network" data-search="error-network network error cannot reach the server ">
+          <span class="dot">·</span><span>Network Error</span>
+        </a>
+        <a href="#error-readonly" data-cmd="error-readonly" data-search="error-readonly read-only mode write operation blocked by teamcity_ro ">
+          <span class="dot">·</span><span>Read-Only Mode</span>
+        </a>
+        <a href="#error-json" data-cmd="error-json" data-search="error-json json error format structured error with --json flag ">
+          <span class="dot">·</span><span>JSON Error Format</span>
+        </a>
+        
+      </li>
+      <li class="grp" data-grp="help">
+        <div class="grp-title"><span>Help Screens</span><span class="count">23</span></div>
+        <a href="#help-root" data-cmd="help-root" data-search="help-root teamcity root command — shows logo and common commands teamcity  --help">
+          <span class="dot">·</span><span>teamcity</span>
+        </a>
+        <a href="#help-run" data-cmd="help-run" data-search="help-run run run (build) management commands teamcity run --help">
+          <span class="dot">·</span><span>run</span>
+        </a>
+        <a href="#help-job" data-cmd="help-job" data-search="help-job job job (build configuration) commands teamcity job --help">
+          <span class="dot">·</span><span>job</span>
+        </a>
+        <a href="#help-agent" data-cmd="help-agent" data-search="help-agent agent build agent commands teamcity agent --help">
+          <span class="dot">·</span><span>agent</span>
+        </a>
+        <a href="#help-queue" data-cmd="help-queue" data-search="help-queue queue build queue commands teamcity queue --help">
+          <span class="dot">·</span><span>queue</span>
+        </a>
+        <a href="#help-pool" data-cmd="help-pool" data-search="help-pool pool agent pool commands teamcity pool --help">
+          <span class="dot">·</span><span>pool</span>
+        </a>
+        <a href="#help-project" data-cmd="help-project" data-search="help-project project project management commands teamcity project --help">
+          <span class="dot">·</span><span>project</span>
+        </a>
+        <a href="#help-pipeline" data-cmd="help-pipeline" data-search="help-pipeline pipeline yaml pipeline commands teamcity pipeline --help">
+          <span class="dot">·</span><span>pipeline</span>
+        </a>
+        <a href="#help-auth" data-cmd="help-auth" data-search="help-auth auth authentication commands teamcity auth --help">
+          <span class="dot">·</span><span>auth</span>
+        </a>
+        <a href="#help-config" data-cmd="help-config" data-search="help-config config configuration commands teamcity config --help">
+          <span class="dot">·</span><span>config</span>
+        </a>
+        <a href="#help-alias" data-cmd="help-alias" data-search="help-alias alias command alias management teamcity alias --help">
+          <span class="dot">·</span><span>alias</span>
+        </a>
+        <a href="#help-skill" data-cmd="help-skill" data-search="help-skill skill ai agent skill management teamcity skill --help">
+          <span class="dot">·</span><span>skill</span>
+        </a>
+        <a href="#help-project-settings" data-cmd="help-project-settings" data-search="help-project-settings project settings versioned settings subcommands teamcity project settings --help">
+          <span class="dot">·</span><span>project settings</span>
+        </a>
+        <a href="#help-project-vcs" data-cmd="help-project-vcs" data-search="help-project-vcs project vcs vcs root subcommands teamcity project vcs --help">
+          <span class="dot">·</span><span>project vcs</span>
+        </a>
+        <a href="#help-project-ssh" data-cmd="help-project-ssh" data-search="help-project-ssh project ssh ssh key subcommands teamcity project ssh --help">
+          <span class="dot">·</span><span>project ssh</span>
+        </a>
+        <a href="#help-project-connection" data-cmd="help-project-connection" data-search="help-project-connection project connection project connection subcommands teamcity project connection --help">
+          <span class="dot">·</span><span>project connection</span>
+        </a>
+        <a href="#help-project-cloud" data-cmd="help-project-cloud" data-search="help-project-cloud project cloud cloud management subcommands teamcity project cloud --help">
+          <span class="dot">·</span><span>project cloud</span>
+        </a>
+        <a href="#help-project-cloud-profile" data-cmd="help-project-cloud-profile" data-search="help-project-cloud-profile project cloud profile cloud profile subcommands teamcity project cloud profile --help">
+          <span class="dot">·</span><span>project cloud profile</span>
+        </a>
+        <a href="#help-project-cloud-image" data-cmd="help-project-cloud-image" data-search="help-project-cloud-image project cloud image cloud image subcommands teamcity project cloud image --help">
+          <span class="dot">·</span><span>project cloud image</span>
+        </a>
+        <a href="#help-project-cloud-instance" data-cmd="help-project-cloud-instance" data-search="help-project-cloud-instance project cloud instance cloud instance subcommands teamcity project cloud instance --help">
+          <span class="dot">·</span><span>project cloud instance</span>
+        </a>
+        <a href="#help-project-token" data-cmd="help-project-token" data-search="help-project-token project token secure token subcommands teamcity project token --help">
+          <span class="dot">·</span><span>project token</span>
+        </a>
+        <a href="#help-project-param" data-cmd="help-project-param" data-search="help-project-param project param project parameter subcommands teamcity project param --help">
+          <span class="dot">·</span><span>project param</span>
+        </a>
+        <a href="#help-job-param" data-cmd="help-job-param" data-search="help-job-param job param job parameter subcommands teamcity job param --help">
+          <span class="dot">·</span><span>job param</span>
+        </a>
+        
+      </li>
+      
+    </ul>
+
+    <div class="side-foot">
+      <a href="https://github.com/jetbrains/teamcity-cli/" target="_blank" rel="noopener">↗ github</a><br>
+      134 screens · 16 groups<br>
+      generated 2026-04-18 17:43
+    </div>
+  </aside>
+
+  <main class="main">
+    <header class="topbar">
+      <div class="crumbs">
+        <span>jetbrains</span><span class="sep">/</span><span>teamcity-cli</span><span class="sep">/</span><span class="here">gallery</span>
+      </div>
+      <div class="theme-toggle" role="tablist" aria-label="Theme">
+        <button id="tDark" class="active" aria-pressed="true">dark</button>
+        <button id="tLight" aria-pressed="false">light</button>
+      </div>
+    </header>
+
+    <section class="mast">
+      <div>
+        
+        <h1><span class="slash">/</span> teamcity cli screen gallery</h1>
+        
+      </div>
+      <div class="fact">
+        <b>134</b> screens<br><b>16</b> command groups<br>
+      </div>
+    </section>
+
+    <div class="notes-panel">
+      <h3>Reading this gallery</h3>
+      
+			<p>Every block is real CLI output, captured on each release — not screenshots or mockups. Skim top-to-bottom, jump by section from the sidebar, or filter by name.</p>
+			<p class="mono-hint">press <span class="kbd">/</span> to filter ·
+			<span class="kbd">T</span> to toggle theme ·
+			<span class="kbd">Esc</span> to clear</p>
+		
+    </div>
+
+    <div>
+      <section class="section" id="section-style-guide" data-grp="style-guide">
+        <div class="section-head">
+          <div class="section-num">§ 01</div>
+          <div class="section-name">Style Guide</div>
+          <div class="section-blurb">The atoms the CLI uses to communicate. Treat these as non-negotiable until we decide to rework them together.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="colors" data-cmd="colors" data-search="colors colors &amp; text styles standard color palette ">
+            <div class="entry-meta">
+              <div class="id">colors</div>
+              <h4>Colors &amp; Text Styles</h4>
+              <p>Standard color palette</p>
+              <div class="tags"><span>style-guide</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Colors &amp; Text Styles</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt"><span class="term-fg32">Green</span> — success, links, positive
 <span class="term-fg31">Red</span> — errors, failures, negative
 <span class="term-fg33">Yellow</span> — warnings, running, caution
 <span class="term-fg36">Cyan</span> — titles, names, emphasis
 <span class="term-fg1">Bold</span> — headers, key labels
-<span class="term-fg2">Faint</span> — secondary info, IDs, hints</pre></div></div>
-    </div>
-    <div class="screen" id="status-icons">
-      <div class="screen-header"><h3>Status Icons</h3><p>Status indicators in tables and views</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>  <span class="term-fg32">✓</span>  <span class="term-fg32">Success</span> <span class="term-fg2">build completed successfully</span>
+<span class="term-fg2">Faint</span> — secondary info, IDs, hints</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="status-icons" data-cmd="status-icons" data-search="status-icons status icons status indicators in tables and views ">
+            <div class="entry-meta">
+              <div class="id">status-icons</div>
+              <h4>Status Icons</h4>
+              <p>Status indicators in tables and views</p>
+              <div class="tags"><span>style-guide</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Status Icons</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">  <span class="term-fg32">✓</span>  <span class="term-fg32">Success</span> <span class="term-fg2">build completed successfully</span>
   <span class="term-fg31">✗</span>  <span class="term-fg31">Failed</span> <span class="term-fg2">build finished with failures</span>
   <span class="term-fg33">●</span>  <span class="term-fg33">Running</span> <span class="term-fg2">build is currently executing</span>
   <span class="term-fg2">◦</span>  <span class="term-fg2">Queued</span> <span class="term-fg2">build is waiting in queue</span>
+  <span class="term-fg2">⊘</span>  <span class="term-fg2">Canceled</span> <span class="term-fg2">build was canceled by a user</span>
   <span class="term-fg31">✗</span>  <span class="term-fg31">Error</span> <span class="term-fg2">internal or infrastructure error</span>
-  <span class="term-fg33">?</span>  <span class="term-fg33">Unknown</span> <span class="term-fg2">unknown status</span></pre></div></div>
-    </div>
-    <div class="screen" id="messages">
-      <div class="screen-header"><h3>Messages</h3><p>Info, success, warning, error patterns</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Logged in as Viktor Tiulpin
+  <span class="term-fg33">?</span>  <span class="term-fg33">Unknown</span> <span class="term-fg2">unknown status</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="messages" data-cmd="messages" data-search="messages messages info, success, warning, error patterns ">
+            <div class="entry-meta">
+              <div class="id">messages</div>
+              <h4>Messages</h4>
+              <p>Info, success, warning, error patterns</p>
+              <div class="tags"><span>style-guide</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Messages</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt"><span class="term-fg32">✓</span> Logged in as Viktor Tiulpin
 3 runs matched your filters
 <span class="term-fg33">!</span> Token expires in 2 days
-Error: build configuration &quot;NonExistent_Build&quot; not found
+Error: job &#39;NonExistent_Build&#39; not found
 &nbsp;
-Hint: Use &#39;teamcity job list&#39; to see available jobs</pre></div></div>
-    </div>
-    <div class="screen" id="table">
-      <div class="screen-header"><h3>Table Rendering</h3><p>Auto-sized columns with colored cells</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID  NAME            STATUS        POOL
+Hint: Use &#39;teamcity job list&#39; to see available jobs</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="table" data-cmd="table" data-search="table table rendering auto-sized columns with colored cells ">
+            <div class="entry-meta">
+              <div class="id">table</div>
+              <h4>Table Rendering</h4>
+              <p>Auto-sized columns with colored cells</p>
+              <div class="tags"><span>style-guide</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Table Rendering</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">ID  NAME            STATUS        POOL
 1   linux-agent-01  <span class="term-fg32">Connected</span>     Default
 2   linux-agent-02  <span class="term-fg32">Connected</span>     Default
 3   mac-agent-01    <span class="term-fg31">Disconnected</span>  macOS
-4   cloud-agent-01  <span class="term-fg33">Disabled</span>      Cloud</pre></div></div>
-    </div>
-    <div class="screen" id="tree">
-      <div class="screen-header"><h3>Tree Rendering</h3><p>Hierarchical display with connectors</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">My Application</span> <span class="term-fg2">MyApp</span>
+4   cloud-agent-01  <span class="term-fg33">Disabled</span>      Cloud</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="tree" data-cmd="tree" data-search="tree tree rendering hierarchical display with connectors ">
+            <div class="entry-meta">
+              <div class="id">tree</div>
+              <h4>Tree Rendering</h4>
+              <p>Hierarchical display with connectors</p>
+              <div class="tags"><span>style-guide</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Tree Rendering</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt"><span class="term-fg36">My Application</span> <span class="term-fg2">MyApp</span>
 ├── <span class="term-fg36">Build</span> <span class="term-fg2">MyApp_Build</span>
 ├── <span class="term-fg36">Run Tests</span> <span class="term-fg2">MyApp_Test</span>
 └── <span class="term-fg36">Deploy</span> <span class="term-fg2">MyApp_Deploy</span>
-    └── <span class="term-fg36">Smoke Tests</span> <span class="term-fg2">MyApp_Smoke</span></pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="runs">
-    <h2>Runs</h2>
-    <div class="screens">
-    <div class="screen" id="run-list">
-      <div class="screen-header"><h3>run list</h3><p>List recent runs with status, job, branch, and timing</p></div>
-      <div class="screen-cmd">teamcity run list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>STATUS     RUN          JOB            BRANCH           TRIGGERED BY    DURATION  AGE
+    └── <span class="term-fg36">Smoke Tests</span> <span class="term-fg2">MyApp_Smoke</span></pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-runs" data-grp="runs">
+        <div class="section-head">
+          <div class="section-num">§ 02</div>
+          <div class="section-name">Runs</div>
+          <div class="section-blurb">List, start, watch, diff, and manage builds.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="run-list" data-cmd="run-list" data-search="run-list run list list recent runs with status, job, branch, and timing teamcity run list">
+            <div class="entry-meta">
+              <div class="id">run-list</div>
+              <h4>run list</h4>
+              <p>List recent runs with status, job, branch, and timing</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run list</span></div>
+                <pre class="term-body">STATUS     RUN          JOB            BRANCH           TRIGGERED BY    DURATION  AGE
 <span class="term-fg32">✓</span> <span class="term-fg32">Success</span>  45231  #831  MyApp_Build    main             Viktor Tiulpin  2m 13s    2h ago
 <span class="term-fg31">✗</span> <span class="term-fg31">Failed</span>   45230  #442  MyApp_Test     feature&#47;auth     CI Bot          5m 1s     3h ago
 <span class="term-fg33">●</span> <span class="term-fg33">Running</span>  45229  #830  MyApp_Deploy   main             Viktor Tiulpin  1m 22s    now
 <span class="term-fg32">✓</span> <span class="term-fg32">Success</span>  45228  #829  MyApp_Build    fix&#47;memory-leak  Anna Kowalski   45s       5h ago
 <span class="term-fg31">✗</span> <span class="term-fg31">Failed</span>   45227  #126  MyApp_IntTest  main             schedule        12m 45s   8h ago
 <span class="term-fg2">◦</span> <span class="term-fg2">Queued</span>   45226  #     MyApp_Build    feature&#47;onboard  GitHub Hook     -         1d ago
-<span class="term-fg32">✓</span> <span class="term-fg32">Success</span>  45225  #118  MyApp_Lint     main             CI Bot          12s       1d ago</pre></div></div>
-    </div>
-    <div class="screen" id="run-view">
-      <div class="screen-header"><h3>run view</h3><p>Detail view of a finished run</p></div>
-      <div class="screen-cmd">teamcity run view 45231</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> <span class="term-fg36">Build</span> 45231  #831 · main
+<span class="term-fg32">✓</span> <span class="term-fg32">Success</span>  45225  #118  MyApp_Lint     main             CI Bot          12s       1d ago</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-view" data-cmd="run-view" data-search="run-view run view detail view of a finished run teamcity run view 45231">
+            <div class="entry-meta">
+              <div class="id">run-view</div>
+              <h4>run view</h4>
+              <p>Detail view of a finished run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run view 45231</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run view 45231</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> <span class="term-fg36">Build</span> 45231  #831 · main
 Triggered by Viktor Tiulpin · 2h ago · Took 2m 13s
 &nbsp;
 Agent: <span class="term-fg2">linux-agent-01</span>
 &nbsp;
 Tags: release, v1.0.0
 &nbsp;
-<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45231</span></pre></div></div>
-    </div>
-    <div class="screen" id="run-start">
-      <div class="screen-header"><h3>run start</h3><p>Trigger a new run</p></div>
-      <div class="screen-cmd">teamcity run start MyApp_Build --no-input</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Queued run 100  #100 for MyApp_Build
+<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45231</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-start" data-cmd="run-start" data-search="run-start run start trigger a new run teamcity run start myapp_build --no-input">
+            <div class="entry-meta">
+              <div class="id">run-start</div>
+              <h4>run start</h4>
+              <p>Trigger a new run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run start MyApp_Build --no-input</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run start MyApp_Build --no-input</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Queued run 100  #100 for MyApp_Build
   URL: https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=100
-  <span class="term-fg2">Follow logs:</span> teamcity run log -f 100</pre></div></div>
-    </div>
-    <div class="screen" id="run-restart">
-      <div class="screen-header"><h3>run restart</h3><p>Re-trigger a completed run</p></div>
-      <div class="screen-cmd">teamcity run restart 1 --no-input</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Queued run 100  #100 for MyApp_Build (restart of 45231)
+  <span class="term-fg2">Follow logs:</span> teamcity run log -f 100</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-restart" data-cmd="run-restart" data-search="run-restart run restart re-trigger a completed run teamcity run restart 1 --no-input">
+            <div class="entry-meta">
+              <div class="id">run-restart</div>
+              <h4>run restart</h4>
+              <p>Re-trigger a completed run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run restart 1 --no-input</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run restart 1 --no-input</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Queued run 100  #100 for MyApp_Build (restart of 45231)
   Job: MyApp_Build
   Branch: main
-  URL: https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=100</pre></div></div>
-    </div>
-    <div class="screen" id="run-watch">
-      <div class="screen-header"><h3>run watch --logs</h3><p>Full-screen TUI with live log streaming (alt-screen)</p></div>
-      <div class="screen-cmd">teamcity run watch --logs 45229</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg33">●</span> Deploy Staging  45229  #830  <span class="term-fg33">Running</span> · Running (67%)
+  URL: https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=100</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-watch" data-cmd="run-watch" data-search="run-watch run watch --logs full-screen tui with live log streaming (alt-screen) teamcity run watch --logs 45229">
+            <div class="entry-meta">
+              <div class="id">run-watch</div>
+              <h4>run watch --logs</h4>
+              <p>Full-screen TUI with live log streaming (alt-screen)</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run watch --logs 45229</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run watch --logs 45229</span></div>
+                <pre class="term-body"><span class="term-fg33">●</span> <span class="term-fg1">Deploy Staging</span> 45229  #830 <span class="term-fg2">https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45229</span> · Running (67%)
 &nbsp;
 <span class="term-fg2">[12:01:10] Downloading artifacts from Build #831</span>
 <span class="term-fg2">[12:01:12] Extracting app.jar (12.4 MB)</span>
@@ -500,12 +1347,26 @@ Tags: release, v1.0.0
 [12:01:42] Draining old instances...
 <span class="term-fg32">[12:01:45] Deploy complete. 2&#47;2 instances healthy</span>
 &nbsp;
-<span class="term-fg2">q</span> quit  ·  <span class="term-fg36">teamcity agent term 1</span>  ·  ~</pre></div></div>
-    </div>
-    <div class="screen" id="run-log">
-      <div class="screen-header"><h3>run log --tail</h3><p>Formatted build log with timestamps</p></div>
-      <div class="screen-cmd">teamcity run log 1 --tail 10</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Build started
+<span class="term-fg2">q quit</span>  <span class="term-fg2">·</span>  <span class="term-fg36">teamcity agent term 1</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-log" data-cmd="run-log" data-search="run-log run log --tail formatted build log with timestamps teamcity run log 1 --tail 10">
+            <div class="entry-meta">
+              <div class="id">run-log</div>
+              <h4>run log --tail</h4>
+              <p>Formatted build log with timestamps</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run log 1 --tail 10</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run log 1 --tail 10</span></div>
+                <pre class="term-body">Build started
 Step 1&#47;3: Compile (go build)
   Starting: go build -o bin&#47;app .&#47;cmd&#47;app
   Process exited with code 0
@@ -515,12 +1376,26 @@ Step 2&#47;3: Test (go test)
   ok  myapp&#47;internal&#47;pool  0.089s
   ok  myapp&#47;internal&#47;handler  0.523s
 Step 3&#47;3: Package
-Build finished</pre></div></div>
-    </div>
-    <div class="screen" id="run-diff">
-      <div class="screen-header"><h3>run diff</h3><p>Compare two runs side by side</p></div>
-      <div class="screen-cmd">teamcity run diff 45231 45230</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg33">!</span> &quot;teamcity run diff&quot; is experimental: flags, output, and JSON schema may change or the command may be removed without notice. It is intentionally undocumented — do not rely on it in scripts.
+Build finished</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-diff" data-cmd="run-diff" data-search="run-diff run diff compare two runs side by side teamcity run diff 45231 45230">
+            <div class="entry-meta">
+              <div class="id">run-diff</div>
+              <h4>run diff</h4>
+              <p>Compare two runs side by side</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run diff 45231 45230</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run diff 45231 45230</span></div>
+                <pre class="term-body"><span class="term-fg33">!</span> &quot;teamcity run diff&quot; is experimental: flags, output, and JSON schema may change or the command may be removed without notice. It is intentionally undocumented — do not rely on it in scripts.
 COMPARING  <span class="term-fg32">✓</span> 45231  #831  →  <span class="term-fg31">✗</span> 45230  #442
 <span class="term-fg2">Job: </span><span class="term-fg36">Build</span><span class="term-fg2">  ·  Branch: </span>main → feature&#47;auth
 &nbsp;
@@ -560,12 +1435,26 @@ COMPARING  <span class="term-fg32">✓</span> 45231  #831  →  <span class="ter
 &nbsp;
 <span class="term-fg2">Changed:</span> status, problems, tests, changes, parameters, agent, duration
 <span class="term-fg2">View -</span> https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45231
-<span class="term-fg2">View +</span> https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45230</pre></div></div>
-    </div>
-    <div class="screen" id="run-artifacts">
-      <div class="screen-header"><h3>run artifacts</h3><p>List downloadable build artifacts</p></div>
-      <div class="screen-cmd">teamcity run artifacts 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ARTIFACTS (6 files, 13 MiB total)
+<span class="term-fg2">View +</span> https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45230</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-artifacts" data-cmd="run-artifacts" data-search="run-artifacts run artifacts list downloadable build artifacts teamcity run artifacts 1">
+            <div class="entry-meta">
+              <div class="id">run-artifacts</div>
+              <h4>run artifacts</h4>
+              <p>List downloadable build artifacts</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run artifacts 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run artifacts 1</span></div>
+                <pre class="term-body">ARTIFACTS (6 files, 13 MiB total)
 &nbsp;
 NAME                    SIZE
 app.jar           <span class="term-fg2">    12 MiB</span>
@@ -576,21 +1465,52 @@ logs&#47;build.log    <span class="term-fg2">    45 KiB</span>
 logs&#47;test.log     <span class="term-fg2">    12 KiB</span>
 &nbsp;
 Download all: teamcity run download 1
-Download one: teamcity run download 1 -a &quot;&lt;name&gt;&quot;</pre></div></div>
-    </div>
-    <div class="screen" id="run-download">
-      <div class="screen-header"><h3>run download</h3><p>Download artifacts to local filesystem</p></div>
-      <div class="screen-cmd">teamcity run download 45231</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Downloaded app.jar (12.4 MB)
-<span class="term-fg32">✓</span> Downloaded test-report.html (234 KB)
-<span class="term-fg32">✓</span> Downloaded logs&#47;build.log (45 KB)
+Download one: teamcity run download 1 -a &quot;&lt;name&gt;&quot;</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-download" data-cmd="run-download" data-search="run-download run download download artifacts to local filesystem teamcity run download 45231">
+            <div class="entry-meta">
+              <div class="id">run-download</div>
+              <h4>run download</h4>
+              <p>Download artifacts to local filesystem</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run download 45231</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run download 45231</span></div>
+                <pre class="term-body">Downloading 3 artifacts (12.6 MiB total) to .&#47;artifacts&#47;
 &nbsp;
-3 files, 12.6 MB total → .&#47;artifacts&#47;</pre></div></div>
-    </div>
-    <div class="screen" id="run-changes">
-      <div class="screen-header"><h3>run changes</h3><p>VCS changes included in a run</p></div>
-      <div class="screen-cmd">teamcity run changes 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>CHANGES (3 commits)
+NAME                      SIZE
+app.jar                 12 MiB  <span class="term-fg32">   ✓</span>
+test-report.html       234 KiB  <span class="term-fg32">   ✓</span>
+logs&#47;build.log          45 KiB  <span class="term-fg32">   ✓</span>
+&nbsp;
+<span class="term-fg32">✓</span> 3 artifacts downloaded</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-changes" data-cmd="run-changes" data-search="run-changes run changes vcs changes included in a run teamcity run changes 1">
+            <div class="entry-meta">
+              <div class="id">run-changes</div>
+              <h4>run changes</h4>
+              <p>VCS changes included in a run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run changes 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run changes 1</span></div>
+                <pre class="term-body">CHANGES (3 commits)
 &nbsp;
 <span class="term-fg33">abc1234</span>  <span class="term-fg2">vtiulpin</span>  <span class="term-fg2">2h ago</span>
   Fix memory leak in connection pool
@@ -606,12 +1526,26 @@ Download one: teamcity run download 1 -a &quot;&lt;name&gt;&quot;</pre></div></d
   Update CI pipeline configuration
   <span class="term-fg33">M</span>  <span class="term-fg2">.teamcity.yml</span>
 &nbsp;
-<span class="term-fg2"># For full diff:</span> git diff 789abcd^..abc1234</pre></div></div>
-    </div>
-    <div class="screen" id="run-tests">
-      <div class="screen-header"><h3>run tests</h3><p>Test results summary</p></div>
-      <div class="screen-cmd">teamcity run tests 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg2">View in browser:</span> https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45231?buildTab=tests
+<span class="term-fg2"># For full diff:</span> git diff 789abcd^..abc1234</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-tests" data-cmd="run-tests" data-search="run-tests run tests test results summary teamcity run tests 1">
+            <div class="entry-meta">
+              <div class="id">run-tests</div>
+              <h4>run tests</h4>
+              <p>Test results summary</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run tests 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run tests 1</span></div>
+                <pre class="term-body"><span class="term-fg2">View in browser:</span> https:&#47;&#47;tc.example.com&#47;viewLog.html?buildId=45231?buildTab=tests
 &nbsp;
 TESTS: <span class="term-fg32">145 passed</span>
 &nbsp;
@@ -619,148 +1553,425 @@ TESTS: <span class="term-fg32">145 passed</span>
 <span class="term-fg32">✓</span> TestConnectionPool&#47;acquire
 <span class="term-fg32">✓</span> TestConnectionPool&#47;release
 <span class="term-fg32">✓</span> TestShutdown&#47;graceful
-<span class="term-fg32">✓</span> TestMigration&#47;forward</pre></div></div>
-    </div>
-    <div class="screen" id="run-tree">
-      <div class="screen-header"><h3>run tree</h3><p>Snapshot dependency tree of a run</p></div>
-      <div class="screen-cmd">teamcity run tree 45229</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg33">●</span> <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">45229</span>
+<span class="term-fg32">✓</span> TestMigration&#47;forward</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-tree" data-cmd="run-tree" data-search="run-tree run tree snapshot dependency tree of a run teamcity run tree 45229">
+            <div class="entry-meta">
+              <div class="id">run-tree</div>
+              <h4>run tree</h4>
+              <p>Snapshot dependency tree of a run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run tree 45229</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run tree 45229</span></div>
+                <pre class="term-body"><span class="term-fg33">●</span> <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">45229</span>
 ├── <span class="term-fg32">✓</span> <span class="term-fg36">Build</span> <span class="term-fg2">45231</span>
 │   ├── <span class="term-fg32">✓</span> <span class="term-fg36">Lint</span> <span class="term-fg2">45225</span>
 │   └── <span class="term-fg32">✓</span> <span class="term-fg36">Compile</span> <span class="term-fg2">45240</span>
 └── <span class="term-fg31">✗</span> <span class="term-fg36">Run Tests</span> <span class="term-fg2">45230</span>
     └── <span class="term-fg32">✓</span> <span class="term-fg36">Build</span> <span class="term-fg2">45231</span>
         ├── <span class="term-fg32">✓</span> <span class="term-fg36">Lint</span> <span class="term-fg2">45225</span>
-        └── <span class="term-fg32">✓</span> <span class="term-fg36">Compile</span> <span class="term-fg2">45240</span></pre></div></div>
-    </div>
-    <div class="screen" id="run-cancel">
-      <div class="screen-header"><h3>run cancel</h3><p>Cancel a running or queued build</p></div>
-      <div class="screen-cmd">teamcity run cancel --yes 45233</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Canceled #45233</pre></div></div>
-    </div>
-    <div class="screen" id="run-pin">
-      <div class="screen-header"><h3>run pin</h3><p>Pin a build to prevent cleanup</p></div>
-      <div class="screen-cmd">teamcity run pin 1 -m &#34;Release candidate&#34;</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Pinned #1
-  Comment: Release candidate</pre></div></div>
-    </div>
-    <div class="screen" id="run-unpin">
-      <div class="screen-header"><h3>run unpin</h3><p>Unpin a build</p></div>
-      <div class="screen-cmd">teamcity run unpin 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Unpinned #1</pre></div></div>
-    </div>
-    <div class="screen" id="run-tag">
-      <div class="screen-header"><h3>run tag</h3><p>Add tags to a run</p></div>
-      <div class="screen-cmd">teamcity run tag 1 release v1.0.0</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Added 2 tag(s) to #1
-  Tags: release, v1.0.0</pre></div></div>
-    </div>
-    <div class="screen" id="run-comment">
-      <div class="screen-header"><h3>run comment</h3><p>View a build comment</p></div>
-      <div class="screen-cmd">teamcity run comment 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>No comment set on #1</pre></div></div>
-    </div>
-    <div class="screen" id="run-comment-set">
-      <div class="screen-header"><h3>run comment (set)</h3><p>Set a comment on a run</p></div>
-      <div class="screen-cmd">teamcity run comment 1 &#34;Ready for prod&#34;</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Set comment on #1
-  Comment: Ready for prod</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="jobs">
-    <h2>Jobs</h2>
-    <div class="screens">
-    <div class="screen" id="job-list">
-      <div class="screen-header"><h3>job list</h3><p>List build configurations</p></div>
-      <div class="screen-cmd">teamcity job list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID             NAME               PROJECT         STATUS
+        └── <span class="term-fg32">✓</span> <span class="term-fg36">Compile</span> <span class="term-fg2">45240</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-cancel" data-cmd="run-cancel" data-search="run-cancel run cancel cancel a running or queued build teamcity run cancel --yes 45233">
+            <div class="entry-meta">
+              <div class="id">run-cancel</div>
+              <h4>run cancel</h4>
+              <p>Cancel a running or queued build</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run cancel --yes 45233</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run cancel --yes 45233</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Canceled #45233</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-pin" data-cmd="run-pin" data-search="run-pin run pin pin a build to prevent cleanup teamcity run pin 1 -m &#34;release candidate&#34;">
+            <div class="entry-meta">
+              <div class="id">run-pin</div>
+              <h4>run pin</h4>
+              <p>Pin a build to prevent cleanup</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run pin 1 -m &#34;Release candidate&#34;</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run pin 1 -m &#34;Release candidate&#34;</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Pinned #1
+  Comment: Release candidate</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-unpin" data-cmd="run-unpin" data-search="run-unpin run unpin unpin a build teamcity run unpin 1">
+            <div class="entry-meta">
+              <div class="id">run-unpin</div>
+              <h4>run unpin</h4>
+              <p>Unpin a build</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run unpin 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run unpin 1</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Unpinned #1</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-tag" data-cmd="run-tag" data-search="run-tag run tag add tags to a run teamcity run tag 1 release v1.0.0">
+            <div class="entry-meta">
+              <div class="id">run-tag</div>
+              <h4>run tag</h4>
+              <p>Add tags to a run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run tag 1 release v1.0.0</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run tag 1 release v1.0.0</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Added 2 tag(s) to #1
+  Tags: release, v1.0.0</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-untag" data-cmd="run-untag" data-search="run-untag run untag remove tags from a run teamcity run untag 1 release">
+            <div class="entry-meta">
+              <div class="id">run-untag</div>
+              <h4>run untag</h4>
+              <p>Remove tags from a run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run untag 1 release</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run untag 1 release</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Removed 1 tag(s) from #1</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-comment" data-cmd="run-comment" data-search="run-comment run comment view a build comment teamcity run comment 1">
+            <div class="entry-meta">
+              <div class="id">run-comment</div>
+              <h4>run comment</h4>
+              <p>View a build comment</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run comment 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run comment 1</span></div>
+                <pre class="term-body">No comment set on #1</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="run-comment-set" data-cmd="run-comment-set" data-search="run-comment-set run comment (set) set a comment on a run teamcity run comment 1 &#34;ready for prod&#34;">
+            <div class="entry-meta">
+              <div class="id">run-comment-set</div>
+              <h4>run comment (set)</h4>
+              <p>Set a comment on a run</p>
+              <div class="tags"><span>runs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run comment 1 &#34;Ready for prod&#34;</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run comment 1 &#34;Ready for prod&#34;</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Set comment on #1
+  Comment: Ready for prod</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-jobs" data-grp="jobs">
+        <div class="section-head">
+          <div class="section-num">§ 03</div>
+          <div class="section-name">Jobs</div>
+          <div class="section-blurb">Build configurations: list, view, pause, parameters.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="job-list" data-cmd="job-list" data-search="job-list job list list build configurations teamcity job list">
+            <div class="entry-meta">
+              <div class="id">job-list</div>
+              <h4>job list</h4>
+              <p>List build configurations</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job list</span></div>
+                <pre class="term-body">ID             NAME               PROJECT         STATUS
 MyApp_Build    Build              My Application  <span class="term-fg32">Active</span>
 MyApp_Test     Run Tests          My Application  <span class="term-fg32">Active</span>
 MyApp_Deploy   Deploy Staging     My Application  <span class="term-fg2">Paused</span>
 MyApp_IntTest  Integration Tests  My Application  <span class="term-fg32">Active</span>
-MyApp_Lint     Lint               My Application  <span class="term-fg32">Active</span></pre></div></div>
-    </div>
-    <div class="screen" id="job-view">
-      <div class="screen-header"><h3>job view</h3><p>Detail view of a build configuration</p></div>
-      <div class="screen-cmd">teamcity job view MyApp_Build</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">Build</span>
+MyApp_Lint     Lint               My Application  <span class="term-fg32">Active</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-view" data-cmd="job-view" data-search="job-view job view detail view of a build configuration teamcity job view myapp_build">
+            <div class="entry-meta">
+              <div class="id">job-view</div>
+              <h4>job view</h4>
+              <p>Detail view of a build configuration</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job view MyApp_Build</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job view MyApp_Build</span></div>
+                <pre class="term-body"><span class="term-fg36">Build</span>
 ID: MyApp_Build
 Project: My Application (MyApp)
 Status: <span class="term-fg32">Active</span>
 &nbsp;
-<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;viewType.html?buildTypeId=MyApp_Build</span></pre></div></div>
-    </div>
-    <div class="screen" id="job-tree">
-      <div class="screen-header"><h3>job tree</h3><p>Snapshot dependency tree of a job</p></div>
-      <div class="screen-cmd">teamcity job tree MyApp_Build</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">Build</span>
+<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;viewType.html?buildTypeId=MyApp_Build</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-tree" data-cmd="job-tree" data-search="job-tree job tree snapshot dependency tree of a job teamcity job tree myapp_build">
+            <div class="entry-meta">
+              <div class="id">job-tree</div>
+              <h4>job tree</h4>
+              <p>Snapshot dependency tree of a job</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job tree MyApp_Build</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job tree MyApp_Build</span></div>
+                <pre class="term-body"><span class="term-fg36">Build</span>
 ├── <span class="term-fg2">▲ Dependents</span>
-│   ├── <span class="term-fg36">Build</span> <span class="term-fg2">MyApp_Build</span> <span class="term-fg33">(circular)</span>
 │   ├── <span class="term-fg36">Run Tests</span> <span class="term-fg2">MyApp_Test</span>
-│   │   ├── <span class="term-fg36">Build</span> <span class="term-fg2">MyApp_Build</span> <span class="term-fg33">(circular)</span>
-│   │   ├── <span class="term-fg36">Run Tests</span> <span class="term-fg2">MyApp_Test</span> <span class="term-fg33">(circular)</span>
-│   │   ├── <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span>
-│   │   │   ├── <span class="term-fg36">Build</span> <span class="term-fg2">MyApp_Build</span> <span class="term-fg33">(circular)</span>
-│   │   │   ├── <span class="term-fg36">Run Tests</span> <span class="term-fg2">MyApp_Test</span> <span class="term-fg33">(circular)</span>
-│   │   │   ├── <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span> <span class="term-fg33">(circular)</span>
-│   │   │   ├── <span class="term-fg36">Integration Tests</span> <span class="term-fg2">MyApp_IntTest</span>
-│   │   │   │   ├── <span class="term-fg36">Build</span> <span class="term-fg2">MyApp_Build</span> <span class="term-fg33">(circular)</span>
-│   │   │   │   ├── <span class="term-fg36">Run Tests</span> <span class="term-fg2">MyApp_Test</span> <span class="term-fg33">(circular)</span>
-│   │   │   │   ├── <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span> <span class="term-fg33">(circular)</span>
-│   │   │   │   ├── <span class="term-fg36">Integration Tests</span> <span class="term-fg2">MyApp_IntTest</span> <span class="term-fg33">(circular)</span>
-│   │   │   │   └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span>
-│   │   │   │       ├── <span class="term-fg36">Build</span> <span class="term-fg2">MyApp_Build</span> <span class="term-fg33">(circular)</span>
-│   │   │   │       ├── <span class="term-fg36">Run Tests</span> <span class="term-fg2">MyApp_Test</span> <span class="term-fg33">(circular)</span>
-│   │   │   │       ├── <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span> <span class="term-fg33">(circular)</span>
-│   │   │   │       ├── <span class="term-fg36">Integration Tests</span> <span class="term-fg2">MyApp_IntTest</span> <span class="term-fg33">(circular)</span>
-│   │   │   │       └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span> <span class="term-fg33">(circular)</span>
-│   │   │   └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span> <span class="term-fg33">(circular)</span>
-│   │   ├── <span class="term-fg36">Integration Tests</span> <span class="term-fg2">MyApp_IntTest</span> <span class="term-fg33">(circular)</span>
-│   │   └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span> <span class="term-fg33">(circular)</span>
-│   ├── <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span> <span class="term-fg33">(circular)</span>
-│   ├── <span class="term-fg36">Integration Tests</span> <span class="term-fg2">MyApp_IntTest</span> <span class="term-fg33">(circular)</span>
-│   └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span> <span class="term-fg33">(circular)</span>
+│   │   └── <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span>
+│   └── <span class="term-fg36">Integration Tests</span> <span class="term-fg2">MyApp_IntTest</span>
+│       └── <span class="term-fg36">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span> <span class="term-fg33">(circular)</span>
 └── <span class="term-fg2">▼ Dependencies</span>
-    └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span>
-        └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span> <span class="term-fg33">(circular)</span></pre></div></div>
-    </div>
-    <div class="screen" id="job-pause">
-      <div class="screen-header"><h3>job pause</h3><p>Pause a build configuration</p></div>
-      <div class="screen-cmd">teamcity job pause MyApp_Deploy</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Paused job MyApp_Deploy</pre></div></div>
-    </div>
-    <div class="screen" id="job-param">
-      <div class="screen-header"><h3>job param list</h3><p>List job parameters</p></div>
-      <div class="screen-cmd">teamcity job param list MyApp_Build</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>NAME            VALUE
+    └── <span class="term-fg36">Lint</span> <span class="term-fg2">MyApp_Lint</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-pause" data-cmd="job-pause" data-search="job-pause job pause pause a build configuration teamcity job pause myapp_deploy">
+            <div class="entry-meta">
+              <div class="id">job-pause</div>
+              <h4>job pause</h4>
+              <p>Pause a build configuration</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job pause MyApp_Deploy</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job pause MyApp_Deploy</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Paused job MyApp_Deploy</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-resume" data-cmd="job-resume" data-search="job-resume job resume resume a paused build configuration teamcity job resume myapp_deploy">
+            <div class="entry-meta">
+              <div class="id">job-resume</div>
+              <h4>job resume</h4>
+              <p>Resume a paused build configuration</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job resume MyApp_Deploy</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job resume MyApp_Deploy</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Resumed job MyApp_Deploy</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-param" data-cmd="job-param" data-search="job-param job param list list job parameters teamcity job param list myapp_build">
+            <div class="entry-meta">
+              <div class="id">job-param</div>
+              <h4>job param list</h4>
+              <p>List job parameters</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job param list MyApp_Build</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job param list MyApp_Build</span></div>
+                <pre class="term-body">NAME            VALUE
 env.JAVA_HOME   &#47;usr&#47;lib&#47;jvm&#47;java-17
 env.GOVERSION   1.26
 version         1.0.0
 deploy.target   staging
-build.parallel  4</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="agents">
-    <h2>Agents</h2>
-    <div class="screens">
-    <div class="screen" id="agent-list">
-      <div class="screen-header"><h3>agent list</h3><p>List build agents</p></div>
-      <div class="screen-cmd">teamcity agent list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID  NAME              POOL     STATUS
+build.parallel  4</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-param-get" data-cmd="job-param-get" data-search="job-param-get job param get get a job parameter value teamcity job param get myapp_build env.java_home">
+            <div class="entry-meta">
+              <div class="id">job-param-get</div>
+              <h4>job param get</h4>
+              <p>Get a job parameter value</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job param get MyApp_Build env.JAVA_HOME</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job param get MyApp_Build env.JAVA_HOME</span></div>
+                <pre class="term-body">value1</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-param-set" data-cmd="job-param-set" data-search="job-param-set job param set set a job parameter value teamcity job param set myapp_build env.java_home /opt/jdk">
+            <div class="entry-meta">
+              <div class="id">job-param-set</div>
+              <h4>job param set</h4>
+              <p>Set a job parameter value</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job param set MyApp_Build env.JAVA_HOME /opt/jdk</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job param set MyApp_Build env.JAVA_HOME /opt/jdk</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Set parameter env.JAVA_HOME</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="job-param-delete" data-cmd="job-param-delete" data-search="job-param-delete job param delete delete a job parameter teamcity job param delete myapp_build env.java_home">
+            <div class="entry-meta">
+              <div class="id">job-param-delete</div>
+              <h4>job param delete</h4>
+              <p>Delete a job parameter</p>
+              <div class="tags"><span>jobs</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job param delete MyApp_Build env.JAVA_HOME</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job param delete MyApp_Build env.JAVA_HOME</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Deleted parameter env.JAVA_HOME</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-agents" data-grp="agents">
+        <div class="section-head">
+          <div class="section-num">§ 04</div>
+          <div class="section-name">Agents</div>
+          <div class="section-blurb">List agents, view status, open terminals, execute commands.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="agent-list" data-cmd="agent-list" data-search="agent-list agent list list build agents teamcity agent list">
+            <div class="entry-meta">
+              <div class="id">agent-list</div>
+              <h4>agent list</h4>
+              <p>List build agents</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent list</span></div>
+                <pre class="term-body">ID  NAME              POOL     STATUS
 1   linux-agent-01    Default  <span class="term-fg32">Connected</span>
 2   linux-agent-02    Default  <span class="term-fg32">Connected</span>
 3   windows-agent-01  Windows  <span class="term-fg32">Connected</span>
 4   mac-agent-01      macOS    <span class="term-fg31">Disconnected</span>
-5   cloud-agent-01    Cloud    <span class="term-fg2">Disabled</span></pre></div></div>
-    </div>
-    <div class="screen" id="agent-view">
-      <div class="screen-header"><h3>agent view</h3><p>Detailed view of an agent</p></div>
-      <div class="screen-cmd">teamcity agent view 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">linux-agent-01</span>
+5   cloud-agent-01    Cloud    <span class="term-fg2">Disabled</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-view" data-cmd="agent-view" data-search="agent-view agent view detailed view of an agent teamcity agent view 1">
+            <div class="entry-meta">
+              <div class="id">agent-view</div>
+              <h4>agent view</h4>
+              <p>Detailed view of an agent</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent view 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent view 1</span></div>
+                <pre class="term-body"><span class="term-fg36">linux-agent-01</span>
 ID: 1
 Pool: Default
 Status: <span class="term-fg32">Connected</span>
@@ -771,31 +1982,166 @@ Authorized: <span class="term-fg32">Yes</span>
 Current build: Deploy Staging 45229  #830 ()
 &nbsp;
 <span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;agentDetails.html?id=1</span>
-<span class="term-fg2">Open terminal:</span> teamcity agent term 1</pre></div></div>
-    </div>
-    <div class="screen" id="agent-jobs">
-      <div class="screen-header"><h3>agent jobs</h3><p>Compatible and incompatible jobs</p></div>
-      <div class="screen-cmd">teamcity agent jobs 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">Compatible Jobs</span> (2)
+<span class="term-fg2">Open terminal:</span> teamcity agent term 1</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-jobs" data-cmd="agent-jobs" data-search="agent-jobs agent jobs compatible and incompatible jobs teamcity agent jobs 1">
+            <div class="entry-meta">
+              <div class="id">agent-jobs</div>
+              <h4>agent jobs</h4>
+              <p>Compatible and incompatible jobs</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent jobs 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent jobs 1</span></div>
+                <pre class="term-body"><span class="term-fg32">Compatible Jobs</span> (5)
 &nbsp;
-ID             NAME   PROJECT
-Project_Build  Build  Project
-Project_Test   Test   Project</pre></div></div>
-    </div>
-    <div class="screen" id="agent-enable">
-      <div class="screen-header"><h3>agent enable</h3><p>Enable an agent</p></div>
-      <div class="screen-cmd">teamcity agent enable 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Enabled agent linux-agent-01</pre></div></div>
-    </div>
-    <div class="screen" id="agent-disable">
-      <div class="screen-header"><h3>agent disable</h3><p>Disable an agent</p></div>
-      <div class="screen-cmd">teamcity agent disable 1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Disabled agent linux-agent-01</pre></div></div>
-    </div>
-    <div class="screen" id="agent-term">
-      <div class="screen-header"><h3>agent term</h3><p>Interactive terminal session on an agent (WebSocket)</p></div>
-      <div class="screen-cmd">teamcity agent term linux-agent-01</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Connected to <span class="term-fg36">linux-agent-01</span>
+ID              NAME               PROJECT
+MyApp_Build     Build              My Application
+MyApp_Test      Run Tests          My Application
+MyApp_Lint      Lint               My Application
+MyApp_IntTest   Integration Tests  My Application
+Infra_Validate  Validate           Infrastructure</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-enable" data-cmd="agent-enable" data-search="agent-enable agent enable enable an agent teamcity agent enable 1">
+            <div class="entry-meta">
+              <div class="id">agent-enable</div>
+              <h4>agent enable</h4>
+              <p>Enable an agent</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent enable 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent enable 1</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Enabled agent linux-agent-01</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-disable" data-cmd="agent-disable" data-search="agent-disable agent disable disable an agent teamcity agent disable 1">
+            <div class="entry-meta">
+              <div class="id">agent-disable</div>
+              <h4>agent disable</h4>
+              <p>Disable an agent</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent disable 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent disable 1</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Disabled agent linux-agent-01</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-authorize" data-cmd="agent-authorize" data-search="agent-authorize agent authorize authorize an agent to accept builds teamcity agent authorize 1">
+            <div class="entry-meta">
+              <div class="id">agent-authorize</div>
+              <h4>agent authorize</h4>
+              <p>Authorize an agent to accept builds</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent authorize 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent authorize 1</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Authorized agent linux-agent-01</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-deauthorize" data-cmd="agent-deauthorize" data-search="agent-deauthorize agent deauthorize revoke authorization from an agent teamcity agent deauthorize 1">
+            <div class="entry-meta">
+              <div class="id">agent-deauthorize</div>
+              <h4>agent deauthorize</h4>
+              <p>Revoke authorization from an agent</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent deauthorize 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent deauthorize 1</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Deauthorized agent linux-agent-01</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-move" data-cmd="agent-move" data-search="agent-move agent move move an agent to a different pool teamcity agent move 1 2">
+            <div class="entry-meta">
+              <div class="id">agent-move</div>
+              <h4>agent move</h4>
+              <p>Move an agent to a different pool</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent move 1 2</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent move 1 2</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Moved agent linux-agent-01 to pool 2</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-reboot" data-cmd="agent-reboot" data-search="agent-reboot agent reboot request agent reboot teamcity agent reboot --yes 1">
+            <div class="entry-meta">
+              <div class="id">agent-reboot</div>
+              <h4>agent reboot</h4>
+              <p>Request agent reboot</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent reboot --yes 1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent reboot --yes 1</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Reboot initiated for linux-agent-01</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-term" data-cmd="agent-term" data-search="agent-term agent term interactive terminal session on an agent (websocket) teamcity agent term linux-agent-01">
+            <div class="entry-meta">
+              <div class="id">agent-term</div>
+              <h4>agent term</h4>
+              <p>Interactive terminal session on an agent (WebSocket)</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent term linux-agent-01</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent term linux-agent-01</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Connected to <span class="term-fg36">linux-agent-01</span>
 <span class="term-fg2">https:&#47;&#47;tc.example.com&#47;agentDetails.html?id=1</span>
 &nbsp;
 <span class="term-fg32">builduser@linux-agent-01:~$</span> uname -a
@@ -809,68 +2155,174 @@ tc-build-45231  Up 12 minutes
 <span class="term-fg32">builduser@linux-agent-01:~$</span> free -h | head -2
               total        used        free      shared  buff&#47;cache   available
 Mem:           31Gi        18Gi       2.1Gi       312Mi        11Gi        12Gi
-<span class="term-fg32">builduser@linux-agent-01:~$</span></pre></div></div>
-    </div>
-    <div class="screen" id="agent-exec">
-      <div class="screen-header"><h3>agent exec</h3><p>Execute a single command on an agent (WebSocket)</p></div>
-      <div class="screen-cmd">teamcity agent exec linux-agent-01 -- top -bn1 | head -5</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>top - 19:31:45 up 14 days,  3:22,  0 users,  load average: 4.12, 3.87, 3.54
+<span class="term-fg32">builduser@linux-agent-01:~$</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="agent-exec" data-cmd="agent-exec" data-search="agent-exec agent exec execute a single command on an agent (websocket) teamcity agent exec linux-agent-01 -- top -bn1 | head -5">
+            <div class="entry-meta">
+              <div class="id">agent-exec</div>
+              <h4>agent exec</h4>
+              <p>Execute a single command on an agent (WebSocket)</p>
+              <div class="tags"><span>agents</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent exec linux-agent-01 -- top -bn1 | head -5</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent exec linux-agent-01 -- top -bn1 | head -5</span></div>
+                <pre class="term-body">top - 19:31:45 up 14 days,  3:22,  0 users,  load average: 4.12, 3.87, 3.54
 Tasks: 287 total,   3 running, 284 sleeping,   0 stopped,   0 zombie
 %Cpu(s): 42.3 us,  5.1 sy,  0.0 ni, 51.2 id,  0.8 wa,  0.0 hi,  0.6 si
 MiB Mem :  32168.4 total,   2152.3 free,  18724.1 used,  11292.0 buff&#47;cache
-MiB Swap:   8192.0 total,   8192.0 free,      0.0 used.  12876.4 avail Mem</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="queue">
-    <h2>Queue</h2>
-    <div class="screens">
-    <div class="screen" id="queue-list">
-      <div class="screen-header"><h3>queue list</h3><p>List builds in the queue</p></div>
-      <div class="screen-cmd">teamcity queue list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID     JOB            BRANCH           STATE   WAIT REASON
+MiB Swap:   8192.0 total,   8192.0 free,      0.0 used.  12876.4 avail Mem</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-queue" data-grp="queue">
+        <div class="section-head">
+          <div class="section-num">§ 05</div>
+          <div class="section-name">Queue</div>
+          <div class="section-blurb">Inspect and reorder the build queue.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="queue-list" data-cmd="queue-list" data-search="queue-list queue list list builds in the queue teamcity queue list">
+            <div class="entry-meta">
+              <div class="id">queue-list</div>
+              <h4>queue list</h4>
+              <p>List builds in the queue</p>
+              <div class="tags"><span>queue</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity queue list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity queue list</span></div>
+                <pre class="term-body">ID     JOB            BRANCH           STATE   WAIT REASON
 45233  MyApp_Build    feature&#47;onboard  queued  All compatible agents are busy
 45234  MyApp_Test     main             queued  Waiting for build #45233 in queue
 45235  MyApp_IntTest  main             queued  Waiting for build #45234 in queue
 45236  MyApp_Build    develop          queued  Build queue is paused
-45237  MyApp_Deploy   main             queued  Waiting for approval</pre></div></div>
-    </div>
-    <div class="screen" id="queue-remove">
-      <div class="screen-header"><h3>queue remove</h3><p>Remove a build from the queue</p></div>
-      <div class="screen-cmd">teamcity queue remove --yes 100</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Removed #100 from queue</pre></div></div>
-    </div>
-    <div class="screen" id="queue-top">
-      <div class="screen-header"><h3>queue top</h3><p>Move a build to the top of the queue</p></div>
-      <div class="screen-cmd">teamcity queue top 100</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Moved run 100 to top of queue</pre></div></div>
-    </div>
-    <div class="screen" id="queue-approve">
-      <div class="screen-header"><h3>queue approve</h3><p>Approve a queued build</p></div>
-      <div class="screen-cmd">teamcity queue approve 100</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Approved run 100</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="pools">
-    <h2>Pools</h2>
-    <div class="screens">
-    <div class="screen" id="pool-list">
-      <div class="screen-header"><h3>pool list</h3><p>List agent pools</p></div>
-      <div class="screen-cmd">teamcity pool list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID  NAME                MAX AGENTS
+45237  MyApp_Deploy   main             queued  Waiting for approval</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="queue-remove" data-cmd="queue-remove" data-search="queue-remove queue remove remove a build from the queue teamcity queue remove --yes 100">
+            <div class="entry-meta">
+              <div class="id">queue-remove</div>
+              <h4>queue remove</h4>
+              <p>Remove a build from the queue</p>
+              <div class="tags"><span>queue</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity queue remove --yes 100</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity queue remove --yes 100</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Removed #100 from queue</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="queue-top" data-cmd="queue-top" data-search="queue-top queue top move a build to the top of the queue teamcity queue top 100">
+            <div class="entry-meta">
+              <div class="id">queue-top</div>
+              <h4>queue top</h4>
+              <p>Move a build to the top of the queue</p>
+              <div class="tags"><span>queue</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity queue top 100</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity queue top 100</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Moved run 100 to top of queue</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="queue-approve" data-cmd="queue-approve" data-search="queue-approve queue approve approve a queued build teamcity queue approve 100">
+            <div class="entry-meta">
+              <div class="id">queue-approve</div>
+              <h4>queue approve</h4>
+              <p>Approve a queued build</p>
+              <div class="tags"><span>queue</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity queue approve 100</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity queue approve 100</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Approved run 100</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-pools" data-grp="pools">
+        <div class="section-head">
+          <div class="section-num">§ 06</div>
+          <div class="section-name">Pools</div>
+          <div class="section-blurb">Agent pools and project assignments.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="pool-list" data-cmd="pool-list" data-search="pool-list pool list list agent pools teamcity pool list">
+            <div class="entry-meta">
+              <div class="id">pool-list</div>
+              <h4>pool list</h4>
+              <p>List agent pools</p>
+              <div class="tags"><span>pools</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pool list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pool list</span></div>
+                <pre class="term-body">ID  NAME                MAX AGENTS
 0   Default             unlimited
 1   Linux Agents        10
 2   Windows Agents      5
 3   macOS Agents        3
-4   Cloud (Auto-scale)  50</pre></div></div>
-    </div>
-    <div class="screen" id="pool-view">
-      <div class="screen-header"><h3>pool view</h3><p>Detailed pool with agents and projects</p></div>
-      <div class="screen-cmd">teamcity pool view 0</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">Default</span>
+4   Cloud (Auto-scale)  50</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pool-view" data-cmd="pool-view" data-search="pool-view pool view detailed pool with agents and projects teamcity pool view 0">
+            <div class="entry-meta">
+              <div class="id">pool-view</div>
+              <h4>pool view</h4>
+              <p>Detailed pool with agents and projects</p>
+              <div class="tags"><span>pools</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pool view 0</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pool view 0</span></div>
+                <pre class="term-body"><span class="term-fg36">Default</span>
 ID: 0
 Max Agents: <span class="term-fg2">unlimited</span>
 &nbsp;
@@ -883,43 +2335,122 @@ Max Agents: <span class="term-fg2">unlimited</span>
   _Root  Root project
   MyApp  My Application
 &nbsp;
-<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;agents.html?tab=agentPools&amp;poolId=0</span></pre></div></div>
-    </div>
-    <div class="screen" id="pool-link">
-      <div class="screen-header"><h3>pool link</h3><p>Link a project to a pool</p></div>
-      <div class="screen-cmd">teamcity pool link 0 MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Linked project MyApp to pool 0</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="projects">
-    <h2>Projects</h2>
-    <div class="screens">
-    <div class="screen" id="project-list">
-      <div class="screen-header"><h3>project list</h3><p>List projects</p></div>
-      <div class="screen-cmd">teamcity project list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID              NAME            PARENT
+<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;agents.html?tab=agentPools&amp;poolId=0</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pool-link" data-cmd="pool-link" data-search="pool-link pool link link a project to a pool teamcity pool link 0 myapp">
+            <div class="entry-meta">
+              <div class="id">pool-link</div>
+              <h4>pool link</h4>
+              <p>Link a project to a pool</p>
+              <div class="tags"><span>pools</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pool link 0 MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pool link 0 MyApp</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Linked project MyApp to pool 0</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pool-unlink" data-cmd="pool-unlink" data-search="pool-unlink pool unlink unlink a project from a pool teamcity pool unlink 0 myapp">
+            <div class="entry-meta">
+              <div class="id">pool-unlink</div>
+              <h4>pool unlink</h4>
+              <p>Unlink a project from a pool</p>
+              <div class="tags"><span>pools</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pool unlink 0 MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pool unlink 0 MyApp</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Unlinked project MyApp to pool 0</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-projects" data-grp="projects">
+        <div class="section-head">
+          <div class="section-num">§ 07</div>
+          <div class="section-name">Projects</div>
+          <div class="section-blurb">Project tree, VCS, SSH, cloud, parameters, tokens.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="project-list" data-cmd="project-list" data-search="project-list project list list projects teamcity project list">
+            <div class="entry-meta">
+              <div class="id">project-list</div>
+              <h4>project list</h4>
+              <p>List projects</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project list</span></div>
+                <pre class="term-body">ID              NAME            PARENT
 _Root           Root project    -
 MyApp           My Application  _Root
 MyApp_Frontend  Frontend        MyApp
 MyApp_Backend   Backend         MyApp
-Infrastructure  Infrastructure  _Root</pre></div></div>
-    </div>
-    <div class="screen" id="project-view">
-      <div class="screen-header"><h3>project view</h3><p>Detailed project view</p></div>
-      <div class="screen-cmd">teamcity project view MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">My Application</span>
+Infrastructure  Infrastructure  _Root</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-view" data-cmd="project-view" data-search="project-view project view detailed project view teamcity project view myapp">
+            <div class="entry-meta">
+              <div class="id">project-view</div>
+              <h4>project view</h4>
+              <p>Detailed project view</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project view MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project view MyApp</span></div>
+                <pre class="term-body"><span class="term-fg36">My Application</span>
 ID: MyApp
 Parent: _Root
 Description: Main product monorepo
 &nbsp;
-<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;project.html?projectId=MyApp</span></pre></div></div>
-    </div>
-    <div class="screen" id="project-tree">
-      <div class="screen-header"><h3>project tree</h3><p>Full hierarchy with jobs and pipelines</p></div>
-      <div class="screen-cmd">teamcity project tree</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">Root project</span> <span class="term-fg2">_Root</span>
+<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;project.html?projectId=MyApp</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-tree" data-cmd="project-tree" data-search="project-tree project tree full hierarchy with jobs and pipelines teamcity project tree">
+            <div class="entry-meta">
+              <div class="id">project-tree</div>
+              <h4>project tree</h4>
+              <p>Full hierarchy with jobs and pipelines</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project tree</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project tree</span></div>
+                <pre class="term-body"><span class="term-fg36">Root project</span> <span class="term-fg2">_Root</span>
 ├── <span class="term-fg36">Infrastructure</span> <span class="term-fg2">Infrastructure</span>
 │   └── <span class="term-fg36">Infrastructure Deploy</span> <span class="term-fg2">Infra_Deploy</span> <span class="term-fg2">⬡ pipeline · 2 jobs</span>
 └── <span class="term-fg36">My Application</span> <span class="term-fg2">MyApp</span>
@@ -933,297 +2464,889 @@ Description: Main product monorepo
     ├── <span class="term-fg2">Deploy Staging</span> <span class="term-fg2">MyApp_Deploy</span>
     ├── <span class="term-fg2">Integration Tests</span> <span class="term-fg2">MyApp_IntTest</span>
     ├── <span class="term-fg2">Lint</span> <span class="term-fg2">MyApp_Lint</span>
-    └── <span class="term-fg2">Run Tests</span> <span class="term-fg2">MyApp_Test</span></pre></div></div>
-    </div>
-    <div class="screen" id="project-settings">
-      <div class="screen-header"><h3>project settings status</h3><p>Versioned settings sync status</p></div>
-      <div class="screen-cmd">teamcity project settings status MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> <span class="term-fg36">My Application</span> <span class="term-fg2">(MyApp)</span> <span class="term-fg2">·</span> synchronized
+    └── <span class="term-fg2">Run Tests</span> <span class="term-fg2">MyApp_Test</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-settings" data-cmd="project-settings" data-search="project-settings project settings status versioned settings sync status teamcity project settings status myapp">
+            <div class="entry-meta">
+              <div class="id">project-settings</div>
+              <h4>project settings status</h4>
+              <p>Versioned settings sync status</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project settings status MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project settings status MyApp</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> <span class="term-fg36">My Application</span> <span class="term-fg2">(MyApp)</span> <span class="term-fg2">·</span> synchronized
 &nbsp;
-<span class="term-fg2">Format</span>
-<span class="term-fg2">Sync</span>
-<span class="term-fg2">Build</span>
+<span class="term-fg2">Format</span> Kotlin
+<span class="term-fg2">Sync</span> enabled
+<span class="term-fg2">Build</span> from VCS
+<span class="term-fg2">VCS Root</span> MyApp_HttpsGithubComOrgRepoGit @ .teamcity
 &nbsp;
-<span class="term-fg2">View</span> <span class="term-fg2">https:&#47;&#47;tc.example.com&#47;project.html?projectId=MyApp&amp;tab=versionedSettings</span></pre></div></div>
-    </div>
-    <div class="screen" id="project-settings-validate">
-      <div class="screen-header"><h3>project settings validate</h3><p>Validate local DSL settings</p></div>
-      <div class="screen-cmd">teamcity project settings validate .teamcity</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Configuration valid
-  Server: https:&#47;&#47;tc.example.com
-  Projects: 5, Build configurations: 12, VCS roots: 3</pre></div></div>
-    </div>
-    <div class="screen" id="project-settings-export">
-      <div class="screen-header"><h3>project settings export</h3><p>Export DSL settings as a zip archive</p></div>
-      <div class="screen-cmd">teamcity project settings export MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Exported kotlin settings to projectSettings.zip (45678 bytes)</pre></div></div>
-    </div>
-    <div class="screen" id="project-vcs-list">
-      <div class="screen-header"><h3>project vcs list</h3><p>List VCS roots in a project</p></div>
-      <div class="screen-cmd">teamcity project vcs list MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID                NAME              TYPE        PROJECT
+<span class="term-fg2">Last sync</span> Jan 27 (Jan 27 11:30)
+&nbsp;
+<span class="term-fg2">View</span> <span class="term-fg2">https:&#47;&#47;tc.example.com&#47;project.html?projectId=MyApp&amp;tab=versionedSettings</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-settings-validate" data-cmd="project-settings-validate" data-search="project-settings-validate project settings validate validate local dsl settings teamcity project settings validate .teamcity">
+            <div class="entry-meta">
+              <div class="id">project-settings-validate</div>
+              <h4>project settings validate</h4>
+              <p>Validate local DSL settings</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project settings validate .teamcity</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project settings validate .teamcity</span></div>
+                <pre class="term-body">Validating <span class="term-fg2">.teamcity</span>
+<span class="term-fg32">✓</span> Configuration valid
+  <span class="term-fg2">Server:</span> https:&#47;&#47;tc.example.com
+  <span class="term-fg2">Projects: 5, Build configurations: 12</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-settings-export" data-cmd="project-settings-export" data-search="project-settings-export project settings export export dsl settings as a zip archive teamcity project settings export myapp">
+            <div class="entry-meta">
+              <div class="id">project-settings-export</div>
+              <h4>project settings export</h4>
+              <p>Export DSL settings as a zip archive</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project settings export MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project settings export MyApp</span></div>
+                <pre class="term-body">Exported kotlin settings to projectSettings.zip (45678 bytes)</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-vcs-list" data-cmd="project-vcs-list" data-search="project-vcs-list project vcs list list vcs roots in a project teamcity project vcs list --project myapp">
+            <div class="entry-meta">
+              <div class="id">project-vcs-list</div>
+              <h4>project vcs list</h4>
+              <p>List VCS roots in a project</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project vcs list --project MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project vcs list --project MyApp</span></div>
+                <pre class="term-body">ID                NAME              TYPE        PROJECT
 MyApp_MainRepo    Main Repo         Git         MyApp
 MyApp_ConfigRepo  Config Repo       Git         MyApp
 MyApp_DocsRepo    Documentation     Git         MyApp
 Shared_Libraries  Shared Libraries  Git         _Root
-Legacy_SVN        Legacy Codebase   Subversion  MyApp</pre></div></div>
-    </div>
-    <div class="screen" id="project-vcs-view">
-      <div class="screen-header"><h3>project vcs view</h3><p>View VCS root details</p></div>
-      <div class="screen-cmd">teamcity project vcs view MyApp_MainRepo</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">My Repo</span>
+Legacy_SVN        Legacy Codebase   Subversion  MyApp</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-vcs-view" data-cmd="project-vcs-view" data-search="project-vcs-view project vcs view view vcs root details teamcity project vcs view myapp_mainrepo">
+            <div class="entry-meta">
+              <div class="id">project-vcs-view</div>
+              <h4>project vcs view</h4>
+              <p>View VCS root details</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project vcs view MyApp_MainRepo</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project vcs view MyApp_MainRepo</span></div>
+                <pre class="term-body"><span class="term-fg36">Main Repo</span>
 ID: MyApp_MainRepo
 Type: Git
-Project: TestProject
-URL: https:&#47;&#47;github.com&#47;org&#47;repo
+Project: MyApp
+URL: https:&#47;&#47;github.com&#47;jetbrains&#47;teamcity-cli.git
 Branch: refs&#47;heads&#47;main
-Auth Method: PASSWORD
-Password: ********
+Auth Method: TEAMCITY_SSH_KEY
+SSH Key: deploy-key
 &nbsp;
-<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;admin&#47;editVcsRoot.html?vcsRootId=MyApp_MainRepo</span></pre></div></div>
-    </div>
-    <div class="screen" id="project-vcs-create">
-      <div class="screen-header"><h3>project vcs create</h3><p>Create a new VCS root (interactive prompts)</p></div>
-      <div class="screen-cmd">teamcity project vcs create MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Created VCS root <span class="term-fg36">New Repo</span>
-  ID: MyApp_NewRepo
-  URL: https:&#47;&#47;github.com&#47;org&#47;new-repo</pre></div></div>
-    </div>
-    <div class="screen" id="project-vcs-test">
-      <div class="screen-header"><h3>project vcs test</h3><p>Test VCS connection</p></div>
-      <div class="screen-cmd">teamcity project vcs test MyApp_MainRepo</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Testing connection... <span class="term-fg32">✓</span>
-<span class="term-fg32">✓</span> Connection to &quot;My Repo&quot; is working</pre></div></div>
-    </div>
-    <div class="screen" id="project-vcs-delete">
-      <div class="screen-header"><h3>project vcs delete</h3><p>Delete a VCS root</p></div>
-      <div class="screen-cmd">teamcity project vcs delete --yes MyApp_Repo</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Deleted VCS root MyApp_Repo</pre></div></div>
-    </div>
-    <div class="screen" id="project-ssh-list">
-      <div class="screen-header"><h3>project ssh list</h3><p>List SSH keys in a project</p></div>
-      <div class="screen-cmd">teamcity project ssh list MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>No SSH keys found</pre></div></div>
-    </div>
-    <div class="screen" id="project-ssh-generate">
-      <div class="screen-header"><h3>project ssh generate</h3><p>Generate a new SSH key</p></div>
-      <div class="screen-cmd">teamcity project ssh generate --project MyApp --name ci-key</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Generated SSH key &quot;ci-key&quot; in project TestProject
+<span class="term-fg2">View in browser:</span> <span class="term-fg32">https:&#47;&#47;tc.example.com&#47;admin&#47;editVcsRoot.html?vcsRootId=MyApp_MainRepo</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-vcs-create" data-cmd="project-vcs-create" data-search="project-vcs-create project vcs create create a new vcs root (interactive prompts) teamcity project vcs create --project myapp --name &#34;new repo&#34; --url https://github.com/org/new-repo">
+            <div class="entry-meta">
+              <div class="id">project-vcs-create</div>
+              <h4>project vcs create</h4>
+              <p>Create a new VCS root (interactive prompts)</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project vcs create --project MyApp --name &#34;New Repo&#34; --url https://github.com/org/new-repo</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project vcs create --project MyApp --name &#34;New Repo&#34; --url https://github.com/org/new-repo</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Created VCS root &quot;New Repo&quot; (MyApp_NewRepo) in project MyApp</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-vcs-test" data-cmd="project-vcs-test" data-search="project-vcs-test project vcs test test vcs connection teamcity project vcs test myapp_mainrepo">
+            <div class="entry-meta">
+              <div class="id">project-vcs-test</div>
+              <h4>project vcs test</h4>
+              <p>Test VCS connection</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project vcs test MyApp_MainRepo</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project vcs test MyApp_MainRepo</span></div>
+                <pre class="term-body">Testing connection... <span class="term-fg32">✓</span>
+<span class="term-fg32">✓</span> Connection to &quot;Main Repo&quot; is working</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-vcs-delete" data-cmd="project-vcs-delete" data-search="project-vcs-delete project vcs delete delete a vcs root teamcity project vcs delete --yes myapp_repo">
+            <div class="entry-meta">
+              <div class="id">project-vcs-delete</div>
+              <h4>project vcs delete</h4>
+              <p>Delete a VCS root</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project vcs delete --yes MyApp_Repo</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project vcs delete --yes MyApp_Repo</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Deleted VCS root MyApp_Repo</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-ssh-list" data-cmd="project-ssh-list" data-search="project-ssh-list project ssh list list ssh keys in a project teamcity project ssh list --project myapp">
+            <div class="entry-meta">
+              <div class="id">project-ssh-list</div>
+              <h4>project ssh list</h4>
+              <p>List SSH keys in a project</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project ssh list --project MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project ssh list --project MyApp</span></div>
+                <pre class="term-body">NAME            ENCRYPTED  PUBLIC KEY
+deploy-key      no         ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA...
+ci-key          no         ssh-ed25519 AAAAC3NzaC1lZDI1NTE5BBBB...
+backup-key      yes        ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB...
+github-app      no         ssh-ed25519 AAAAC3NzaC1lZDI1NTE5CCCC...
+staging-access  yes        ssh-rsa AAAAB3NzaC1yc2EAAAADAQCC...</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-ssh-generate" data-cmd="project-ssh-generate" data-search="project-ssh-generate project ssh generate generate a new ssh key teamcity project ssh generate --project myapp --name ci-key">
+            <div class="entry-meta">
+              <div class="id">project-ssh-generate</div>
+              <h4>project ssh generate</h4>
+              <p>Generate a new SSH key</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project ssh generate --project MyApp --name ci-key</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project ssh generate --project MyApp --name ci-key</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Generated SSH key &quot;ci-key&quot; in project MyApp
 &nbsp;
-ssh-ed25519 AAAAC3_generated_key</pre></div></div>
-    </div>
-    <div class="screen" id="project-ssh-upload">
-      <div class="screen-header"><h3>project ssh upload</h3><p>Upload an SSH private key</p></div>
-      <div class="screen-cmd">teamcity project ssh upload id_ed25519 --project MyApp --name deploy-key</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Uploaded SSH key <span class="term-fg36">deploy-key</span></pre></div></div>
-    </div>
-    <div class="screen" id="project-ssh-delete">
-      <div class="screen-header"><h3>project ssh delete</h3><p>Delete an SSH key</p></div>
-      <div class="screen-cmd">teamcity project ssh delete deploy-key --project MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Deleted SSH key &quot;deploy-key&quot; from project TestProject</pre></div></div>
-    </div>
-    <div class="screen" id="project-connection-list">
-      <div class="screen-header"><h3>project connection list</h3><p>List project connections</p></div>
-      <div class="screen-cmd">teamcity project connection list MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>No connections found</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-profile">
-      <div class="screen-header"><h3>project cloud profile list</h3><p>List cloud profiles</p></div>
-      <div class="screen-cmd">teamcity project cloud profile list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID           NAME                TYPE
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5_generated_key</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-ssh-upload" data-cmd="project-ssh-upload" data-search="project-ssh-upload project ssh upload upload an ssh private key teamcity project ssh upload id_ed25519 --project myapp --name deploy-key">
+            <div class="entry-meta">
+              <div class="id">project-ssh-upload</div>
+              <h4>project ssh upload</h4>
+              <p>Upload an SSH private key</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project ssh upload id_ed25519 --project MyApp --name deploy-key</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project ssh upload id_ed25519 --project MyApp --name deploy-key</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Uploaded SSH key &quot;deploy-key&quot; to project MyApp</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-ssh-delete" data-cmd="project-ssh-delete" data-search="project-ssh-delete project ssh delete delete an ssh key teamcity project ssh delete deploy-key --project myapp">
+            <div class="entry-meta">
+              <div class="id">project-ssh-delete</div>
+              <h4>project ssh delete</h4>
+              <p>Delete an SSH key</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project ssh delete deploy-key --project MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project ssh delete deploy-key --project MyApp</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Deleted SSH key &quot;deploy-key&quot; from project MyApp</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-connection-list" data-cmd="project-connection-list" data-search="project-connection-list project connection list list project connections teamcity project connection list --project myapp">
+            <div class="entry-meta">
+              <div class="id">project-connection-list</div>
+              <h4>project connection list</h4>
+              <p>List project connections</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project connection list --project MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project connection list --project MyApp</span></div>
+                <pre class="term-body">ID             NAME             TYPE
+PROJECT_EXT_1  GitHub App       GitHubApp
+PROJECT_EXT_2  Docker Registry  DockerRegistry
+PROJECT_EXT_3  AWS Connection   AWSConnection
+PROJECT_EXT_4  Slack Notifier   SlackConnection
+PROJECT_EXT_5  Jira Cloud       JiraCloud</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-profile" data-cmd="project-cloud-profile" data-search="project-cloud-profile project cloud profile list list cloud profiles teamcity project cloud profile list">
+            <div class="entry-meta">
+              <div class="id">project-cloud-profile</div>
+              <h4>project cloud profile list</h4>
+              <p>List cloud profiles</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud profile list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud profile list</span></div>
+                <pre class="term-body">ID           NAME                TYPE
 aws-prod     AWS Production      amazon
 aws-staging  AWS Staging         amazon
 azure-eu     Azure EU            azure
 gcp-us       GCP US Central      google
-k8s-local    Kubernetes On-Prem  kubernetes</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-profile-view">
-      <div class="screen-header"><h3>project cloud profile view</h3><p>View cloud profile details</p></div>
-      <div class="screen-cmd">teamcity project cloud profile view aws-prod</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">AWS Production</span>
+k8s-local    Kubernetes On-Prem  kubernetes</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-profile-view" data-cmd="project-cloud-profile-view" data-search="project-cloud-profile-view project cloud profile view view cloud profile details teamcity project cloud profile view aws-prod">
+            <div class="entry-meta">
+              <div class="id">project-cloud-profile-view</div>
+              <h4>project cloud profile view</h4>
+              <p>View cloud profile details</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud profile view aws-prod</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud profile view aws-prod</span></div>
+                <pre class="term-body"><span class="term-fg36">AWS Production</span>
 ID: aws-prod
 Type: amazon
-Project: TestProject</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-image">
-      <div class="screen-header"><h3>project cloud image list</h3><p>List cloud images</p></div>
-      <div class="screen-cmd">teamcity project cloud image list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>NAME              PROFILE         ID
+Project: MyApp</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-image" data-cmd="project-cloud-image" data-search="project-cloud-image project cloud image list list cloud images teamcity project cloud image list">
+            <div class="entry-meta">
+              <div class="id">project-cloud-image</div>
+              <h4>project cloud image list</h4>
+              <p>List cloud images</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud image list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud image list</span></div>
+                <pre class="term-body">NAME              PROFILE         ID
 ubuntu-22-large   AWS Production  img-1
 ubuntu-22-xlarge  AWS Production  img-2
 windows-2022      Azure EU        img-3
 debian-12-small   AWS Staging     img-4
-ubuntu-22-gpu     GCP US Central  img-5</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-image-view">
-      <div class="screen-header"><h3>project cloud image view</h3><p>View cloud image details</p></div>
-      <div class="screen-cmd">teamcity project cloud image view img-1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">ubuntu-22-large</span>
+ubuntu-22-gpu     GCP US Central  img-5</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-image-view" data-cmd="project-cloud-image-view" data-search="project-cloud-image-view project cloud image view view cloud image details teamcity project cloud image view img-1">
+            <div class="entry-meta">
+              <div class="id">project-cloud-image-view</div>
+              <h4>project cloud image view</h4>
+              <p>View cloud image details</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud image view img-1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud image view img-1</span></div>
+                <pre class="term-body"><span class="term-fg36">ubuntu-22-large</span>
 ID: id:img-1,profileId:aws-prod
-Profile: AWS Production</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-image-start">
-      <div class="screen-header"><h3>project cloud image start</h3><p>Start a cloud instance from an image</p></div>
-      <div class="screen-cmd">teamcity project cloud image start img-1</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Started instance i-new-instance from image ubuntu-22-large</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-instance">
-      <div class="screen-header"><h3>project cloud instance list</h3><p>List running cloud instances</p></div>
-      <div class="screen-cmd">teamcity project cloud instance list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>NAME           STATE     IMAGE             AGENT          STARTED  ID
+Profile: AWS Production</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-image-start" data-cmd="project-cloud-image-start" data-search="project-cloud-image-start project cloud image start start a cloud instance from an image teamcity project cloud image start img-1">
+            <div class="entry-meta">
+              <div class="id">project-cloud-image-start</div>
+              <h4>project cloud image start</h4>
+              <p>Start a cloud instance from an image</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud image start img-1</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud image start img-1</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Started instance i-new-instance from image ubuntu-22-large</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-instance" data-cmd="project-cloud-instance" data-search="project-cloud-instance project cloud instance list list running cloud instances teamcity project cloud instance list">
+            <div class="entry-meta">
+              <div class="id">project-cloud-instance</div>
+              <h4>project cloud instance list</h4>
+              <p>List running cloud instances</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud instance list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud instance list</span></div>
+                <pre class="term-body">NAME           STATE     IMAGE             AGENT          STARTED  ID
 agent-cloud-1  running   ubuntu-22-large   agent-cloud-1           i-0a24f...
 agent-cloud-2  running   ubuntu-22-large   agent-cloud-2           i-0b35e...
 agent-cloud-3  starting  ubuntu-22-xlarge                          i-0c46d...
 agent-azure-1  running   windows-2022      agent-azure-1           vm-eu-01
-agent-k8s-5    running   ubuntu-22-gpu     agent-k8s-5             gke-node-5</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-instance-view">
-      <div class="screen-header"><h3>project cloud instance view</h3><p>View cloud instance details</p></div>
-      <div class="screen-cmd">teamcity project cloud instance view i-024...</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">agent-cloud-1</span>
+agent-k8s-5    running   ubuntu-22-gpu     agent-k8s-5             gke-node-5</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-instance-view" data-cmd="project-cloud-instance-view" data-search="project-cloud-instance-view project cloud instance view view cloud instance details teamcity project cloud instance view i-024...">
+            <div class="entry-meta">
+              <div class="id">project-cloud-instance-view</div>
+              <h4>project cloud instance view</h4>
+              <p>View cloud instance details</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud instance view i-024...</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud instance view i-024...</span></div>
+                <pre class="term-body"><span class="term-fg36">agent-cloud-1</span>
 ID: i-0245b46070c443201
 State: running
 Image: ubuntu-22-large
 Agent: agent-cloud-1
-Started: Jan 01</pre></div></div>
-    </div>
-    <div class="screen" id="project-cloud-instance-stop">
-      <div class="screen-header"><h3>project cloud instance stop</h3><p>Stop a cloud instance</p></div>
-      <div class="screen-cmd">teamcity project cloud instance stop i-024...</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Stopped instance i-0245b46070c443201</pre></div></div>
-    </div>
-    <div class="screen" id="project-param">
-      <div class="screen-header"><h3>project param list</h3><p>List project parameters</p></div>
-      <div class="screen-cmd">teamcity project param list MyApp</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>NAME                          VALUE
+Started: Jan 01</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-cloud-instance-stop" data-cmd="project-cloud-instance-stop" data-search="project-cloud-instance-stop project cloud instance stop stop a cloud instance teamcity project cloud instance stop i-024...">
+            <div class="entry-meta">
+              <div class="id">project-cloud-instance-stop</div>
+              <h4>project cloud instance stop</h4>
+              <p>Stop a cloud instance</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud instance stop i-024...</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud instance stop i-024...</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Stopped instance i-0245b46070c443201</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-param" data-cmd="project-param" data-search="project-param project param list list project parameters teamcity project param list myapp">
+            <div class="entry-meta">
+              <div class="id">project-param</div>
+              <h4>project param list</h4>
+              <p>List project parameters</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project param list MyApp</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project param list MyApp</span></div>
+                <pre class="term-body">NAME                          VALUE
 env.DEPLOY_ENV                staging
 env.JAVA_HOME                 &#47;usr&#47;lib&#47;jvm&#47;java-17
 version.prefix                1.0
 docker.registry               ghcr.io&#47;myorg
-system.teamcity.build.branch  main</pre></div></div>
-    </div>
-    <div class="screen" id="project-token-put">
-      <div class="screen-header"><h3>project token put</h3><p>Store a secret and get a secure token reference</p></div>
-      <div class="screen-cmd">teamcity project token put MyApp &#34;s3cret-db-password&#34;</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>credentialsJSON:abc123
+system.teamcity.build.branch  main</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-param-get" data-cmd="project-param-get" data-search="project-param-get project param get get a project parameter value teamcity project param get myapp env.deploy_env">
+            <div class="entry-meta">
+              <div class="id">project-param-get</div>
+              <h4>project param get</h4>
+              <p>Get a project parameter value</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project param get MyApp env.DEPLOY_ENV</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project param get MyApp env.DEPLOY_ENV</span></div>
+                <pre class="term-body">value1</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-param-set" data-cmd="project-param-set" data-search="project-param-set project param set set a project parameter value teamcity project param set myapp env.deploy_env prod">
+            <div class="entry-meta">
+              <div class="id">project-param-set</div>
+              <h4>project param set</h4>
+              <p>Set a project parameter value</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project param set MyApp env.DEPLOY_ENV prod</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project param set MyApp env.DEPLOY_ENV prod</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Set parameter env.DEPLOY_ENV</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-param-delete" data-cmd="project-param-delete" data-search="project-param-delete project param delete delete a project parameter teamcity project param delete myapp env.deploy_env">
+            <div class="entry-meta">
+              <div class="id">project-param-delete</div>
+              <h4>project param delete</h4>
+              <p>Delete a project parameter</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project param delete MyApp env.DEPLOY_ENV</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project param delete MyApp env.DEPLOY_ENV</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Deleted parameter env.DEPLOY_ENV</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-token-put" data-cmd="project-token-put" data-search="project-token-put project token put store a secret and get a secure token reference teamcity project token put myapp &#34;s3cret-db-password&#34;">
+            <div class="entry-meta">
+              <div class="id">project-token-put</div>
+              <h4>project token put</h4>
+              <p>Store a secret and get a secure token reference</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project token put MyApp &#34;s3cret-db-password&#34;</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project token put MyApp &#34;s3cret-db-password&#34;</span></div>
+                <pre class="term-body">credentialsJSON:abc123
 &nbsp;
-<span class="term-fg2">Use in versioned settings as: credentialsJSON:abc123</span></pre></div></div>
-    </div>
-    <div class="screen" id="project-token-get">
-      <div class="screen-header"><h3>project token get</h3><p>Retrieve the value of a secure token</p></div>
-      <div class="screen-cmd">teamcity project token get MyApp credentialsJSON:abc123</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>s3cret-db-password</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="pipelines">
-    <h2>Pipelines</h2>
-    <div class="screens">
-    <div class="screen" id="pipeline-list">
-      <div class="screen-header"><h3>pipeline list</h3><p>List YAML pipelines</p></div>
-      <div class="screen-cmd">teamcity pipeline list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>ID             NAME                   PROJECT         JOBS
+<span class="term-fg2">Use in versioned settings as: credentialsJSON:abc123</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="project-token-get" data-cmd="project-token-get" data-search="project-token-get project token get retrieve the value of a secure token teamcity project token get myapp credentialsjson:abc123">
+            <div class="entry-meta">
+              <div class="id">project-token-get</div>
+              <h4>project token get</h4>
+              <p>Retrieve the value of a secure token</p>
+              <div class="tags"><span>projects</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project token get MyApp credentialsJSON:abc123</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project token get MyApp credentialsJSON:abc123</span></div>
+                <pre class="term-body">s3cret-db-password</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-pipelines" data-grp="pipelines">
+        <div class="section-head">
+          <div class="section-num">§ 08</div>
+          <div class="section-name">Pipelines</div>
+          <div class="section-blurb">YAML pipeline lifecycle: validate, push, pull.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="pipeline-list" data-cmd="pipeline-list" data-search="pipeline-list pipeline list list yaml pipelines teamcity pipeline list">
+            <div class="entry-meta">
+              <div class="id">pipeline-list</div>
+              <h4>pipeline list</h4>
+              <p>List YAML pipelines</p>
+              <div class="tags"><span>pipelines</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline list</span></div>
+                <pre class="term-body">ID             NAME                   PROJECT         JOBS
 MyApp_CI       CI                     My Application  2
 MyApp_Release  Release                My Application  4
 MyApp_Nightly  Nightly                My Application  3
 Infra_Deploy   Infrastructure Deploy  Infrastructure  2
-Frontend_CI    Frontend CI            Frontend        3</pre></div></div>
-    </div>
-    <div class="screen" id="pipeline-view">
-      <div class="screen-header"><h3>pipeline view</h3><p>View pipeline details and jobs</p></div>
-      <div class="screen-cmd">teamcity pipeline view MyApp_CI</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg36">CI</span>
+Frontend_CI    Frontend CI            Frontend        3</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pipeline-view" data-cmd="pipeline-view" data-search="pipeline-view pipeline view view pipeline details and jobs teamcity pipeline view myapp_ci">
+            <div class="entry-meta">
+              <div class="id">pipeline-view</div>
+              <h4>pipeline view</h4>
+              <p>View pipeline details and jobs</p>
+              <div class="tags"><span>pipelines</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline view MyApp_CI</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline view MyApp_CI</span></div>
+                <pre class="term-body"><span class="term-fg36">CI</span>
 ID: MyApp_CI
 Project: My Application (MyApp)
 Head Job: MyApp_CI
 &nbsp;
   <span class="term-fg36">Jobs</span> (2):
     <span class="term-fg2">build  </span> Build
-    <span class="term-fg2">test   </span> Test</pre></div></div>
-    </div>
-    <div class="screen" id="pipeline-validate">
-      <div class="screen-header"><h3>pipeline validate</h3><p>Validate pipeline YAML</p></div>
-      <div class="screen-cmd">teamcity pipeline validate .teamcity.yml</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> &#47;var&#47;folders&#47;4y&#47;7q13x9990bv9hf94lw6g4ptm0000gn&#47;T&#47;TestGenerateGallery2417321501&#47;001&#47;436233947.teamcity.yml is valid
-  Jobs: build, test</pre></div></div>
-    </div>
-    <div class="screen" id="pipeline-delete">
-      <div class="screen-header"><h3>pipeline delete</h3><p>Delete a pipeline</p></div>
-      <div class="screen-cmd">teamcity pipeline delete --yes MyApp_CI</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Deleted pipeline &quot;CI&quot; (MyApp_CI)</pre></div></div>
-    </div>
-    <div class="screen" id="pipeline-push">
-      <div class="screen-header"><h3>pipeline push</h3><p>Upload YAML to a pipeline</p></div>
-      <div class="screen-cmd">teamcity pipeline push MyApp_CI .teamcity.yml</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Updated pipeline MyApp_CI from .teamcity.yml</pre></div></div>
-    </div>
-    <div class="screen" id="pipeline-pull">
-      <div class="screen-header"><h3>pipeline pull</h3><p>Download pipeline YAML</p></div>
-      <div class="screen-cmd">teamcity pipeline pull MyApp_CI</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Saved pipeline MyApp_CI to .teamcity.yml</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="auth">
-    <h2>Auth</h2>
-    <div class="screens">
-    <div class="screen" id="auth-status">
-      <div class="screen-header"><h3>auth status</h3><p>Authentication status</p></div>
-      <div class="screen-cmd">teamcity auth status</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Logged in to <span class="term-fg36">https:&#47;&#47;tc.example.com</span>
-  User: Administrator (admin) · environment variable
-  Server: TeamCity 2025.7 (build 197398)
-  <span class="term-fg32">✓</span> API compatible</pre></div></div>
-    </div>
-    <div class="screen" id="auth-status-multi">
-      <div class="screen-header"><h3>auth status (multi-server)</h3><p>Multi-server authentication status</p></div>
-      <div class="screen-cmd">teamcity auth status</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Logged in to <span class="term-fg36">https:&#47;&#47;tc.example.com</span> <span class="term-fg2">(default)</span>
-  User: Administrator (admin) · system keyring
+    <span class="term-fg2">test   </span> Test</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pipeline-create" data-cmd="pipeline-create" data-search="pipeline-create pipeline create create a new pipeline from yaml teamcity pipeline create onboarding --project myapp --vcs-root myapp_mainrepo --file .teamcity.yml">
+            <div class="entry-meta">
+              <div class="id">pipeline-create</div>
+              <h4>pipeline create</h4>
+              <p>Create a new pipeline from YAML</p>
+              <div class="tags"><span>pipelines</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline create Onboarding --project MyApp --vcs-root MyApp_MainRepo --file .teamcity.yml</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline create Onboarding --project MyApp --vcs-root MyApp_MainRepo --file .teamcity.yml</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Created pipeline &quot;Onboarding&quot; (MyApp_Onboarding)
+  https:&#47;&#47;tc.example.com&#47;pipeline&#47;MyApp_Onboarding</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pipeline-validate" data-cmd="pipeline-validate" data-search="pipeline-validate pipeline validate validate pipeline yaml teamcity pipeline validate .teamcity.yml">
+            <div class="entry-meta">
+              <div class="id">pipeline-validate</div>
+              <h4>pipeline validate</h4>
+              <p>Validate pipeline YAML</p>
+              <div class="tags"><span>pipelines</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline validate .teamcity.yml</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline validate .teamcity.yml</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> .teamcity.yml is valid
+  Jobs: build, test</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pipeline-delete" data-cmd="pipeline-delete" data-search="pipeline-delete pipeline delete delete a pipeline teamcity pipeline delete --yes myapp_ci">
+            <div class="entry-meta">
+              <div class="id">pipeline-delete</div>
+              <h4>pipeline delete</h4>
+              <p>Delete a pipeline</p>
+              <div class="tags"><span>pipelines</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline delete --yes MyApp_CI</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline delete --yes MyApp_CI</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Deleted pipeline &quot;CI&quot; (MyApp_CI)</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pipeline-push" data-cmd="pipeline-push" data-search="pipeline-push pipeline push upload yaml to a pipeline teamcity pipeline push myapp_ci .teamcity.yml">
+            <div class="entry-meta">
+              <div class="id">pipeline-push</div>
+              <h4>pipeline push</h4>
+              <p>Upload YAML to a pipeline</p>
+              <div class="tags"><span>pipelines</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline push MyApp_CI .teamcity.yml</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline push MyApp_CI .teamcity.yml</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Updated pipeline MyApp_CI</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="pipeline-pull" data-cmd="pipeline-pull" data-search="pipeline-pull pipeline pull download pipeline yaml teamcity pipeline pull myapp_ci">
+            <div class="entry-meta">
+              <div class="id">pipeline-pull</div>
+              <h4>pipeline pull</h4>
+              <p>Download pipeline YAML</p>
+              <div class="tags"><span>pipelines</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline pull MyApp_CI</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline pull MyApp_CI</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Written to .teamcity.yml</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-auth" data-grp="auth">
+        <div class="section-head">
+          <div class="section-num">§ 09</div>
+          <div class="section-name">Auth</div>
+          <div class="section-blurb">Login, logout, multi-server status.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="auth-status" data-cmd="auth-status" data-search="auth-status auth status authentication status teamcity auth status">
+            <div class="entry-meta">
+              <div class="id">auth-status</div>
+              <h4>auth status</h4>
+              <p>Authentication status</p>
+              <div class="tags"><span>auth</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity auth status</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity auth status</span></div>
+                <pre class="term-body">&nbsp;
+<span class="term-fg32">✓</span> Logged in to <span class="term-fg36">https:&#47;&#47;tc.example.com</span>
+  <span class="term-fg2">User:</span> Administrator (admin) <span class="term-fg2">·</span> <span class="term-fg2">environment variable</span>
+  <span class="term-fg2">Server: TeamCity 2025.7 (build 197398)</span>
+  <span class="term-fg32">✓</span> <span class="term-fg2">API compatible</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="auth-status-multi" data-cmd="auth-status-multi" data-search="auth-status-multi auth status (multi-server) multi-server authentication status teamcity auth status">
+            <div class="entry-meta">
+              <div class="id">auth-status-multi</div>
+              <h4>auth status (multi-server)</h4>
+              <p>Multi-server authentication status</p>
+              <div class="tags"><span>auth</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity auth status</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity auth status</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Logged in to <span class="term-fg36">https:&#47;&#47;tc.example.com</span> <span class="term-fg2">(default)</span>
+  <span class="term-fg2">User:</span> Viktor Tiulpin (vtiulpin) <span class="term-fg2">·</span> <span class="term-fg2">system keyring</span>
   Token expires: Dec 31, 2026
-  Server: TeamCity 2025.7 (build 197398)
-  <span class="term-fg32">✓</span> API compatible
+  <span class="term-fg2">Server: TeamCity 2025.7 (build 197398)</span>
+  <span class="term-fg32">✓</span> <span class="term-fg2">API compatible</span>
 &nbsp;
 <span class="term-fg32">✓</span> Guest access to <span class="term-fg36">https:&#47;&#47;staging.tc.example.com</span>
-  Server: TeamCity 2025.7 (build 197398)
-  <span class="term-fg32">✓</span> API compatible
+  <span class="term-fg2">Server: TeamCity 2025.7 (build 197398)</span>
+  <span class="term-fg32">✓</span> <span class="term-fg2">API compatible</span>
 &nbsp;
-<span class="term-fg31">✗</span> <span class="term-fg36">https:&#47;&#47;legacy.tc.example.com</span>
+<span class="term-fg32">✓</span> Logged in to <span class="term-fg36">https:&#47;&#47;legacy.tc.example.com</span>
+  <span class="term-fg2">User:</span> Viktor Tiulpin (vtiulpin) <span class="term-fg2">·</span> <span class="term-fg2">system keyring</span>
   <span class="term-fg31">✗</span> Token expired on Mar 15, 2025
-  Server: TeamCity 2024.3 (build 185432)
-  <span class="term-fg33">!</span> CLI requires TeamCity 2024.7 or later</pre></div></div>
-    </div>
-    <div class="screen" id="auth-login">
-      <div class="screen-header"><h3>auth login</h3><p>Interactive authentication flow (browser-based PKCE)</p></div>
-      <div class="screen-cmd">teamcity auth login</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Secure browser login available on this server
+  Run <span class="term-fg36">teamcity auth login</span> to re-authenticate
+  <span class="term-fg2">Server: TeamCity 2024.3 (build 185432)</span>
+  <span class="term-fg33">!</span> CLI requires TeamCity 2024.7 or later</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="auth-login" data-cmd="auth-login" data-search="auth-login auth login interactive authentication flow (browser-based pkce) teamcity auth login">
+            <div class="entry-meta">
+              <div class="id">auth-login</div>
+              <h4>auth login</h4>
+              <p>Interactive authentication flow (browser-based PKCE)</p>
+              <div class="tags"><span>auth</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity auth login</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity auth login</span></div>
+                <pre class="term-body">Secure browser login available on this server
 Opening browser for authentication...
-→ Approve access in TeamCity
+  <span class="term-fg33">→</span> Approve access in TeamCity
 &nbsp;
-<span class="term-fg32">✓</span> Validated
-<span class="term-fg32">✓</span> Logged in as <span class="term-fg36">Viktor Tiulpin</span> (vtiulpin)
+<span class="term-fg32">✓</span>
+<span class="term-fg32">✓</span> Logged in as <span class="term-fg36">Viktor Tiulpin</span>
 <span class="term-fg32">✓</span> Token stored in system keyring
-  Token expires: Dec 31, 2026
-  Server: TeamCity 2025.7 (build 197398)
-  <span class="term-fg32">✓</span> API compatible</pre></div></div>
-    </div>
-    <div class="screen" id="auth-logout">
-      <div class="screen-header"><h3>auth logout</h3><p>Log out from a server</p></div>
-      <div class="screen-cmd">teamcity auth logout</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Logged out from https:&#47;&#47;tc.example.com</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="config">
-    <h2>Config</h2>
-    <div class="screens">
-    <div class="screen" id="config-list">
-      <div class="screen-header"><h3>config list</h3><p>Show full CLI configuration</p></div>
-      <div class="screen-cmd">teamcity config list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg2">Config:</span> ~&#47;.config&#47;tc&#47;config.yml
+Token expires: <span class="term-fg33">Dec 31, 2026</span></pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="auth-logout" data-cmd="auth-logout" data-search="auth-logout auth logout log out from a server teamcity auth logout">
+            <div class="entry-meta">
+              <div class="id">auth-logout</div>
+              <h4>auth logout</h4>
+              <p>Log out from a server</p>
+              <div class="tags"><span>auth</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity auth logout</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity auth logout</span></div>
+                <pre class="term-body">Logged out from https:&#47;&#47;tc.example.com</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-config" data-grp="config">
+        <div class="section-head">
+          <div class="section-num">§ 10</div>
+          <div class="section-name">Config</div>
+          <div class="section-blurb">CLI configuration values.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="config-list" data-cmd="config-list" data-search="config-list config list show full cli configuration teamcity config list">
+            <div class="entry-meta">
+              <div class="id">config-list</div>
+              <h4>config list</h4>
+              <p>Show full CLI configuration</p>
+              <div class="tags"><span>config</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity config list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity config list</span></div>
+                <pre class="term-body"><span class="term-fg2">Config:</span> ~&#47;.config&#47;tc&#47;config.yml
 &nbsp;
 default_server=https:&#47;&#47;tc.example.com
 &nbsp;
@@ -1234,10 +3357,7 @@ https:&#47;&#47;tc.example.com<span class="term-fg2"> (default)</span>
 https:&#47;&#47;staging.tc.example.com
   guest=false
   ro=false
-&nbsp;
-https:&#47;&#47;tc.example.com
-  guest=false
-  ro=false
+  token_expiry=2026-05-17T14:39:53.398Z
 &nbsp;
 https:&#47;&#47;ai.tc.example.com
   guest=false
@@ -1252,173 +3372,451 @@ https:&#47;&#47;nightly.tc.example.com
 &nbsp;
 <span class="term-fg2">Environment overrides:</span>
   <span class="term-fg33">!</span> TEAMCITY_TOKEN=****
-  <span class="term-fg33">!</span> TEAMCITY_URL=https:&#47;&#47;tc.example.com</pre></div></div>
-    </div>
-    <div class="screen" id="config-get">
-      <div class="screen-header"><h3>config get</h3><p>Get a config value</p></div>
-      <div class="screen-cmd">teamcity config get default_server</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>https:&#47;&#47;tc.example.com</pre></div></div>
-    </div>
-    <div class="screen" id="config-set">
-      <div class="screen-header"><h3>config set</h3><p>Set a config value</p></div>
-      <div class="screen-cmd">teamcity config set default_server https://tc.example.com</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Set default_server to &quot;https:&#47;&#47;tc.example.com&quot;</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="aliases">
-    <h2>Aliases</h2>
-    <div class="screens">
-    <div class="screen" id="alias-list">
-      <div class="screen-header"><h3>alias list</h3><p>List configured command aliases</p></div>
-      <div class="screen-cmd">teamcity alias list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>NAME       EXPANSION  TYPE
+  <span class="term-fg33">!</span> TEAMCITY_URL=https:&#47;&#47;tc.example.com</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="config-get" data-cmd="config-get" data-search="config-get config get get a config value teamcity config get default_server">
+            <div class="entry-meta">
+              <div class="id">config-get</div>
+              <h4>config get</h4>
+              <p>Get a config value</p>
+              <div class="tags"><span>config</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity config get default_server</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity config get default_server</span></div>
+                <pre class="term-body">https:&#47;&#47;tc.example.com</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="config-set" data-cmd="config-set" data-search="config-set config set set a config value teamcity config set default_server https://tc.example.com">
+            <div class="entry-meta">
+              <div class="id">config-set</div>
+              <h4>config set</h4>
+              <p>Set a config value</p>
+              <div class="tags"><span>config</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity config set default_server https://tc.example.com</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity config set default_server https://tc.example.com</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Set default_server to &quot;https:&#47;&#47;tc.example.com&quot;</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-aliases" data-grp="aliases">
+        <div class="section-head">
+          <div class="section-num">§ 11</div>
+          <div class="section-name">Aliases</div>
+          <div class="section-blurb">Command shortcuts.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="alias-list" data-cmd="alias-list" data-search="alias-list alias list list configured command aliases teamcity alias list">
+            <div class="entry-meta">
+              <div class="id">alias-list</div>
+              <h4>alias list</h4>
+              <p>List configured command aliases</p>
+              <div class="tags"><span>aliases</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity alias list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity alias list</span></div>
+                <pre class="term-body">NAME       EXPANSION  TYPE
 build      run        built-in
 buildtype  job        built-in
-testing    run        expansion</pre></div></div>
-    </div>
-    <div class="screen" id="alias-set">
-      <div class="screen-header"><h3>alias set</h3><p>Create or update an alias</p></div>
-      <div class="screen-cmd">teamcity alias set mybuilds &#34;run list&#34;</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Added alias &quot;mybuilds&quot;</pre></div></div>
-    </div>
-    <div class="screen" id="alias-delete">
-      <div class="screen-header"><h3>alias delete</h3><p>Remove an alias</p></div>
-      <div class="screen-cmd">teamcity alias delete mybuilds</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Deleted alias &quot;mybuilds&quot;</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="skills">
-    <h2>Skills</h2>
-    <div class="screens">
-    <div class="screen" id="skill-list">
-      <div class="screen-header"><h3>skill list</h3><p>List available AI agent skills</p></div>
-      <div class="screen-cmd">teamcity skill list</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Name          Version  Description
-teamcity-cli  0.9.0    Use when working with TeamCity CI&#47;CD or when user provides a TeamCity build URL. Use `teamcity` CLI for builds, logs, jobs, queues, agents, and pipelines.  (default)</pre></div></div>
-    </div>
-    <div class="screen" id="skill-install">
-      <div class="screen-header"><h3>skill install</h3><p>Install a skill</p></div>
-      <div class="screen-cmd">teamcity skill install teamcity-cli</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Installed teamcity-cli for claude-code (0.9.0)
+testing    run        expansion</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="alias-set" data-cmd="alias-set" data-search="alias-set alias set create or update an alias teamcity alias set mybuilds &#34;run list&#34;">
+            <div class="entry-meta">
+              <div class="id">alias-set</div>
+              <h4>alias set</h4>
+              <p>Create or update an alias</p>
+              <div class="tags"><span>aliases</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity alias set mybuilds &#34;run list&#34;</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity alias set mybuilds &#34;run list&#34;</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Added alias &quot;mybuilds&quot;</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="alias-delete" data-cmd="alias-delete" data-search="alias-delete alias delete remove an alias teamcity alias delete mybuilds">
+            <div class="entry-meta">
+              <div class="id">alias-delete</div>
+              <h4>alias delete</h4>
+              <p>Remove an alias</p>
+              <div class="tags"><span>aliases</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity alias delete mybuilds</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity alias delete mybuilds</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Deleted alias &quot;mybuilds&quot;</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-skills" data-grp="skills">
+        <div class="section-head">
+          <div class="section-num">§ 12</div>
+          <div class="section-name">Skills</div>
+          <div class="section-blurb">AI coding agent skills: install, update, remove.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="skill-list" data-cmd="skill-list" data-search="skill-list skill list list available ai agent skills teamcity skill list">
+            <div class="entry-meta">
+              <div class="id">skill-list</div>
+              <h4>skill list</h4>
+              <p>List available AI agent skills</p>
+              <div class="tags"><span>skills</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity skill list</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity skill list</span></div>
+                <pre class="term-body">Name          Version  Description
+teamcity-cli  0.9.0    Use when working with TeamCity CI&#47;CD or when user provides a TeamCity build URL. Use `teamcity` CLI for builds, logs, jobs, queues, agents, and pipelines.  (default)</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="skill-install" data-cmd="skill-install" data-search="skill-install skill install install a skill teamcity skill install teamcity-cli">
+            <div class="entry-meta">
+              <div class="id">skill-install</div>
+              <h4>skill install</h4>
+              <p>Install a skill</p>
+              <div class="tags"><span>skills</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity skill install teamcity-cli</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity skill install teamcity-cli</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Installed teamcity-cli for warp (0.9.0)
+<span class="term-fg32">✓</span> Installed teamcity-cli for claude-code (0.9.0)
 <span class="term-fg32">✓</span> Installed teamcity-cli for codex (0.9.0)
 <span class="term-fg32">✓</span> Installed teamcity-cli for opencode (0.9.0)
 <span class="term-fg32">✓</span> Installed teamcity-cli for cursor (0.9.0)
 <span class="term-fg32">✓</span> Installed teamcity-cli for antigravity (0.9.0)
 <span class="term-fg32">✓</span> Installed teamcity-cli for gemini-cli (0.9.0)
-<span class="term-fg32">✓</span> Installed teamcity-cli for junie (0.9.0)</pre></div></div>
-    </div>
-    <div class="screen" id="skill-update">
-      <div class="screen-header"><h3>skill update</h3><p>Update installed skills</p></div>
-      <div class="screen-cmd">teamcity skill update</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Skill teamcity-cli already up to date (0.9.0)</pre></div></div>
-    </div>
-    <div class="screen" id="skill-remove">
-      <div class="screen-header"><h3>skill remove</h3><p>Remove an installed skill</p></div>
-      <div class="screen-cmd">teamcity skill remove teamcity-cli</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre><span class="term-fg32">✓</span> Removed teamcity-cli from claude-code
+<span class="term-fg32">✓</span> Installed teamcity-cli for junie (0.9.0)</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="skill-update" data-cmd="skill-update" data-search="skill-update skill update update installed skills teamcity skill update">
+            <div class="entry-meta">
+              <div class="id">skill-update</div>
+              <h4>skill update</h4>
+              <p>Update installed skills</p>
+              <div class="tags"><span>skills</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity skill update</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity skill update</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Skill teamcity-cli already up to date (0.9.0)</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="skill-remove" data-cmd="skill-remove" data-search="skill-remove skill remove remove an installed skill teamcity skill remove teamcity-cli">
+            <div class="entry-meta">
+              <div class="id">skill-remove</div>
+              <h4>skill remove</h4>
+              <p>Remove an installed skill</p>
+              <div class="tags"><span>skills</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity skill remove teamcity-cli</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity skill remove teamcity-cli</span></div>
+                <pre class="term-body"><span class="term-fg32">✓</span> Removed teamcity-cli from warp
+<span class="term-fg32">✓</span> Removed teamcity-cli from claude-code
 <span class="term-fg32">✓</span> Removed teamcity-cli from codex
 <span class="term-fg32">✓</span> Removed teamcity-cli from opencode
 <span class="term-fg32">✓</span> Removed teamcity-cli from cursor
 <span class="term-fg32">✓</span> Removed teamcity-cli from antigravity
 <span class="term-fg32">✓</span> Removed teamcity-cli from gemini-cli
-<span class="term-fg32">✓</span> Removed teamcity-cli from junie</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="api">
-    <h2>API</h2>
-    <div class="screens">
-    <div class="screen" id="api-get">
-      <div class="screen-header"><h3>api</h3><p>Make raw REST API requests</p></div>
-      <div class="screen-cmd">teamcity api /app/rest/server</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>{
+<span class="term-fg32">✓</span> Removed teamcity-cli from junie</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-api" data-grp="api">
+        <div class="section-head">
+          <div class="section-num">§ 13</div>
+          <div class="section-name">API</div>
+          <div class="section-blurb">Raw authenticated REST calls.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="api-get" data-cmd="api-get" data-search="api-get api make raw rest api requests teamcity api /app/rest/server">
+            <div class="entry-meta">
+              <div class="id">api-get</div>
+              <h4>api</h4>
+              <p>Make raw REST API requests</p>
+              <div class="tags"><span>api</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity api /app/rest/server</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity api /app/rest/server</span></div>
+                <pre class="term-body">{
   &quot;buildNumber&quot;: &quot;197398&quot;,
   &quot;version&quot;: &quot; (build 197398)&quot;,
   &quot;versionMajor&quot;: 2025,
   &quot;versionMinor&quot;: 7,
   &quot;webUrl&quot;: &quot;https:&#47;&#47;tc.example.com&quot;
-}</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="update">
-    <h2>Update</h2>
-    <div class="screens">
-    <div class="screen" id="update">
-      <div class="screen-header"><h3>update</h3><p>Check for CLI updates</p></div>
-      <div class="screen-cmd">teamcity update</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Checking for updates...
+}</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-update" data-grp="update">
+        <div class="section-head">
+          <div class="section-num">§ 14</div>
+          <div class="section-name">Update</div>
+          <div class="section-blurb">Check for new CLI releases.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="update" data-cmd="update" data-search="update update check for cli updates teamcity update">
+            <div class="entry-meta">
+              <div class="id">update</div>
+              <h4>update</h4>
+              <p>Check for CLI updates</p>
+              <div class="tags"><span>update</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity update</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity update</span></div>
+                <pre class="term-body">Checking for updates...
 <span class="term-fg2">vdev</span> → <span class="term-fg32">v0.9.0</span>: <span class="term-fg1">Visit https:&#47;&#47;github.com&#47;JetBrains&#47;teamcity-cli&#47;releases&#47;latest</span>
-<span class="term-fg2">https:&#47;&#47;github.com&#47;JetBrains&#47;teamcity-cli&#47;releases&#47;tag&#47;v0.9.0</span></pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="errors">
-    <h2>Errors</h2>
-    <div class="screens">
-    <div class="screen" id="error-not-found">
-      <div class="screen-header"><h3>Not Found</h3><p>Resource not found with contextual hint</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Error: not found: No build found by locator &#39;id:999999&#39;
+<span class="term-fg2">https:&#47;&#47;github.com&#47;JetBrains&#47;teamcity-cli&#47;releases&#47;tag&#47;v0.9.0</span></pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-errors" data-grp="errors">
+        <div class="section-head">
+          <div class="section-num">§ 15</div>
+          <div class="section-name">Errors</div>
+          <div class="section-blurb">Error message shapes and hints.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="error-not-found" data-cmd="error-not-found" data-search="error-not-found not found resource not found with contextual hint ">
+            <div class="entry-meta">
+              <div class="id">error-not-found</div>
+              <h4>Not Found</h4>
+              <p>Resource not found with contextual hint</p>
+              <div class="tags"><span>errors</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Not Found</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">Error: run &#39;999999&#39; not found
 &nbsp;
-Hint: Use &#39;teamcity run list&#39; to see available resources</pre></div></div>
-    </div>
-    <div class="screen" id="error-auth">
-      <div class="screen-header"><h3>Authentication Failed</h3><p>Invalid or expired token</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Error: Authentication failed: invalid or expired token
+Hint: Use &#39;teamcity run list&#39; to see available resources</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="error-auth" data-cmd="error-auth" data-search="error-auth authentication failed invalid or expired token ">
+            <div class="entry-meta">
+              <div class="id">error-auth</div>
+              <h4>Authentication Failed</h4>
+              <p>Invalid or expired token</p>
+              <div class="tags"><span>errors</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Authentication Failed</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">Error: Authentication failed: invalid or expired token
 &nbsp;
-Hint: Run &#39;teamcity auth login&#39; to re-authenticate</pre></div></div>
-    </div>
-    <div class="screen" id="error-permission">
-      <div class="screen-header"><h3>Permission Denied</h3><p>Insufficient permissions</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Error: permission denied: You do not have &quot;Run build&quot; permission
+Hint: Run &#39;teamcity auth login&#39; to re-authenticate</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="error-permission" data-cmd="error-permission" data-search="error-permission permission denied insufficient permissions ">
+            <div class="entry-meta">
+              <div class="id">error-permission</div>
+              <h4>Permission Denied</h4>
+              <p>Insufficient permissions</p>
+              <div class="tags"><span>errors</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Permission Denied</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">Error: permission denied: cannot reboot agent
 &nbsp;
-Hint: Check your TeamCity permissions or contact your administrator</pre></div></div>
-    </div>
-    <div class="screen" id="error-network">
-      <div class="screen-header"><h3>Network Error</h3><p>Cannot reach the server</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Error: network error: dial tcp: lookup tc.example.com: no such host
+Hint: Check your TeamCity permissions or contact your administrator</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="error-network" data-cmd="error-network" data-search="error-network network error cannot reach the server ">
+            <div class="entry-meta">
+              <div class="id">error-network</div>
+              <h4>Network Error</h4>
+              <p>Cannot reach the server</p>
+              <div class="tags"><span>errors</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Network Error</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">Error: cannot connect to https:&#47;&#47;tc.example.com: dial tcp: lookup tc.example.com: no such host
 &nbsp;
-Hint: Check your network connection and verify the server URL</pre></div></div>
-    </div>
-    <div class="screen" id="error-readonly">
-      <div class="screen-header"><h3>Read-Only Mode</h3><p>Write operation blocked by TEAMCITY_RO</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Error: read-only mode: POST &#47;app&#47;rest&#47;buildQueue is not allowed
+Hint: Check your network connection and verify the server URL</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="error-readonly" data-cmd="error-readonly" data-search="error-readonly read-only mode write operation blocked by teamcity_ro ">
+            <div class="entry-meta">
+              <div class="id">error-readonly</div>
+              <h4>Read-Only Mode</h4>
+              <p>Write operation blocked by TEAMCITY_RO</p>
+              <div class="tags"><span>errors</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">Read-Only Mode</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">Error: read-only mode: write operations are not allowed: POST &#47;app&#47;rest&#47;buildQueue
 &nbsp;
-Hint: Unset the TEAMCITY_RO environment variable to allow write operations</pre></div></div>
-    </div>
-    <div class="screen" id="error-json">
-      <div class="screen-header"><h3>JSON Error Format</h3><p>Structured error with --json flag</p></div>
-      
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>{
+Hint: Unset TEAMCITY_RO to allow write operations</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="error-json" data-cmd="error-json" data-search="error-json json error format structured error with --json flag ">
+            <div class="entry-meta">
+              <div class="id">error-json</div>
+              <h4>JSON Error Format</h4>
+              <p>Structured error with --json flag</p>
+              <div class="tags"><span>errors</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">JSON Error Format</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                
+                <pre class="term-body no-prompt">{
   &quot;error&quot;: {
     &quot;code&quot;: &quot;not_found&quot;,
-    &quot;message&quot;: &quot;not found: No build found by locator &#39;id:999999&#39;&quot;,
+    &quot;message&quot;: &quot;run &#39;999999&#39; not found&quot;,
     &quot;suggestion&quot;: &quot;Use &#39;teamcity run list&#39; to see available resources&quot;
   }
-}</pre></div></div>
-    </div>
-    
-    </div>
-  </section>
-  <section class="category" id="help">
-    <h2>Help Screens</h2>
-    <div class="screens">
-    <div class="screen" id="help-root">
-      <div class="screen-header"><h3>teamcity</h3><p>Root command — shows logo and common commands</p></div>
-      <div class="screen-cmd">teamcity  --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>TeamCity CLI vdev
+}</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      <section class="section" id="section-help" data-grp="help">
+        <div class="section-head">
+          <div class="section-num">§ 16</div>
+          <div class="section-name">Help Screens</div>
+          <div class="section-blurb">Built-in --help output for every command group.</div>
+        </div>
+        <div class="entries">
+          <article class="entry" id="help-root" data-cmd="help-root" data-search="help-root teamcity root command — shows logo and common commands teamcity  --help">
+            <div class="entry-meta">
+              <div class="id">help-root</div>
+              <h4>teamcity</h4>
+              <p>Root command — shows logo and common commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity  --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity  --help</span></div>
+                <pre class="term-body">TeamCity CLI vdev
 &nbsp;
 A command-line interface for interacting with TeamCity CI&#47;CD server.
 &nbsp;
@@ -1458,12 +3856,26 @@ Flags:
   -V, --verbose    Show detailed output including debug info
   -v, --version    version for teamcity
 &nbsp;
-Use &quot;teamcity [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-run">
-      <div class="screen-header"><h3>run</h3><p>Run (build) management commands</p></div>
-      <div class="screen-cmd">teamcity run --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List, view, start, and manage TeamCity runs (builds).
+Use &quot;teamcity [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-run" data-cmd="help-run" data-search="help-run run run (build) management commands teamcity run --help">
+            <div class="entry-meta">
+              <div class="id">help-run</div>
+              <h4>run</h4>
+              <p>Run (build) management commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity run --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity run --help</span></div>
+                <pre class="term-body">List, view, start, and manage TeamCity runs (builds).
 &nbsp;
 Usage:
   teamcity run [flags]
@@ -1502,12 +3914,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity run [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-job">
-      <div class="screen-header"><h3>job</h3><p>Job (build configuration) commands</p></div>
-      <div class="screen-cmd">teamcity job --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List and manage TeamCity jobs (build configurations).
+Use &quot;teamcity run [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-job" data-cmd="help-job" data-search="help-job job job (build configuration) commands teamcity job --help">
+            <div class="entry-meta">
+              <div class="id">help-job</div>
+              <h4>job</h4>
+              <p>Job (build configuration) commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job --help</span></div>
+                <pre class="term-body">List and manage TeamCity jobs (build configurations).
 &nbsp;
 Usage:
   teamcity job [flags]
@@ -1534,12 +3960,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity job [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-agent">
-      <div class="screen-header"><h3>agent</h3><p>Build agent commands</p></div>
-      <div class="screen-cmd">teamcity agent --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List, view, and manage TeamCity build agents.
+Use &quot;teamcity job [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-agent" data-cmd="help-agent" data-search="help-agent agent build agent commands teamcity agent --help">
+            <div class="entry-meta">
+              <div class="id">help-agent</div>
+              <h4>agent</h4>
+              <p>Build agent commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity agent --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity agent --help</span></div>
+                <pre class="term-body">List, view, and manage TeamCity build agents.
 &nbsp;
 Usage:
   teamcity agent [flags]
@@ -1568,12 +4008,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity agent [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-queue">
-      <div class="screen-header"><h3>queue</h3><p>Build queue commands</p></div>
-      <div class="screen-cmd">teamcity queue --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List and manage the TeamCity build queue.
+Use &quot;teamcity agent [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-queue" data-cmd="help-queue" data-search="help-queue queue build queue commands teamcity queue --help">
+            <div class="entry-meta">
+              <div class="id">help-queue</div>
+              <h4>queue</h4>
+              <p>Build queue commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity queue --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity queue --help</span></div>
+                <pre class="term-body">List and manage the TeamCity build queue.
 &nbsp;
 Usage:
   teamcity queue [flags]
@@ -1595,12 +4049,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity queue [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-pool">
-      <div class="screen-header"><h3>pool</h3><p>Agent pool commands</p></div>
-      <div class="screen-cmd">teamcity pool --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List agent pools and manage project assignments.
+Use &quot;teamcity queue [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-pool" data-cmd="help-pool" data-search="help-pool pool agent pool commands teamcity pool --help">
+            <div class="entry-meta">
+              <div class="id">help-pool</div>
+              <h4>pool</h4>
+              <p>Agent pool commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pool --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pool --help</span></div>
+                <pre class="term-body">List agent pools and manage project assignments.
 &nbsp;
 Usage:
   teamcity pool [flags]
@@ -1622,12 +4090,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity pool [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project">
-      <div class="screen-header"><h3>project</h3><p>Project management commands</p></div>
-      <div class="screen-cmd">teamcity project --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List and view TeamCity projects.
+Use &quot;teamcity pool [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project" data-cmd="help-project" data-search="help-project project project management commands teamcity project --help">
+            <div class="entry-meta">
+              <div class="id">help-project</div>
+              <h4>project</h4>
+              <p>Project management commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project --help</span></div>
+                <pre class="term-body">List and view TeamCity projects.
 &nbsp;
 Usage:
   teamcity project [flags]
@@ -1655,12 +4137,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-pipeline">
-      <div class="screen-header"><h3>pipeline</h3><p>YAML pipeline commands</p></div>
-      <div class="screen-cmd">teamcity pipeline --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List, view, validate, and manage TeamCity pipelines.
+Use &quot;teamcity project [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-pipeline" data-cmd="help-pipeline" data-search="help-pipeline pipeline yaml pipeline commands teamcity pipeline --help">
+            <div class="entry-meta">
+              <div class="id">help-pipeline</div>
+              <h4>pipeline</h4>
+              <p>YAML pipeline commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity pipeline --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity pipeline --help</span></div>
+                <pre class="term-body">List, view, validate, and manage TeamCity pipelines.
 &nbsp;
 Usage:
   teamcity pipeline [flags]
@@ -1685,12 +4181,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity pipeline [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-auth">
-      <div class="screen-header"><h3>auth</h3><p>Authentication commands</p></div>
-      <div class="screen-cmd">teamcity auth --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Manage authentication state for TeamCity servers.
+Use &quot;teamcity pipeline [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-auth" data-cmd="help-auth" data-search="help-auth auth authentication commands teamcity auth --help">
+            <div class="entry-meta">
+              <div class="id">help-auth</div>
+              <h4>auth</h4>
+              <p>Authentication commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity auth --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity auth --help</span></div>
+                <pre class="term-body">Manage authentication state for TeamCity servers.
 &nbsp;
 Usage:
   teamcity auth [flags]
@@ -1711,12 +4221,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity auth [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-config">
-      <div class="screen-header"><h3>config</h3><p>Configuration commands</p></div>
-      <div class="screen-cmd">teamcity config --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Get, set, and list CLI configuration values.
+Use &quot;teamcity auth [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-config" data-cmd="help-config" data-search="help-config config configuration commands teamcity config --help">
+            <div class="entry-meta">
+              <div class="id">help-config</div>
+              <h4>config</h4>
+              <p>Configuration commands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity config --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity config --help</span></div>
+                <pre class="term-body">Get, set, and list CLI configuration values.
 &nbsp;
 Usage:
   teamcity config [flags]
@@ -1737,12 +4261,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity config [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-alias">
-      <div class="screen-header"><h3>alias</h3><p>Command alias management</p></div>
-      <div class="screen-cmd">teamcity alias --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Create, list, and delete command shortcuts.
+Use &quot;teamcity config [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-alias" data-cmd="help-alias" data-search="help-alias alias command alias management teamcity alias --help">
+            <div class="entry-meta">
+              <div class="id">help-alias</div>
+              <h4>alias</h4>
+              <p>Command alias management</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity alias --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity alias --help</span></div>
+                <pre class="term-body">Create, list, and delete command shortcuts.
 &nbsp;
 Usage:
   teamcity alias [flags]
@@ -1763,12 +4301,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity alias [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-skill">
-      <div class="screen-header"><h3>skill</h3><p>AI agent skill management</p></div>
-      <div class="screen-cmd">teamcity skill --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Install, update, or remove TeamCity skills for AI coding agents (Claude Code, Cursor, etc.).
+Use &quot;teamcity alias [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-skill" data-cmd="help-skill" data-search="help-skill skill ai agent skill management teamcity skill --help">
+            <div class="entry-meta">
+              <div class="id">help-skill</div>
+              <h4>skill</h4>
+              <p>AI agent skill management</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity skill --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity skill --help</span></div>
+                <pre class="term-body">Install, update, or remove TeamCity skills for AI coding agents (Claude Code, Cursor, etc.).
 &nbsp;
 Usage:
   teamcity skill [flags]
@@ -1790,12 +4342,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity skill [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-settings">
-      <div class="screen-header"><h3>project settings</h3><p>Versioned settings subcommands</p></div>
-      <div class="screen-cmd">teamcity project settings --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>View and manage versioned settings (Kotlin DSL) for a project.
+Use &quot;teamcity skill [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-settings" data-cmd="help-project-settings" data-search="help-project-settings project settings versioned settings subcommands teamcity project settings --help">
+            <div class="entry-meta">
+              <div class="id">help-project-settings</div>
+              <h4>project settings</h4>
+              <p>Versioned settings subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project settings --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project settings --help</span></div>
+                <pre class="term-body">View and manage versioned settings (Kotlin DSL) for a project.
 &nbsp;
 Versioned settings allow you to store project configuration as code in a VCS repository.
 This enables version control, code review, and automated deployment of CI&#47;CD configuration.
@@ -1821,12 +4387,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project settings [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-vcs">
-      <div class="screen-header"><h3>project vcs</h3><p>VCS root subcommands</p></div>
-      <div class="screen-cmd">teamcity project vcs --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List, view, create, test, and delete VCS roots in a project.
+Use &quot;teamcity project settings [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-vcs" data-cmd="help-project-vcs" data-search="help-project-vcs project vcs vcs root subcommands teamcity project vcs --help">
+            <div class="entry-meta">
+              <div class="id">help-project-vcs</div>
+              <h4>project vcs</h4>
+              <p>VCS root subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project vcs --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project vcs --help</span></div>
+                <pre class="term-body">List, view, create, test, and delete VCS roots in a project.
 &nbsp;
 Usage:
   teamcity project vcs [flags]
@@ -1849,12 +4429,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project vcs [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-ssh">
-      <div class="screen-header"><h3>project ssh</h3><p>SSH key subcommands</p></div>
-      <div class="screen-cmd">teamcity project ssh --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List, upload, generate, and delete SSH keys in a project.
+Use &quot;teamcity project vcs [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-ssh" data-cmd="help-project-ssh" data-search="help-project-ssh project ssh ssh key subcommands teamcity project ssh --help">
+            <div class="entry-meta">
+              <div class="id">help-project-ssh</div>
+              <h4>project ssh</h4>
+              <p>SSH key subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project ssh --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project ssh --help</span></div>
+                <pre class="term-body">List, upload, generate, and delete SSH keys in a project.
 &nbsp;
 Usage:
   teamcity project ssh [flags]
@@ -1876,12 +4470,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project ssh [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-connection">
-      <div class="screen-header"><h3>project connection</h3><p>Project connection subcommands</p></div>
-      <div class="screen-cmd">teamcity project connection --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List OAuth and other connections configured in a project.
+Use &quot;teamcity project ssh [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-connection" data-cmd="help-project-connection" data-search="help-project-connection project connection project connection subcommands teamcity project connection --help">
+            <div class="entry-meta">
+              <div class="id">help-project-connection</div>
+              <h4>project connection</h4>
+              <p>Project connection subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project connection --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project connection --help</span></div>
+                <pre class="term-body">List OAuth and other connections configured in a project.
 &nbsp;
 Usage:
   teamcity project connection [flags]
@@ -1900,12 +4508,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project connection [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-cloud">
-      <div class="screen-header"><h3>project cloud</h3><p>Cloud management subcommands</p></div>
-      <div class="screen-cmd">teamcity project cloud --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List and manage cloud profiles, images, and instances for a project.
+Use &quot;teamcity project connection [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-cloud" data-cmd="help-project-cloud" data-search="help-project-cloud project cloud cloud management subcommands teamcity project cloud --help">
+            <div class="entry-meta">
+              <div class="id">help-project-cloud</div>
+              <h4>project cloud</h4>
+              <p>Cloud management subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud --help</span></div>
+                <pre class="term-body">List and manage cloud profiles, images, and instances for a project.
 &nbsp;
 Usage:
   teamcity project cloud [flags]
@@ -1926,12 +4548,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project cloud [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-cloud-profile">
-      <div class="screen-header"><h3>project cloud profile</h3><p>Cloud profile subcommands</p></div>
-      <div class="screen-cmd">teamcity project cloud profile --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Manage cloud profiles
+Use &quot;teamcity project cloud [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-cloud-profile" data-cmd="help-project-cloud-profile" data-search="help-project-cloud-profile project cloud profile cloud profile subcommands teamcity project cloud profile --help">
+            <div class="entry-meta">
+              <div class="id">help-project-cloud-profile</div>
+              <h4>project cloud profile</h4>
+              <p>Cloud profile subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud profile --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud profile --help</span></div>
+                <pre class="term-body">Manage cloud profiles
 &nbsp;
 Usage:
   teamcity project cloud profile [flags]
@@ -1951,12 +4587,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project cloud profile [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-cloud-image">
-      <div class="screen-header"><h3>project cloud image</h3><p>Cloud image subcommands</p></div>
-      <div class="screen-cmd">teamcity project cloud image --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Manage cloud images
+Use &quot;teamcity project cloud profile [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-cloud-image" data-cmd="help-project-cloud-image" data-search="help-project-cloud-image project cloud image cloud image subcommands teamcity project cloud image --help">
+            <div class="entry-meta">
+              <div class="id">help-project-cloud-image</div>
+              <h4>project cloud image</h4>
+              <p>Cloud image subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud image --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud image --help</span></div>
+                <pre class="term-body">Manage cloud images
 &nbsp;
 Usage:
   teamcity project cloud image [flags]
@@ -1977,12 +4627,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project cloud image [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-cloud-instance">
-      <div class="screen-header"><h3>project cloud instance</h3><p>Cloud instance subcommands</p></div>
-      <div class="screen-cmd">teamcity project cloud instance --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Manage cloud instances
+Use &quot;teamcity project cloud image [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-cloud-instance" data-cmd="help-project-cloud-instance" data-search="help-project-cloud-instance project cloud instance cloud instance subcommands teamcity project cloud instance --help">
+            <div class="entry-meta">
+              <div class="id">help-project-cloud-instance</div>
+              <h4>project cloud instance</h4>
+              <p>Cloud instance subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project cloud instance --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project cloud instance --help</span></div>
+                <pre class="term-body">Manage cloud instances
 &nbsp;
 Usage:
   teamcity project cloud instance [flags]
@@ -2003,12 +4667,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project cloud instance [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-token">
-      <div class="screen-header"><h3>project token</h3><p>Secure token subcommands</p></div>
-      <div class="screen-cmd">teamcity project token --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>Manage secure tokens for versioned settings.
+Use &quot;teamcity project cloud instance [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-token" data-cmd="help-project-token" data-search="help-project-token project token secure token subcommands teamcity project token --help">
+            <div class="entry-meta">
+              <div class="id">help-project-token</div>
+              <h4>project token</h4>
+              <p>Secure token subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project token --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project token --help</span></div>
+                <pre class="term-body">Manage secure tokens for versioned settings.
 &nbsp;
 Secure tokens allow you to store sensitive values (passwords, API keys, etc.)
 in TeamCity&#39;s credentials storage. The scrambled token can be safely committed
@@ -2034,12 +4712,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project token [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-project-param">
-      <div class="screen-header"><h3>project param</h3><p>Project parameter subcommands</p></div>
-      <div class="screen-cmd">teamcity project param --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List, get, set, and delete project parameters.
+Use &quot;teamcity project token [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-project-param" data-cmd="help-project-param" data-search="help-project-param project param project parameter subcommands teamcity project param --help">
+            <div class="entry-meta">
+              <div class="id">help-project-param</div>
+              <h4>project param</h4>
+              <p>Project parameter subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity project param --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity project param --help</span></div>
+                <pre class="term-body">List, get, set, and delete project parameters.
 &nbsp;
 Usage:
   teamcity project param [flags]
@@ -2061,12 +4753,26 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity project param [command] --help&quot; for more information about a command.</pre></div></div>
-    </div>
-    <div class="screen" id="help-job-param">
-      <div class="screen-header"><h3>job param</h3><p>Job parameter subcommands</p></div>
-      <div class="screen-cmd">teamcity job param --help</div>
-      <div class="terminal"><div class="terminal-chrome"><i></i><i></i><i></i></div><div class="terminal-body"><pre>List, get, set, and delete job parameters.
+Use &quot;teamcity project param [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          <article class="entry" id="help-job-param" data-cmd="help-job-param" data-search="help-job-param job param job parameter subcommands teamcity job param --help">
+            <div class="entry-meta">
+              <div class="id">help-job-param</div>
+              <h4>job param</h4>
+              <p>Job parameter subcommands</p>
+              <div class="tags"><span>help</span></div>
+            </div>
+            <div class="entry-term">
+              <div class="term">
+                <div class="term-head">
+                  <div class="term-dots"><i></i><i></i><i></i></div>
+                  <div class="term-title">teamcity job param --help</div>
+                  <div class="term-head-pad"></div>
+                </div>
+                <div class="term-prompt"><span class="p">$</span> <span class="cmd">teamcity job param --help</span></div>
+                <pre class="term-body">List, get, set, and delete job parameters.
 &nbsp;
 Usage:
   teamcity job param [flags]
@@ -2088,57 +4794,114 @@ Global Flags:
   -q, --quiet      Suppress non-essential output
   -V, --verbose    Show detailed output including debug info
 &nbsp;
-Use &quot;teamcity job param [command] --help&quot; for more information about a command.</pre></div></div>
+Use &quot;teamcity job param [command] --help&quot; for more information about a command.</pre>
+              </div>
+            </div>
+          </article>
+          
+        </div>
+      </section>
+      
     </div>
-    
-    </div>
-  </section>
-  
+
+    <footer class="foot">
+      <div>teamcity cli · screen gallery</div>
+      <div>134 screens · 2026-04-18 17:43</div>
+    </footer>
+    <div class="attrib">
+			<span class="jb-wordmark">JetBrains</span>
+			<span class="dot">·</span>
+			<span>Developer Tools</span>
+			<span class="dot">·</span>
+			<span>The Drive to Develop</span>
+			<span style="margin-left:auto">© 2026 JetBrains s.r.o.</span>
+		</div>
+  </main>
 </div>
 
 <script>
 (function(){
-  var s=localStorage.getItem('tc-gallery-theme');
-  if(s){document.documentElement.dataset.theme=s;document.getElementById('theme-label').textContent=s}
-})();
-function toggleTheme(){
-  var t=document.documentElement.dataset.theme==='dark'?'light':'dark';
-  document.documentElement.dataset.theme=t;
-  localStorage.setItem('tc-gallery-theme',t);
-  document.getElementById('theme-label').textContent=t;
-}
-document.addEventListener('click',function(e){
-  var t=e.target.closest('.terminal');
-  if(t){t.classList.toggle('expanded');markOverflows()}
-});
-function markOverflows(){
-  document.querySelectorAll('.terminal').forEach(function(t){
-    t.classList.toggle('overflows',!t.classList.contains('expanded')&&t.scrollHeight>t.clientHeight)
-  });
-}
-window.addEventListener('load',markOverflows);
-window.addEventListener('resize',markOverflows);
+  var D = document.documentElement;
+  var saved = localStorage.getItem('termbook-theme');
+  if (saved) D.setAttribute('data-theme', saved);
+  var tDark = document.getElementById('tDark');
+  var tLight = document.getElementById('tLight');
+  function sync(){
+    var t = D.getAttribute('data-theme');
+    tDark.classList.toggle('active', t === 'dark');
+    tLight.classList.toggle('active', t === 'light');
+    tDark.setAttribute('aria-pressed', t === 'dark');
+    tLight.setAttribute('aria-pressed', t === 'light');
+  }
+  sync();
+  function set(t){ D.setAttribute('data-theme', t); localStorage.setItem('termbook-theme', t); sync(); }
+  tDark.addEventListener('click', function(){ set('dark'); });
+  tLight.addEventListener('click', function(){ set('light'); });
+  function toggleTheme(){ set(D.getAttribute('data-theme') === 'dark' ? 'light' : 'dark'); }
 
- 
-var observer = new IntersectionObserver(function(entries){
-  entries.forEach(function(e){
-    var link = document.querySelector('.sidebar a[data-target="'+e.target.id+'"]');
-    if(link){ link.classList.toggle('active', e.isIntersecting) }
-  });
-}, { rootMargin: '-10% 0px -80% 0px' });
-document.querySelectorAll('.screen[id]').forEach(function(el){ observer.observe(el) });
+  var q = document.getElementById('q');
+  function updateFilter(){
+    var v = q.value.trim().toLowerCase();
+    document.querySelectorAll('.entry').forEach(function(el){
+      var hit = !v || (el.dataset.search || '').includes(v);
+      el.classList.toggle('hidden', !hit);
+    });
+    document.querySelectorAll('.side-nav a').forEach(function(el){
+      var hit = !v || (el.dataset.search || '').includes(v);
+      el.classList.toggle('hidden', !hit);
+    });
+    document.querySelectorAll('.section').forEach(function(sec){
+      var visible = sec.querySelectorAll('.entry:not(.hidden)').length;
+      sec.classList.toggle('empty', visible === 0);
+    });
+    document.querySelectorAll('.side-nav .grp').forEach(function(grp){
+      var visible = grp.querySelectorAll('a:not(.hidden)').length;
+      grp.style.display = visible ? '' : 'none';
+    });
+  }
+  q.addEventListener('input', updateFilter);
 
- 
-var cardObs = new IntersectionObserver(function(entries){
-  entries.forEach(function(e){
-    if(e.isIntersecting){
-      var cards = e.target.querySelectorAll('.screen');
-      cards.forEach(function(c,i){ c.style.animationDelay = (i*0.03)+'s' });
-      cardObs.unobserve(e.target);
+  var sideEl = document.getElementById('side');
+  var navToggle = document.getElementById('navToggle');
+  function setNavOpen(open){
+    sideEl.classList.toggle('nav-open', open);
+    navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+    var icon = navToggle.querySelector('.nav-toggle-icon');
+    var label = navToggle.querySelector('.nav-toggle-label');
+    if (icon) icon.textContent = open ? '✕' : '☰';
+    if (label) label.textContent = open ? 'close' : 'menu';
+  }
+  navToggle.addEventListener('click', function(){
+    setNavOpen(!sideEl.classList.contains('nav-open'));
+  });
+   
+  q.addEventListener('focus', function(){
+    if (window.matchMedia('(max-width: 900px)').matches) setNavOpen(true);
+  });
+   
+  sideEl.addEventListener('click', function(e){
+    if (e.target.closest('.side-nav a') && window.matchMedia('(max-width: 900px)').matches) {
+      setNavOpen(false);
     }
   });
-}, { threshold: 0.1 });
-document.querySelectorAll('.screens').forEach(function(el){ cardObs.observe(el) });
+
+  document.addEventListener('keydown', function(e){
+    if (e.target.tagName === 'INPUT') {
+      if (e.key === 'Escape') { q.value = ''; q.blur(); updateFilter(); }
+      return;
+    }
+    if (e.key === '/') { e.preventDefault(); q.focus(); }
+    else if (e.key === 't' || e.key === 'T') { toggleTheme(); }
+  });
+
+  var obs = new IntersectionObserver(function(entries){
+    entries.forEach(function(e){
+      var link = document.querySelector('.side-nav a[data-cmd="' + e.target.id + '"]');
+      if (link) link.classList.toggle('active', e.isIntersecting);
+    });
+  }, { rootMargin: '-20% 0px -70% 0px' });
+  document.querySelectorAll('.entry[id]').forEach(function(el){ obs.observe(el); });
+})();
 </script>
 </body>
 </html>

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 
 require (
 	github.com/buildkite/terminal-to-html/v3 v3.16.8 // indirect
-	github.com/tiulpin/termbook v0.0.0-20260414185724-4588728d2b87
+	github.com/tiulpin/termbook v0.0.0-20260418144716-4da9f77fcd23
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -227,8 +227,8 @@ github.com/testcontainers/testcontainers-go v0.41.0 h1:mfpsD0D36YgkxGj2LrIyxuwQ9
 github.com/testcontainers/testcontainers-go v0.41.0/go.mod h1:pdFrEIfaPl24zmBjerWTTYaY0M6UHsqA1YSvsoU40MI=
 github.com/tiulpin/instill v0.0.0-20260409102126-21f299ecb245 h1:GDY9EUD9I7wzMjqx0L21hDlDg1j/RX374081jItBCqc=
 github.com/tiulpin/instill v0.0.0-20260409102126-21f299ecb245/go.mod h1:OxdrM9ElyAp2nLawA1UpPHWVscyOqfsI0+2mZnwEjIU=
-github.com/tiulpin/termbook v0.0.0-20260414185724-4588728d2b87 h1:Xpx1S3snQR2o2WA7F+8bYT1ERoHWuhVleuqeRbMZpaQ=
-github.com/tiulpin/termbook v0.0.0-20260414185724-4588728d2b87/go.mod h1:FsYSe+6mgO8oPtycK1ux6z/JVJFpjnpzZWqRb6OFYcc=
+github.com/tiulpin/termbook v0.0.0-20260418144716-4da9f77fcd23 h1:l29Z25hirqfjtM2q2ngi1APaxw9XEIIG6oeQU92OEGA=
+github.com/tiulpin/termbook v0.0.0-20260418144716-4da9f77fcd23/go.mod h1:FsYSe+6mgO8oPtycK1ux6z/JVJFpjnpzZWqRb6OFYcc=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=
 github.com/tklauser/go-sysconf v0.3.16/go.mod h1:/qNL9xxDhc7tx3HSRsLWNnuzbVfh3e7gh/BmM179nYI=
 github.com/tklauser/numcpus v0.11.0 h1:nSTwhKH5e1dMNsCdVBukSZrURJRoHbSEQjdEbY+9RXw=

--- a/internal/gallery/gallery_test.go
+++ b/internal/gallery/gallery_test.go
@@ -4,6 +4,7 @@ package gallery_test
 
 import (
 	"bytes"
+	"html/template"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -31,34 +32,95 @@ func TestGenerateGallery(t *testing.T) {
 	_, _ = yamlFile.WriteString("version: v1.0\njobs:\n  build:\n    steps:\n      - script: go build ./...\n  test:\n    needs: [build]\n    steps:\n      - script: go test -race ./...\n")
 	yamlFile.Close()
 
-	book := termbook.New("TeamCity CLI — Screen Gallery",
+	book := termbook.New("teamcity cli screen gallery",
 		termbook.WithGitHub("https://github.com/jetbrains/teamcity-cli/"),
-		termbook.WithAccent("#07C3F2"),
-		termbook.WithIntro("Auto-generated from real command output. Click terminals to expand. Regenerate with just gallery"),
+		termbook.WithCSS(jetBrainsCSS),
+		termbook.WithDecor(termbook.Decor{
+			BrandName:    "teamcity cli",
+			BrandVersion: "v0.9.0",
+			Crumbs:       []string{"jetbrains", "teamcity-cli", "gallery"},
+			Facts: []termbook.Fact{
+				{Value: "134", Label: "screens"},
+				{Value: "16", Label: "command groups"},
+			},
+			Notes: termbook.Notes{
+				Title: "Reading this gallery",
+				Body: template.HTML(`
+			<p>Every block is real CLI output, captured on each release — not screenshots or mockups. Skim top-to-bottom, jump by section from the sidebar, or filter by name.</p>
+			<p class="mono-hint">press <span class="kbd">/</span> to filter ·
+			<span class="kbd">T</span> to toggle theme ·
+			<span class="kbd">Esc</span> to clear</p>
+		`), //nolint:gosec // trusted
+			},
+			Footer: "teamcity cli · screen gallery",
+			Attribution: template.HTML(`
+			<span class="jb-wordmark">JetBrains</span>
+			<span class="dot">·</span>
+			<span>Developer Tools</span>
+			<span class="dot">·</span>
+			<span>The Drive to Develop</span>
+			<span style="margin-left:auto">© 2026 JetBrains s.r.o.</span>
+		`), //nolint:gosec // trusted
+			BloomDark:  "radial-gradient(closest-side, oklch(0.74 0.20 20 / 0.28), oklch(0.78 0.18 45 / 0.16) 45%, transparent 72%)",
+			BloomLight: "radial-gradient(closest-side, oklch(0.78 0.18 340 / 0.30), oklch(0.82 0.14 60 / 0.18) 45%, transparent 72%)",
+		}),
 	)
 
-	book.Category("Style Guide", "style-guide", styleGuideScreens()...)
-	book.Category("Runs", "runs", runScreens(t, ts)...)
-	book.Category("Jobs", "jobs", jobScreens(t, ts)...)
-	book.Category("Agents", "agents", agentScreens(t, ts)...)
-	book.Category("Queue", "queue", queueScreens(t, ts)...)
-	book.Category("Pools", "pools", poolScreens(t, ts)...)
-	book.Category("Projects", "projects", projectScreens(t, ts)...)
-	book.Category("Pipelines", "pipelines", pipelineScreens(t, ts, yamlFile.Name())...)
-	book.Category("Auth", "auth", authScreens(t, ts)...)
-	book.Category("Config", "config", configScreens(t, ts)...)
-	book.Category("Aliases", "aliases", aliasScreens(t, ts)...)
-	book.Category("Skills", "skills", skillScreens(t, ts)...)
-	book.Category("API", "api", apiScreens(t, ts)...)
-	book.Category("Update", "update", updateScreens(t, ts)...)
-	book.Category("Errors", "errors", errorScreens()...)
-	book.Category("Help Screens", "help", helpScreens(t, ts)...)
+	book.CategoryWithBlurb("Style Guide", "style-guide",
+		"The atoms the CLI uses to communicate. Treat these as non-negotiable until we decide to rework them together.",
+		styleGuideScreens()...)
+	book.CategoryWithBlurb("Runs", "runs",
+		"List, start, watch, diff, and manage builds.",
+		runScreens(t, ts)...)
+	book.CategoryWithBlurb("Jobs", "jobs",
+		"Build configurations: list, view, pause, parameters.",
+		jobScreens(t, ts)...)
+	book.CategoryWithBlurb("Agents", "agents",
+		"List agents, view status, open terminals, execute commands.",
+		agentScreens(t, ts)...)
+	book.CategoryWithBlurb("Queue", "queue",
+		"Inspect and reorder the build queue.",
+		queueScreens(t, ts)...)
+	book.CategoryWithBlurb("Pools", "pools",
+		"Agent pools and project assignments.",
+		poolScreens(t, ts)...)
+	book.CategoryWithBlurb("Projects", "projects",
+		"Project tree, VCS, SSH, cloud, parameters, tokens.",
+		projectScreens(t, ts)...)
+	book.CategoryWithBlurb("Pipelines", "pipelines",
+		"YAML pipeline lifecycle: validate, push, pull.",
+		pipelineScreens(t, ts, yamlFile.Name())...)
+	book.CategoryWithBlurb("Auth", "auth",
+		"Login, logout, multi-server status.",
+		authScreens(t, ts)...)
+	book.CategoryWithBlurb("Config", "config",
+		"CLI configuration values.",
+		configScreens(t, ts)...)
+	book.CategoryWithBlurb("Aliases", "aliases",
+		"Command shortcuts.",
+		aliasScreens(t, ts)...)
+	book.CategoryWithBlurb("Skills", "skills",
+		"AI coding agent skills: install, update, remove.",
+		skillScreens(t, ts)...)
+	book.CategoryWithBlurb("API", "api",
+		"Raw authenticated REST calls.",
+		apiScreens(t, ts)...)
+	book.CategoryWithBlurb("Update", "update",
+		"Check for new CLI releases.",
+		updateScreens(t, ts)...)
+	book.CategoryWithBlurb("Errors", "errors",
+		"Error message shapes and hints.",
+		errorScreens()...)
+	book.CategoryWithBlurb("Help Screens", "help",
+		"Built-in --help output for every command group.",
+		helpScreens(t, ts)...)
 
 	outPath := filepath.Join(repoRoot(), "docs", "index.html")
 	require.NoError(t, book.Generate(outPath))
 
 	t.Logf("Gallery written to %s", outPath)
 }
+
 var mockURLReplacer *strings.Replacer
 
 func capture(t *testing.T, ts *cmdtest.TestServer, args ...string) string {
@@ -91,3 +153,21 @@ func repoRoot() string {
 	_, file, _, _ := runtime.Caller(0)
 	return filepath.Join(filepath.Dir(file), "..", "..")
 }
+
+const jetBrainsCSS = `
+.mast h1 .slash {
+  background: linear-gradient(135deg, #FE2857 0%, #FF9E2C 45%, #E1309B 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+}
+.attrib .jb-wordmark {
+  font-family: var(--mono);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+  font-size: 12px;
+}
+`
+

--- a/internal/gallery/mocks_test.go
+++ b/internal/gallery/mocks_test.go
@@ -80,7 +80,25 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 		}})
 	})
 
+	dependents := map[string][]api.BuildType{
+		"MyApp_Lint":    {{ID: "MyApp_Build", Name: "Build", ProjectID: "MyApp"}},
+		"MyApp_Build":   {{ID: "MyApp_Test", Name: "Run Tests", ProjectID: "MyApp"}, {ID: "MyApp_IntTest", Name: "Integration Tests", ProjectID: "MyApp"}},
+		"MyApp_Test":    {{ID: "MyApp_Deploy", Name: "Deploy Staging", ProjectID: "MyApp"}},
+		"MyApp_IntTest": {{ID: "MyApp_Deploy", Name: "Deploy Staging", ProjectID: "MyApp"}},
+		"MyApp_Deploy":  nil,
+	}
 	ts.Handle("GET /app/rest/buildTypes", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.RawQuery
+		if strings.Contains(q, "snapshotDependency") && strings.Contains(q, "from") {
+			for id, list := range dependents {
+				if strings.Contains(q, "id:"+id) || strings.Contains(q, "id%3A"+id) {
+					cmdtest.JSON(w, api.BuildTypeList{Count: len(list), BuildTypes: list})
+					return
+				}
+			}
+			cmdtest.JSON(w, api.BuildTypeList{Count: 0, BuildTypes: []api.BuildType{}})
+			return
+		}
 		if strings.Contains(r.URL.Path, "id:") {
 			id := cmdtest.ExtractID(r.URL.Path, "id:")
 			cmdtest.JSON(w, api.BuildType{ID: id, Name: "Build", ProjectID: "MyApp", ProjectName: "My Application", WebURL: ts.URL + "/viewType.html?buildTypeId=" + id})
@@ -134,19 +152,19 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 		cmdtest.JSON(w, api.PipelineList{Count: 5, Pipelines: []api.Pipeline{
 			{ID: "MyApp_CI", Name: "CI", ParentProject: &api.ProjectRef{ID: "MyApp", Name: "My Application"},
 				HeadBuildType: &api.BuildTypeRef{ID: "MyApp_CI"},
-				Jobs: &api.PipelineJobs{Count: 2, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}}}},
+				Jobs:          &api.PipelineJobs{Count: 2, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}}}},
 			{ID: "MyApp_Release", Name: "Release", ParentProject: &api.ProjectRef{ID: "MyApp", Name: "My Application"},
 				HeadBuildType: &api.BuildTypeRef{ID: "MyApp_Release"},
-				Jobs: &api.PipelineJobs{Count: 4, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}, {ID: "stage", Name: "Stage"}, {ID: "prod", Name: "Production"}}}},
+				Jobs:          &api.PipelineJobs{Count: 4, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}, {ID: "stage", Name: "Stage"}, {ID: "prod", Name: "Production"}}}},
 			{ID: "MyApp_Nightly", Name: "Nightly", ParentProject: &api.ProjectRef{ID: "MyApp", Name: "My Application"},
 				HeadBuildType: &api.BuildTypeRef{ID: "MyApp_Nightly"},
-				Jobs: &api.PipelineJobs{Count: 3, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}, {ID: "perf", Name: "Performance"}}}},
+				Jobs:          &api.PipelineJobs{Count: 3, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}, {ID: "perf", Name: "Performance"}}}},
 			{ID: "Infra_Deploy", Name: "Infrastructure Deploy", ParentProject: &api.ProjectRef{ID: "Infrastructure", Name: "Infrastructure"},
 				HeadBuildType: &api.BuildTypeRef{ID: "Infra_Deploy"},
-				Jobs: &api.PipelineJobs{Count: 2, Job: []api.PipelineJob{{ID: "plan", Name: "Plan"}, {ID: "apply", Name: "Apply"}}}},
+				Jobs:          &api.PipelineJobs{Count: 2, Job: []api.PipelineJob{{ID: "plan", Name: "Plan"}, {ID: "apply", Name: "Apply"}}}},
 			{ID: "Frontend_CI", Name: "Frontend CI", ParentProject: &api.ProjectRef{ID: "MyApp_Frontend", Name: "Frontend"},
 				HeadBuildType: &api.BuildTypeRef{ID: "Frontend_CI"},
-				Jobs: &api.PipelineJobs{Count: 3, Job: []api.PipelineJob{{ID: "lint", Name: "Lint"}, {ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}}}},
+				Jobs:          &api.PipelineJobs{Count: 3, Job: []api.PipelineJob{{ID: "lint", Name: "Lint"}, {ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}}}},
 		}})
 	})
 
@@ -180,12 +198,12 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 		"45229": {ID: 45229, Number: "830", Status: "", State: "running", BuildTypeID: "MyApp_Deploy", BranchName: "main",
 			BuildType: &api.BuildType{ID: "MyApp_Deploy", Name: "Deploy Staging", ProjectID: "MyApp", ProjectName: "My Application"},
 			Triggered: &api.Triggered{Type: "user", User: &api.User{Name: "Viktor Tiulpin"}},
-			Agent: &api.Agent{ID: 1, Name: "linux-agent-01"}, PercentageComplete: 67,
+			Agent:     &api.Agent{ID: 1, Name: "linux-agent-01"}, PercentageComplete: 67,
 			StartDate: tcTime(-1*time.Minute - 22*time.Second),
-			WebURL: ts.URL + "/viewLog.html?buildId=45229"},
+			WebURL:    ts.URL + "/viewLog.html?buildId=45229"},
 		"45233": {ID: 45233, Number: "", Status: "", State: "queued", BuildTypeID: "MyApp_Build",
 			BuildType: &api.BuildType{ID: "MyApp_Build", Name: "Build", ProjectID: "MyApp", ProjectName: "My Application"},
-			WebURL: ts.URL + "/viewLog.html?buildId=45233"},
+			WebURL:    ts.URL + "/viewLog.html?buildId=45233"},
 	}
 	ts.Handle("GET /app/rest/builds/id:", func(w http.ResponseWriter, r *http.Request) {
 		path := r.URL.Path
@@ -357,6 +375,23 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 	ts.Handle("PUT /app/rest/agents/id:", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})
+	ts.Handle("GET /app/rest/agents/id:1/compatibleBuildTypes", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.BuildTypeList{Count: 5, BuildTypes: []api.BuildType{
+			{ID: "MyApp_Build", Name: "Build", ProjectName: "My Application", ProjectID: "MyApp"},
+			{ID: "MyApp_Test", Name: "Run Tests", ProjectName: "My Application", ProjectID: "MyApp"},
+			{ID: "MyApp_Lint", Name: "Lint", ProjectName: "My Application", ProjectID: "MyApp"},
+			{ID: "MyApp_IntTest", Name: "Integration Tests", ProjectName: "My Application", ProjectID: "MyApp"},
+			{ID: "Infra_Validate", Name: "Validate", ProjectName: "Infrastructure", ProjectID: "Infrastructure"},
+		}})
+	})
+	ts.Handle("GET /app/rest/agents/id:1/incompatibleBuildTypes", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.CompatibilityList{Count: 2, Compatibility: []api.Compatibility{
+			{Compatible: false, BuildType: &api.BuildType{ID: "MyApp_Deploy", Name: "Deploy Staging", ProjectName: "My Application"},
+				Reasons: &api.IncompatibleReasons{Reasons: []string{"Missing requirement: docker.server.version >= 20.0"}}},
+			{Compatible: false, BuildType: &api.BuildType{ID: "Infra_Deploy", Name: "Infra Deploy", ProjectName: "Infrastructure"},
+				Reasons: &api.IncompatibleReasons{Reasons: []string{"Missing requirement: terraform >= 1.5", "Missing requirement: aws-cli"}}},
+		}})
+	})
 
 	ts.Handle("GET /app/rest/agentPools/id:", func(w http.ResponseWriter, r *http.Request) {
 		cmdtest.JSON(w, api.Pool{
@@ -373,8 +408,12 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 		})
 	})
 
-	ts.Handle("GET /app/rest/projects/id:", func(w http.ResponseWriter, r *http.Request) {
+	projectDetailHandler := func(w http.ResponseWriter, r *http.Request) {
 		id := cmdtest.ExtractID(r.URL.Path, "id:")
+		if id == "" {
+			trimmed := strings.TrimPrefix(r.URL.Path, "/app/rest/projects/")
+			id, _, _ = strings.Cut(trimmed, "/")
+		}
 		if strings.Contains(r.URL.Path, "/parameters/") {
 			cmdtest.JSON(w, api.Parameter{Name: "param1", Value: "value1"})
 			return
@@ -432,6 +471,16 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 			ID: id, Name: "My Application", ParentProjectID: "_Root", Description: "Main product monorepo",
 			WebURL: ts.URL + "/project.html?projectId=" + id,
 		})
+	}
+	ts.Handle("GET /app/rest/projects/id:", projectDetailHandler)
+	ts.Handle("GET /app/rest/projects/", projectDetailHandler)
+
+	ts.Handle("POST /app/rest/projects/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/secure/tokens") {
+			cmdtest.Text(w, "credentialsJSON:abc123")
+			return
+		}
+		w.WriteHeader(http.StatusOK)
 	})
 
 	ts.Handle("GET /app/rest/vcs-roots", func(w http.ResponseWriter, r *http.Request) {
@@ -443,6 +492,20 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 			{ID: "Legacy_SVN", Name: "Legacy Codebase", VcsName: "svn", Project: &api.Project{ID: "MyApp"}},
 		}})
 	})
+	ts.Handle("GET /app/rest/vcs-roots/id:", func(w http.ResponseWriter, r *http.Request) {
+		id := cmdtest.ExtractID(r.URL.Path, "id:")
+		cmdtest.JSON(w, api.VcsRoot{
+			ID: id, Name: "Main Repo", VcsName: "jetbrains.git",
+			Project: &api.Project{ID: "MyApp", Name: "My Application"},
+			Href:    "/app/rest/vcs-roots/id:" + id,
+			Properties: &api.PropertyList{Property: []api.Property{
+				{Name: "url", Value: "https://github.com/jetbrains/teamcity-cli.git"},
+				{Name: "branch", Value: "refs/heads/main"},
+				{Name: "authMethod", Value: "TEAMCITY_SSH_KEY"},
+				{Name: "teamcitySshKey", Value: "deploy-key"},
+			}},
+		})
+	})
 
 	ts.Handle("GET /app/rest/cloud/profiles", func(w http.ResponseWriter, r *http.Request) {
 		cmdtest.JSON(w, api.CloudProfileList{Count: 5, Profiles: []api.CloudProfile{
@@ -452,6 +515,12 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 			{ID: "gcp-us", Name: "GCP US Central", CloudProviderID: "google", Project: &api.Project{ID: "MyApp"}},
 			{ID: "k8s-local", Name: "Kubernetes On-Prem", CloudProviderID: "kubernetes", Project: &api.Project{ID: "MyApp"}},
 		}})
+	})
+	ts.Handle("GET /app/rest/cloud/profiles/", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.CloudProfile{
+			ID: "aws-prod", Name: "AWS Production", CloudProviderID: "amazon",
+			Project: &api.Project{ID: "MyApp", Name: "My Application"},
+		})
 	})
 	ts.Handle("GET /app/rest/cloud/images", func(w http.ResponseWriter, r *http.Request) {
 		cmdtest.JSON(w, api.CloudImageList{Count: 5, Images: []api.CloudImage{
@@ -472,6 +541,25 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 		}})
 	})
 
+	ts.Handle("POST /app/rest/projects/id:MyApp/sshKeys/generated", func(w http.ResponseWriter, r *http.Request) {
+		name := r.URL.Query().Get("keyName")
+		cmdtest.JSON(w, api.SSHKey{
+			Name:      name,
+			PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5_generated_key",
+		})
+	})
+	ts.Handle("DELETE /app/rest/projects/id:MyApp/sshKeys/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	ts.Handle("POST /app/pipeline", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Pipeline{ID: "MyApp_Onboarding", Name: "Onboarding",
+			ParentProject: &api.ProjectRef{ID: "MyApp", Name: "My Application"},
+			HeadBuildType: &api.BuildTypeRef{ID: "MyApp_Onboarding"},
+			WebURL:        ts.URL + "/pipeline/MyApp_Onboarding",
+		})
+	})
+
 	ts.Handle("GET /app/rest/pipelines/id:", func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/yaml") {
 			cmdtest.Text(w, "version: v1.0\njobs:\n  build:\n    steps:\n      - script: go build ./...\n  test:\n    needs: [build]\n    steps:\n      - script: go test -race ./...\n")
@@ -480,7 +568,7 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 		cmdtest.JSON(w, api.Pipeline{ID: "MyApp_CI", Name: "CI",
 			ParentProject: &api.ProjectRef{ID: "MyApp", Name: "My Application"},
 			HeadBuildType: &api.BuildTypeRef{ID: "MyApp_CI"},
-			Jobs: &api.PipelineJobs{Count: 2, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}}}})
+			Jobs:          &api.PipelineJobs{Count: 2, Job: []api.PipelineJob{{ID: "build", Name: "Build"}, {ID: "test", Name: "Test"}}}})
 	})
 	ts.Handle("PUT /app/rest/pipelines/id:", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -492,9 +580,19 @@ func setupGalleryMocks(t *testing.T) *cmdtest.TestServer {
 	ts.Handle("GET /app/rest/buildTypes/id:", func(w http.ResponseWriter, r *http.Request) {
 		id := cmdtest.ExtractID(r.URL.Path, "id:")
 		if strings.Contains(r.URL.Path, "/snapshot-dependencies") {
-			cmdtest.JSON(w, api.SnapshotDependencyList{Count: 1, SnapshotDependency: []api.SnapshotDependency{
-				{ID: "snap1", SourceBuildType: &api.BuildType{ID: "MyApp_Lint", Name: "Lint"}},
-			}})
+			var deps []api.SnapshotDependency
+			switch id {
+			case "MyApp_Build":
+				deps = []api.SnapshotDependency{{ID: "snap-build-lint", SourceBuildType: &api.BuildType{ID: "MyApp_Lint", Name: "Lint"}}}
+			case "MyApp_Test", "MyApp_IntTest":
+				deps = []api.SnapshotDependency{{ID: "snap-dep", SourceBuildType: &api.BuildType{ID: "MyApp_Build", Name: "Build"}}}
+			case "MyApp_Deploy":
+				deps = []api.SnapshotDependency{
+					{ID: "snap-dep-test", SourceBuildType: &api.BuildType{ID: "MyApp_Test", Name: "Run Tests"}},
+					{ID: "snap-dep-int", SourceBuildType: &api.BuildType{ID: "MyApp_IntTest", Name: "Integration Tests"}},
+				}
+			}
+			cmdtest.JSON(w, api.SnapshotDependencyList{Count: len(deps), SnapshotDependency: deps})
 			return
 		}
 		if strings.Contains(r.URL.Path, "/parameters/") {

--- a/internal/gallery/screens_test.go
+++ b/internal/gallery/screens_test.go
@@ -5,6 +5,7 @@ package gallery_test
 import (
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/tiulpin/termbook"
@@ -24,15 +25,19 @@ func styleGuideScreens() []termbook.Screen {
 			fmt.Fprintln(w, output.Faint("Faint")+" — secondary info, IDs, hints")
 		}),
 		termbook.Manual("status-icons", "Status Icons", "Status indicators in tables and views", "", func(w io.Writer) {
-			for _, s := range []struct{ st, state, desc string }{
-				{"SUCCESS", "finished", "build completed successfully"},
-				{"FAILURE", "finished", "build finished with failures"},
-				{"", "running", "build is currently executing"},
-				{"", "queued", "build is waiting in queue"},
-				{"ERROR", "finished", "internal or infrastructure error"},
-				{"UNKNOWN", "finished", "unknown status"},
+			for _, s := range []struct{ st, state, text, desc string }{
+				{"SUCCESS", "finished", "", "build completed successfully"},
+				{"FAILURE", "finished", "", "build finished with failures"},
+				{"", "running", "", "build is currently executing"},
+				{"", "queued", "", "build is waiting in queue"},
+				{"UNKNOWN", "finished", "Canceled", "build was canceled by a user"},
+				{"ERROR", "finished", "", "internal or infrastructure error"},
+				{"UNKNOWN", "finished", "", "unknown status"},
 			} {
-				fmt.Fprintf(w, "  %s  %-12s %s\n", output.StatusIcon(s.st, s.state), output.StatusText(s.st, s.state), output.Faint(s.desc))
+				fmt.Fprintf(w, "  %s  %-12s %s\n",
+					output.StatusIcon(s.st, s.state, s.text),
+					output.StatusText(s.st, s.state, s.text),
+					output.Faint(s.desc))
 			}
 		}),
 		termbook.Manual("messages", "Messages", "Info, success, warning, error patterns", "", func(w io.Writer) {
@@ -40,7 +45,7 @@ func styleGuideScreens() []termbook.Screen {
 			p.Success("Logged in as Viktor Tiulpin")
 			p.Info("3 runs matched your filters")
 			p.Warn("Token expires in 2 days")
-			fmt.Fprintf(w, "Error: build configuration %q not found\n\nHint: Use 'teamcity job list' to see available jobs\n", "NonExistent_Build")
+			fmt.Fprintf(w, "Error: job '%s' not found\n\nHint: Use 'teamcity job list' to see available jobs\n", "NonExistent_Build")
 		}),
 		termbook.Manual("table", "Table Rendering", "Auto-sized columns with colored cells", "", func(w io.Writer) {
 			p := &output.Printer{Out: w, ErrOut: w}
@@ -107,8 +112,10 @@ func runScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 		termbook.Scr("run-restart", "run restart", "Re-trigger a completed run",
 			"teamcity run restart 1 --no-input", capture(t, ts, "run", "restart", "1", "--no-input")),
 		termbook.Manual("run-watch", "run watch --logs", "Full-screen TUI with live log streaming (alt-screen)", "teamcity run watch --logs 45229", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Deploy Staging  45229  #830  %s · Running (67%%)\n\n",
-				output.Yellow("●"), output.Yellow("Running"))
+			fmt.Fprintf(w, "%s %s 45229  #830 %s · Running (67%%)\n\n",
+				output.Yellow("●"),
+				output.Bold("Deploy Staging"),
+				output.Faint("https://tc.example.com/viewLog.html?buildId=45229"))
 			fmt.Fprintf(w, "%s\n", output.Faint("[12:01:10] Downloading artifacts from Build #831"))
 			fmt.Fprintf(w, "%s\n", output.Faint("[12:01:12] Extracting app.jar (12.4 MB)"))
 			fmt.Fprintf(w, "%s\n", output.Faint("[12:01:15] Verifying checksums... OK"))
@@ -121,7 +128,10 @@ func runScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 			fmt.Fprintf(w, "[12:01:40] Updating load balancer config...\n")
 			fmt.Fprintf(w, "[12:01:42] Draining old instances...\n")
 			fmt.Fprintf(w, "%s\n", output.Green("[12:01:45] Deploy complete. 2/2 instances healthy"))
-			fmt.Fprintf(w, "\n%s quit  ·  %s  ·  ~\n", output.Faint("q"), output.Cyan("teamcity agent term 1"))
+			fmt.Fprintf(w, "\n%s  %s  %s\n",
+				output.Faint("q quit"),
+				output.Faint("·"),
+				output.Cyan("teamcity agent term 1"))
 		}),
 		termbook.Scr("run-log", "run log --tail", "Formatted build log with timestamps",
 			"teamcity run log 1 --tail 10", capture(t, ts, "run", "log", "1", "--tail", "10")),
@@ -130,10 +140,13 @@ func runScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 		termbook.Scr("run-artifacts", "run artifacts", "List downloadable build artifacts",
 			"teamcity run artifacts 1", capture(t, ts, "run", "artifacts", "1")),
 		termbook.Manual("run-download", "run download", "Download artifacts to local filesystem", "teamcity run download 45231", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Downloaded app.jar (12.4 MB)\n", output.Green("✓"))
-			fmt.Fprintf(w, "%s Downloaded test-report.html (234 KB)\n", output.Green("✓"))
-			fmt.Fprintf(w, "%s Downloaded logs/build.log (45 KB)\n", output.Green("✓"))
-			fmt.Fprintf(w, "\n3 files, 12.6 MB total → ./artifacts/\n")
+			fmt.Fprintln(w, "Downloading 3 artifacts (12.6 MiB total) to ./artifacts/")
+			fmt.Fprintln(w)
+			fmt.Fprintf(w, "%-18s  %10s\n", "NAME", "SIZE")
+			fmt.Fprintf(w, "%-18s  %10s  %s\n", "app.jar", "12 MiB", output.Green("   ✓"))
+			fmt.Fprintf(w, "%-18s  %10s  %s\n", "test-report.html", "234 KiB", output.Green("   ✓"))
+			fmt.Fprintf(w, "%-18s  %10s  %s\n", "logs/build.log", "45 KiB", output.Green("   ✓"))
+			fmt.Fprintf(w, "\n%s 3 artifacts downloaded\n", output.Green("✓"))
 		}),
 		termbook.Scr("run-changes", "run changes", "VCS changes included in a run",
 			"teamcity run changes 1", capture(t, ts, "run", "changes", "1")),
@@ -149,6 +162,8 @@ func runScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 			"teamcity run unpin 1", capture(t, ts, "run", "unpin", "1")),
 		termbook.Scr("run-tag", "run tag", "Add tags to a run",
 			"teamcity run tag 1 release v1.0.0", capture(t, ts, "run", "tag", "1", "release", "v1.0.0")),
+		termbook.Scr("run-untag", "run untag", "Remove tags from a run",
+			"teamcity run untag 1 release", capture(t, ts, "run", "untag", "1", "release")),
 		termbook.Scr("run-comment", "run comment", "View a build comment",
 			"teamcity run comment 1", capture(t, ts, "run", "comment", "1")),
 		termbook.Scr("run-comment-set", "run comment (set)", "Set a comment on a run",
@@ -164,8 +179,16 @@ func jobScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 			"teamcity job tree MyApp_Build", capture(t, ts, "job", "tree", "MyApp_Build")),
 		termbook.Scr("job-pause", "job pause", "Pause a build configuration",
 			"teamcity job pause MyApp_Deploy", capture(t, ts, "job", "pause", "MyApp_Deploy")),
+		termbook.Scr("job-resume", "job resume", "Resume a paused build configuration",
+			"teamcity job resume MyApp_Deploy", capture(t, ts, "job", "resume", "MyApp_Deploy")),
 		termbook.Scr("job-param", "job param list", "List job parameters",
 			"teamcity job param list MyApp_Build", capture(t, ts, "job", "param", "list", "MyApp_Build")),
+		termbook.Scr("job-param-get", "job param get", "Get a job parameter value",
+			"teamcity job param get MyApp_Build env.JAVA_HOME", capture(t, ts, "job", "param", "get", "MyApp_Build", "env.JAVA_HOME")),
+		termbook.Scr("job-param-set", "job param set", "Set a job parameter value",
+			"teamcity job param set MyApp_Build env.JAVA_HOME /opt/jdk", capture(t, ts, "job", "param", "set", "MyApp_Build", "env.JAVA_HOME", "/opt/jdk")),
+		termbook.Scr("job-param-delete", "job param delete", "Delete a job parameter",
+			"teamcity job param delete MyApp_Build env.JAVA_HOME", capture(t, ts, "job", "param", "delete", "MyApp_Build", "env.JAVA_HOME")),
 	}
 }
 func agentScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
@@ -179,6 +202,14 @@ func agentScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 			"teamcity agent enable 1", capture(t, ts, "agent", "enable", "1")),
 		termbook.Scr("agent-disable", "agent disable", "Disable an agent",
 			"teamcity agent disable 1", capture(t, ts, "agent", "disable", "1")),
+		termbook.Scr("agent-authorize", "agent authorize", "Authorize an agent to accept builds",
+			"teamcity agent authorize 1", capture(t, ts, "agent", "authorize", "1")),
+		termbook.Scr("agent-deauthorize", "agent deauthorize", "Revoke authorization from an agent",
+			"teamcity agent deauthorize 1", capture(t, ts, "agent", "deauthorize", "1")),
+		termbook.Scr("agent-move", "agent move", "Move an agent to a different pool",
+			"teamcity agent move 1 2", capture(t, ts, "agent", "move", "1", "2")),
+		termbook.Scr("agent-reboot", "agent reboot", "Request agent reboot",
+			"teamcity agent reboot --yes 1", capture(t, ts, "agent", "reboot", "--yes", "1")),
 		termbook.Manual("agent-term", "agent term", "Interactive terminal session on an agent (WebSocket)", "teamcity agent term linux-agent-01", func(w io.Writer) {
 			fmt.Fprintf(w, "%s Connected to %s\n", output.Green("✓"), output.Cyan("linux-agent-01"))
 			fmt.Fprintf(w, "%s\n\n", output.Faint("https://tc.example.com/agentDetails.html?id=1"))
@@ -222,6 +253,8 @@ func poolScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 			"teamcity pool view 0", capture(t, ts, "pool", "view", "0")),
 		termbook.Scr("pool-link", "pool link", "Link a project to a pool",
 			"teamcity pool link 0 MyApp", capture(t, ts, "pool", "link", "0", "MyApp")),
+		termbook.Scr("pool-unlink", "pool unlink", "Unlink a project from a pool",
+			"teamcity pool unlink 0 MyApp", capture(t, ts, "pool", "unlink", "0", "MyApp")),
 	}
 }
 func projectScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
@@ -234,33 +267,36 @@ func projectScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 		termbook.Scr("project-settings", "project settings status", "Versioned settings sync status",
 			"teamcity project settings status MyApp", capture(t, ts, "project", "settings", "status", "MyApp")),
 		termbook.Manual("project-settings-validate", "project settings validate", "Validate local DSL settings", "teamcity project settings validate .teamcity", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Configuration valid\n  Server: https://tc.example.com\n  Projects: 5, Build configurations: 12, VCS roots: 3\n", output.Green("✓"))
+			fmt.Fprintf(w, "Validating %s\n", output.Faint(".teamcity"))
+			fmt.Fprintf(w, "%s Configuration valid\n", output.Green("✓"))
+			fmt.Fprintf(w, "  %s %s\n", output.Faint("Server:"), "https://tc.example.com")
+			fmt.Fprintf(w, "  %s\n", output.Faint("Projects: 5, Build configurations: 12"))
 		}),
 		termbook.Manual("project-settings-export", "project settings export", "Export DSL settings as a zip archive", "teamcity project settings export MyApp", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Exported kotlin settings to projectSettings.zip (45678 bytes)\n", output.Green("✓"))
+			fmt.Fprintln(w, "Exported kotlin settings to projectSettings.zip (45678 bytes)")
 		}),
 		termbook.Scr("project-vcs-list", "project vcs list", "List VCS roots in a project",
-			"teamcity project vcs list MyApp", capture(t, ts, "project", "vcs", "list", "MyApp")),
+			"teamcity project vcs list --project MyApp", capture(t, ts, "project", "vcs", "list", "--project", "MyApp")),
 		termbook.Scr("project-vcs-view", "project vcs view", "View VCS root details",
 			"teamcity project vcs view MyApp_MainRepo", capture(t, ts, "project", "vcs", "view", "MyApp_MainRepo")),
-		termbook.Manual("project-vcs-create", "project vcs create", "Create a new VCS root (interactive prompts)", "teamcity project vcs create MyApp", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Created VCS root %s\n  ID: MyApp_NewRepo\n  URL: https://github.com/org/new-repo\n", output.Green("✓"), output.Cyan("New Repo"))
+		termbook.Manual("project-vcs-create", "project vcs create", "Create a new VCS root (interactive prompts)", "teamcity project vcs create --project MyApp --name \"New Repo\" --url https://github.com/org/new-repo", func(w io.Writer) {
+			fmt.Fprintf(w, "%s Created VCS root \"New Repo\" (MyApp_NewRepo) in project MyApp\n", output.Green("✓"))
 		}),
 		termbook.Scr("project-vcs-test", "project vcs test", "Test VCS connection",
 			"teamcity project vcs test MyApp_MainRepo", capture(t, ts, "project", "vcs", "test", "MyApp_MainRepo")),
 		termbook.Scr("project-vcs-delete", "project vcs delete", "Delete a VCS root",
 			"teamcity project vcs delete --yes MyApp_Repo", capture(t, ts, "project", "vcs", "delete", "--yes", "MyApp_Repo")),
 		termbook.Scr("project-ssh-list", "project ssh list", "List SSH keys in a project",
-			"teamcity project ssh list MyApp", capture(t, ts, "project", "ssh", "list", "MyApp")),
+			"teamcity project ssh list --project MyApp", capture(t, ts, "project", "ssh", "list", "--project", "MyApp")),
 		termbook.Scr("project-ssh-generate", "project ssh generate", "Generate a new SSH key",
-			"teamcity project ssh generate --project MyApp --name ci-key", capture(t, ts, "project", "ssh", "generate", "--project", "TestProject", "--name", "ci-key")),
+			"teamcity project ssh generate --project MyApp --name ci-key", capture(t, ts, "project", "ssh", "generate", "--project", "MyApp", "--name", "ci-key")),
 		termbook.Manual("project-ssh-upload", "project ssh upload", "Upload an SSH private key", "teamcity project ssh upload id_ed25519 --project MyApp --name deploy-key", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Uploaded SSH key %s\n", output.Green("✓"), output.Cyan("deploy-key"))
+			fmt.Fprintf(w, "%s Uploaded SSH key \"deploy-key\" to project MyApp\n", output.Green("✓"))
 		}),
 		termbook.Scr("project-ssh-delete", "project ssh delete", "Delete an SSH key",
-			"teamcity project ssh delete deploy-key --project MyApp", capture(t, ts, "project", "ssh", "delete", "deploy-key", "--project", "TestProject")),
+			"teamcity project ssh delete deploy-key --project MyApp", capture(t, ts, "project", "ssh", "delete", "deploy-key", "--project", "MyApp")),
 		termbook.Scr("project-connection-list", "project connection list", "List project connections",
-			"teamcity project connection list MyApp", capture(t, ts, "project", "connection", "list", "MyApp")),
+			"teamcity project connection list --project MyApp", capture(t, ts, "project", "connection", "list", "--project", "MyApp")),
 		termbook.Scr("project-cloud-profile", "project cloud profile list", "List cloud profiles",
 			"teamcity project cloud profile list", capture(t, ts, "project", "cloud", "profile", "list")),
 		termbook.Scr("project-cloud-profile-view", "project cloud profile view", "View cloud profile details",
@@ -279,8 +315,14 @@ func projectScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 			"teamcity project cloud instance stop i-024...", capture(t, ts, "project", "cloud", "instance", "stop", "i-0245b46070c443201")),
 		termbook.Scr("project-param", "project param list", "List project parameters",
 			"teamcity project param list MyApp", capture(t, ts, "project", "param", "list", "MyApp")),
+		termbook.Scr("project-param-get", "project param get", "Get a project parameter value",
+			"teamcity project param get MyApp env.DEPLOY_ENV", capture(t, ts, "project", "param", "get", "MyApp", "env.DEPLOY_ENV")),
+		termbook.Scr("project-param-set", "project param set", "Set a project parameter value",
+			"teamcity project param set MyApp env.DEPLOY_ENV prod", capture(t, ts, "project", "param", "set", "MyApp", "env.DEPLOY_ENV", "prod")),
+		termbook.Scr("project-param-delete", "project param delete", "Delete a project parameter",
+			"teamcity project param delete MyApp env.DEPLOY_ENV", capture(t, ts, "project", "param", "delete", "MyApp", "env.DEPLOY_ENV")),
 		termbook.Scr("project-token-put", "project token put", "Store a secret and get a secure token reference",
-			"teamcity project token put MyApp \"s3cret-db-password\"", capture(t, ts, "project", "token", "put", "TestProject", "my-secret-password")),
+			"teamcity project token put MyApp \"s3cret-db-password\"", capture(t, ts, "project", "token", "put", "MyApp", "s3cret-db-password")),
 		termbook.Manual("project-token-get", "project token get", "Retrieve the value of a secure token", "teamcity project token get MyApp credentialsJSON:abc123", func(w io.Writer) {
 			fmt.Fprintln(w, "s3cret-db-password")
 		}),
@@ -291,15 +333,19 @@ func pipelineScreens(t *testing.T, ts *cmdtest.TestServer, yamlPath string) []te
 		termbook.Scr("pipeline-list", "pipeline list", "List YAML pipelines", "teamcity pipeline list", capture(t, ts, "pipeline", "list")),
 		termbook.Scr("pipeline-view", "pipeline view", "View pipeline details and jobs",
 			"teamcity pipeline view MyApp_CI", capture(t, ts, "pipeline", "view", "MyApp_CI")),
+		termbook.Scr("pipeline-create", "pipeline create", "Create a new pipeline from YAML",
+			"teamcity pipeline create Onboarding --project MyApp --vcs-root MyApp_MainRepo --file .teamcity.yml",
+			capture(t, ts, "pipeline", "create", "Onboarding", "--project", "MyApp", "--vcs-root", "MyApp_MainRepo", "--file", yamlPath)),
 		termbook.Scr("pipeline-validate", "pipeline validate", "Validate pipeline YAML",
-			"teamcity pipeline validate .teamcity.yml", capture(t, ts, "pipeline", "validate", yamlPath)),
+			"teamcity pipeline validate .teamcity.yml",
+			strings.ReplaceAll(capture(t, ts, "pipeline", "validate", yamlPath), yamlPath, ".teamcity.yml")),
 		termbook.Scr("pipeline-delete", "pipeline delete", "Delete a pipeline",
 			"teamcity pipeline delete --yes MyApp_CI", capture(t, ts, "pipeline", "delete", "--yes", "MyApp_CI")),
 		termbook.Manual("pipeline-push", "pipeline push", "Upload YAML to a pipeline", "teamcity pipeline push MyApp_CI .teamcity.yml", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Updated pipeline MyApp_CI from .teamcity.yml\n", output.Green("✓"))
+			fmt.Fprintf(w, "%s Updated pipeline MyApp_CI\n", output.Green("✓"))
 		}),
 		termbook.Manual("pipeline-pull", "pipeline pull", "Download pipeline YAML", "teamcity pipeline pull MyApp_CI", func(w io.Writer) {
-			fmt.Fprintf(w, "%s Saved pipeline MyApp_CI to .teamcity.yml\n", output.Green("✓"))
+			fmt.Fprintf(w, "%s Written to .teamcity.yml\n", output.Green("✓"))
 		}),
 	}
 }
@@ -309,30 +355,30 @@ func authScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 			"teamcity auth status", capture(t, ts, "auth", "status")),
 		termbook.Manual("auth-status-multi", "auth status (multi-server)", "Multi-server authentication status", "teamcity auth status", func(w io.Writer) {
 			fmt.Fprintf(w, "%s Logged in to %s %s\n", output.Green("✓"), output.Cyan("https://tc.example.com"), output.Faint("(default)"))
-			fmt.Fprintln(w, "  User: Administrator (admin) · system keyring")
+			fmt.Fprintf(w, "  %s Viktor Tiulpin (vtiulpin) %s %s\n", output.Faint("User:"), output.Faint("·"), output.Faint("system keyring"))
 			fmt.Fprintln(w, "  Token expires: Dec 31, 2026")
-			fmt.Fprintln(w, "  Server: TeamCity 2025.7 (build 197398)")
-			fmt.Fprintf(w, "  %s API compatible\n", output.Green("✓"))
+			fmt.Fprintf(w, "  %s\n", output.Faint("Server: TeamCity 2025.7 (build 197398)"))
+			fmt.Fprintf(w, "  %s %s\n", output.Green("✓"), output.Faint("API compatible"))
 			fmt.Fprintln(w)
 			fmt.Fprintf(w, "%s Guest access to %s\n", output.Green("✓"), output.Cyan("https://staging.tc.example.com"))
-			fmt.Fprintln(w, "  Server: TeamCity 2025.7 (build 197398)")
-			fmt.Fprintf(w, "  %s API compatible\n", output.Green("✓"))
+			fmt.Fprintf(w, "  %s\n", output.Faint("Server: TeamCity 2025.7 (build 197398)"))
+			fmt.Fprintf(w, "  %s %s\n", output.Green("✓"), output.Faint("API compatible"))
 			fmt.Fprintln(w)
-			fmt.Fprintf(w, "%s %s\n", output.Red("✗"), output.Cyan("https://legacy.tc.example.com"))
+			fmt.Fprintf(w, "%s Logged in to %s\n", output.Green("✓"), output.Cyan("https://legacy.tc.example.com"))
+			fmt.Fprintf(w, "  %s Viktor Tiulpin (vtiulpin) %s %s\n", output.Faint("User:"), output.Faint("·"), output.Faint("system keyring"))
 			fmt.Fprintf(w, "  %s Token expired on Mar 15, 2025\n", output.Red("✗"))
-			fmt.Fprintln(w, "  Server: TeamCity 2024.3 (build 185432)")
+			fmt.Fprintf(w, "  Run %s to re-authenticate\n", output.Cyan("teamcity auth login"))
+			fmt.Fprintf(w, "  %s\n", output.Faint("Server: TeamCity 2024.3 (build 185432)"))
 			fmt.Fprintf(w, "  %s CLI requires TeamCity 2024.7 or later\n", output.Yellow("!"))
 		}),
 		termbook.Manual("auth-login", "auth login", "Interactive authentication flow (browser-based PKCE)", "teamcity auth login", func(w io.Writer) {
 			fmt.Fprintln(w, "Secure browser login available on this server")
 			fmt.Fprintln(w, "Opening browser for authentication...")
-			fmt.Fprintf(w, "→ Approve access in TeamCity\n\n")
-			fmt.Fprintf(w, "%s Validated\n", output.Green("✓"))
-			fmt.Fprintf(w, "%s Logged in as %s (%s)\n", output.Green("✓"), output.Cyan("Viktor Tiulpin"), "vtiulpin")
+			fmt.Fprintf(w, "  %s Approve access in TeamCity\n\n", output.Yellow("→"))
+			fmt.Fprintln(w, output.Green("✓"))
+			fmt.Fprintf(w, "%s Logged in as %s\n", output.Green("✓"), output.Cyan("Viktor Tiulpin"))
 			fmt.Fprintf(w, "%s Token stored in system keyring\n", output.Green("✓"))
-			fmt.Fprintln(w, "  Token expires: Dec 31, 2026")
-			fmt.Fprintln(w, "  Server: TeamCity 2025.7 (build 197398)")
-			fmt.Fprintf(w, "  %s API compatible\n", output.Green("✓"))
+			fmt.Fprintf(w, "Token expires: %s\n", output.Yellow("Dec 31, 2026"))
 		}),
 		termbook.Scr("auth-logout", "auth logout", "Log out from a server",
 			"teamcity auth logout", capture(t, ts, "auth", "logout")),
@@ -386,25 +432,25 @@ func updateScreens(t *testing.T, ts *cmdtest.TestServer) []termbook.Screen {
 func errorScreens() []termbook.Screen {
 	return []termbook.Screen{
 		termbook.Manual("error-not-found", "Not Found", "Resource not found with contextual hint", "", func(w io.Writer) {
-			fmt.Fprintln(w, "Error: not found: No build found by locator 'id:999999'\n\nHint: Use 'teamcity run list' to see available resources")
+			fmt.Fprintln(w, "Error: run '999999' not found\n\nHint: Use 'teamcity run list' to see available resources")
 		}),
 		termbook.Manual("error-auth", "Authentication Failed", "Invalid or expired token", "", func(w io.Writer) {
 			fmt.Fprintln(w, "Error: Authentication failed: invalid or expired token\n\nHint: Run 'teamcity auth login' to re-authenticate")
 		}),
 		termbook.Manual("error-permission", "Permission Denied", "Insufficient permissions", "", func(w io.Writer) {
-			fmt.Fprintln(w, "Error: permission denied: You do not have \"Run build\" permission\n\nHint: Check your TeamCity permissions or contact your administrator")
+			fmt.Fprintln(w, "Error: permission denied: cannot reboot agent\n\nHint: Check your TeamCity permissions or contact your administrator")
 		}),
 		termbook.Manual("error-network", "Network Error", "Cannot reach the server", "", func(w io.Writer) {
-			fmt.Fprintln(w, "Error: network error: dial tcp: lookup tc.example.com: no such host\n\nHint: Check your network connection and verify the server URL")
+			fmt.Fprintln(w, "Error: cannot connect to https://tc.example.com: dial tcp: lookup tc.example.com: no such host\n\nHint: Check your network connection and verify the server URL")
 		}),
 		termbook.Manual("error-readonly", "Read-Only Mode", "Write operation blocked by TEAMCITY_RO", "", func(w io.Writer) {
-			fmt.Fprintln(w, "Error: read-only mode: POST /app/rest/buildQueue is not allowed\n\nHint: Unset the TEAMCITY_RO environment variable to allow write operations")
+			fmt.Fprintln(w, "Error: read-only mode: write operations are not allowed: POST /app/rest/buildQueue\n\nHint: Unset TEAMCITY_RO to allow write operations")
 		}),
 		termbook.Manual("error-json", "JSON Error Format", "Structured error with --json flag", "", func(w io.Writer) {
 			fmt.Fprintln(w, `{`)
 			fmt.Fprintln(w, `  "error": {`)
 			fmt.Fprintln(w, `    "code": "not_found",`)
-			fmt.Fprintln(w, `    "message": "not found: No build found by locator 'id:999999'",`)
+			fmt.Fprintln(w, `    "message": "run '999999' not found",`)
 			fmt.Fprintln(w, `    "suggestion": "Use 'teamcity run list' to see available resources"`)
 			fmt.Fprintln(w, `  }`)
 			fmt.Fprintln(w, `}`)


### PR DESCRIPTION
## Summary

Expand the screen gallery to cover every CLI leaf command (97/97) and rewrite hand-crafted `termbook.Manual` screens that had drifted from real CLI output.

## Changes

- **Coverage.** Added missing screens for `run untag`; `job resume` + `job param get/set/delete`; `project param get/set/delete`; `agent authorize/deauthorize/move/reboot`; `pool unlink`; `pipeline create`; `Canceled` status icon.
- **Manual screen accuracy.** Audited every `termbook.Manual` against its real code path (`Printer.Success/Info/Warn`, `api/errors.go`) and rewrote 14 stale outputs:
  - `run download` (NAME/SIZE table + `✓ N artifacts downloaded` summary)
  - `run watch --logs` (header/footer match `tui.go`)
  - `project settings validate` (add missing `Validating` line; drop fake `VCS roots:`)
  - `project settings export` (no `✓` prefix)
  - `project vcs create`, `project ssh upload` (real `Printer.Success` shape)
  - `pipeline push`, `pipeline pull` (real `✓ Updated pipeline …` / `✓ Written to …`)
  - `auth login`, `auth status (multi-server)` (match `login.go` + `status.go` flow; add `Run teamcity auth login` line for expired token)
  - Error screens: `Not Found`, `Network`, `Permission`, `Read-Only`, `JSON Error Format` match real `NotFoundError`, `NetworkError`, `PermissionError`, `ErrReadOnly`
- **Mock fixes for captured (`termbook.Scr`) screens.** Several captures were silently hitting `cmdtest` defaults and returning `TestProject` data or empty lists:
  - Register project detail handler at both `id:` and plain path (so `versionedSettings/config` etc. resolve).
  - Override `cmdtest`'s `TestProject` handlers for `vcs-roots/id:`, `cloud/profiles/`, `agents/id:1/{in,}compatibleBuildTypes`.
  - Add `MyApp` ssh generate/delete and secure-token POST mocks.
  - Route `project ssh/vcs/connection list MyApp` through `--project MyApp` flag (the positional arg was being ignored).
  - Trim the temp path from `pipeline validate` capture to `.teamcity.yml`.
  - Tune snapshot-dependency mock per build type so `job tree` renders a real acyclic graph instead of recursing to depth 15.
- **Deps.** Updated `github.com/tiulpin/termbook` to latest `main`.

## Design Decisions

Gallery test runs under `//go:build gallery` so it stays out of the default test set; `docs/index.html` is the generated artifact and is committed so the hosted page updates without a separate workflow. Captured screens are preferred over `termbook.Manual` where the command's output can be reproduced with the mock server — `Manual` is only used for interactive/TUI/filesystem commands.

## Example

```bash
go test -tags gallery ./internal/gallery/...
open docs/index.html
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [x] If adding a new command/flag: added \`.txtar\` test in \`acceptance/testdata/\` — n/a (gallery-only change)
- [x] If adding a data-producing command: includes \`--json\` support — n/a
- [x] If modifying \`--json\` output: no field removals/renames (additive only) — n/a
- [x] If changing docs-visible behavior: updated \`docs/\`, \`skills/\`, and \`README.md\` — \`docs/index.html\` regenerated