### PR TITLE
test(terminal): pty-based integration tests for agent term and exec

### DIFF
--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -174,16 +174,24 @@ jobs:
         script-content: |-
           set -eu
 
+          sudo add-apt-repository -y ppa:longsleep/golang-backports
+          sudo apt-get update
+          sudo apt-get install -y golang-1.26-go jq
+
+          go install ./tc
+          export TEAMCITY_URL="${TC_PTY_HOST:-https://cli.teamcity.com}"
+          export TEAMCITY_TOKEN="${TC_PTY_TOKEN:-${TC_ACCEPTANCE_TOKEN:-${TEAMCITY_TOKEN:-}}}"
+          if [ -z "$TEAMCITY_TOKEN" ]; then
+            echo "No token available (set TC_PTY_TOKEN or TC_ACCEPTANCE_TOKEN); skipping"
+            exit 0
+          fi
+
           CHANGES=$(teamcity run changes "%teamcity.build.id%" 2>/dev/null || true)
           if [ -n "$CHANGES" ] && ! echo "$CHANGES" | grep -qE '^\s+\S+\s+(internal/terminal/|api/terminal)'; then
             echo "No terminal-related changes, skipping"
             exit 0
           fi
 
-          sudo add-apt-repository -y ppa:longsleep/golang-backports
-          sudo apt-get update
-          sudo apt-get install -y golang-1.26-go jq
-          go mod download
           go install gotest.tools/gotestsum@latest
 
           teamcity run start CLI_LinuxAgentTerminal   --json --no-input >/dev/null

--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -162,6 +162,48 @@ jobs:
           head -1 coverage-integration.out > coverage.out
           tail -n +2 coverage-integration.out >> coverage.out
           tail -n +2 coverage-guest.out >> coverage.out
+  test_terminal_pty:
+    name: Test Terminal (pty)
+    runs-on: Ubuntu-24.04-Large
+    parameters:
+      env.GOROOT: /usr/lib/go-1.26
+      env.PATH: /usr/lib/go-1.26/bin:%env.GOBIN%:%env.PATH%
+    steps:
+      - type: script
+        name: Terminal pty tests
+        script-content: |-
+          set -eu
+
+          CHANGES=$(teamcity run changes "%teamcity.build.id%" 2>/dev/null || true)
+          if [ -n "$CHANGES" ] && ! echo "$CHANGES" | grep -qE '^\s+\S+\s+(internal/terminal/|api/terminal)'; then
+            echo "No terminal-related changes, skipping"
+            exit 0
+          fi
+
+          sudo add-apt-repository -y ppa:longsleep/golang-backports
+          sudo apt-get update
+          sudo apt-get install -y golang-1.26-go jq
+          go mod download
+          go install gotest.tools/gotestsum@latest
+
+          teamcity run start CLI_LinuxAgentTerminal   --json --no-input >/dev/null
+          teamcity run start CLI_WindowsAgentTerminal --json --no-input >/dev/null
+
+          LINUX_ID=""; WINDOWS_ID=""
+          for _ in $(seq 1 90); do
+            AGENTS=$(teamcity agent list --connected --json 2>/dev/null || echo '{}')
+            [ -z "$LINUX_ID" ]   && LINUX_ID=$(echo "$AGENTS"   | jq -r '[.agent[]? | select(.name | test("(Ubuntu|Linux)"; "i"))] | .[0].id // empty')
+            [ -z "$WINDOWS_ID" ] && WINDOWS_ID=$(echo "$AGENTS" | jq -r '[.agent[]? | select(.name | test("Windows"; "i"))] | .[0].id // empty')
+            [ -n "$LINUX_ID" ] && [ -n "$WINDOWS_ID" ] && break
+            sleep 10
+          done
+          [ -z "$LINUX_ID" ]   && { echo "no Linux agent after 15m";   exit 1; }
+          [ -z "$WINDOWS_ID" ] && { echo "no Windows agent after 15m"; exit 1; }
+          echo "Linux=$LINUX_ID Windows=$WINDOWS_ID"
+
+          export TC_PTY_LINUX_AGENT_ID=$LINUX_ID
+          export TC_PTY_WINDOWS_AGENT_ID=$WINDOWS_ID
+          gotestsum --format pkgname-and-test-fails -- -count=1 -tags=terminal_pty ./api -run 'TestTerminalPty' -timeout 15m
   goreleaser:
     name: GoReleaser
     allow-reuse: true

--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -163,14 +163,14 @@ jobs:
           tail -n +2 coverage-integration.out >> coverage.out
           tail -n +2 coverage-guest.out >> coverage.out
   test_terminal_pty:
-    name: Test Terminal (pty)
+    name: Test Terminal PTY
     runs-on: Ubuntu-24.04-Large
     parameters:
       env.GOROOT: /usr/lib/go-1.26
       env.PATH: /usr/lib/go-1.26/bin:%env.GOBIN%:%env.PATH%
     steps:
       - type: script
-        name: Terminal pty tests
+        name: Terminal PTY tests
         script-content: |-
           set -eu
 

--- a/.teamcity.yml
+++ b/.teamcity.yml
@@ -187,26 +187,31 @@ jobs:
           fi
 
           CHANGES=$(teamcity run changes "%teamcity.build.id%" 2>/dev/null || true)
-          if [ -n "$CHANGES" ] && ! echo "$CHANGES" | grep -qE '^\s+\S+\s+(internal/terminal/|api/terminal)'; then
+          if [ -n "$CHANGES" ] && ! echo "$CHANGES" | grep -qE '^\s+\S+\s+(internal/terminal/|internal/cmd/agent/terminal\.go|api/terminal)'; then
             echo "No terminal-related changes, skipping"
             exit 0
           fi
 
           go install gotest.tools/gotestsum@latest
 
-          teamcity run start CLI_LinuxAgentTerminal   --json --no-input >/dev/null
-          teamcity run start CLI_WindowsAgentTerminal --json --no-input >/dev/null
+          # Correlate agents to the builds we started: capture each build id,
+          # then poll `run view` for .agent.id. Matching by name pattern in the
+          # global agent list is unreliable when unrelated agents are connected.
+          LINUX_BUILD_ID=$(teamcity run start CLI_LinuxAgentTerminal     --json --no-input | jq -r '.id')
+          WINDOWS_BUILD_ID=$(teamcity run start CLI_WindowsAgentTerminal --json --no-input | jq -r '.id')
+          [ -n "$LINUX_BUILD_ID" ]   || { echo "failed to start CLI_LinuxAgentTerminal";   exit 1; }
+          [ -n "$WINDOWS_BUILD_ID" ] || { echo "failed to start CLI_WindowsAgentTerminal"; exit 1; }
+          echo "LinuxBuild=$LINUX_BUILD_ID WindowsBuild=$WINDOWS_BUILD_ID"
 
           LINUX_ID=""; WINDOWS_ID=""
           for _ in $(seq 1 90); do
-            AGENTS=$(teamcity agent list --connected --json 2>/dev/null || echo '{}')
-            [ -z "$LINUX_ID" ]   && LINUX_ID=$(echo "$AGENTS"   | jq -r '[.agent[]? | select(.name | test("(Ubuntu|Linux)"; "i"))] | .[0].id // empty')
-            [ -z "$WINDOWS_ID" ] && WINDOWS_ID=$(echo "$AGENTS" | jq -r '[.agent[]? | select(.name | test("Windows"; "i"))] | .[0].id // empty')
+            [ -z "$LINUX_ID" ]   && LINUX_ID=$(teamcity run view   "$LINUX_BUILD_ID" --json 2>/dev/null | jq -r '.agent.id // empty')
+            [ -z "$WINDOWS_ID" ] && WINDOWS_ID=$(teamcity run view "$WINDOWS_BUILD_ID" --json 2>/dev/null | jq -r '.agent.id // empty')
             [ -n "$LINUX_ID" ] && [ -n "$WINDOWS_ID" ] && break
             sleep 10
           done
-          [ -z "$LINUX_ID" ]   && { echo "no Linux agent after 15m";   exit 1; }
-          [ -z "$WINDOWS_ID" ] && { echo "no Windows agent after 15m"; exit 1; }
+          [ -z "$LINUX_ID" ]   && { echo "no agent assigned to build $LINUX_BUILD_ID after 15m";   exit 1; }
+          [ -z "$WINDOWS_ID" ] && { echo "no agent assigned to build $WINDOWS_BUILD_ID after 15m"; exit 1; }
           echo "Linux=$LINUX_ID Windows=$WINDOWS_ID"
 
           export TC_PTY_LINUX_AGENT_ID=$LINUX_ID

--- a/api/terminal_pty_test.go
+++ b/api/terminal_pty_test.go
@@ -1,0 +1,176 @@
+//go:build terminal_pty
+
+// Drives `teamcity agent term` under a real pty against live agents on
+// cli.teamcity.com. Agent ids come from TC_PTY_{LINUX,WINDOWS}_AGENT_ID.
+package api_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	expect "github.com/Netflix/go-expect"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	ptyEnvBinary       = "TC_PTY_BINARY"
+	ptyEnvHost         = "TC_PTY_HOST"
+	ptyEnvToken        = "TC_PTY_TOKEN"
+	ptyEnvLinuxAgent   = "TC_PTY_LINUX_AGENT_ID"
+	ptyEnvWindowsAgent = "TC_PTY_WINDOWS_AGENT_ID"
+
+	ptyDefaultHost = "https://cli.teamcity.com"
+	ptyIdleWait    = 75 * time.Second // > pingInterval (60s) so a missed pong would be visible
+)
+
+func ptyBinary(t *testing.T) string {
+	t.Helper()
+	if bin := os.Getenv(ptyEnvBinary); bin != "" {
+		abs, err := filepath.Abs(bin)
+		require.NoError(t, err)
+		return abs
+	}
+	bin := filepath.Join(t.TempDir(), "teamcity")
+	cmd := exec.Command("go", "build", "-o", bin, "./tc")
+	cmd.Dir = repoRoot(t)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "go build: %s", out)
+	return bin
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("go.mod not found above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+func ptyEnv() []string {
+	host := os.Getenv(ptyEnvHost)
+	if host == "" {
+		host = ptyDefaultHost
+	}
+	env := append(os.Environ(), "TEAMCITY_URL="+host)
+	token := os.Getenv(ptyEnvToken)
+	if token == "" {
+		token = os.Getenv("TEAMCITY_TOKEN")
+	}
+	if token != "" {
+		env = append(env, "TEAMCITY_TOKEN="+token)
+	}
+	return env
+}
+
+func ptySpawn(t *testing.T, args ...string) *expect.Console {
+	t.Helper()
+	c, err := expect.NewConsole(expect.WithDefaultTimeout(45 * time.Second))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = c.Close() })
+
+	cmd := exec.Command(ptyBinary(t), args...)
+	cmd.Env = ptyEnv()
+	cmd.Stdin = c.Tty()
+	cmd.Stdout = c.Tty()
+	cmd.Stderr = c.Tty()
+	require.NoError(t, cmd.Start())
+
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			_, _ = cmd.Process.Wait()
+		}
+	})
+	return c
+}
+
+func TestTerminalPtyLinux(t *testing.T) {
+	agentID := os.Getenv(ptyEnvLinuxAgent)
+	if agentID == "" {
+		t.Skipf("%s not set — bring up an agent via CLI_LinuxAgentTerminal and export its id", ptyEnvLinuxAgent)
+	}
+
+	t.Run("prompt echo exit", func(t *testing.T) {
+		c := ptySpawn(t, "agent", "term", agentID)
+		_, err := c.Expect(expect.String("$ "))
+		require.NoError(t, err, "no shell prompt seen")
+		_, err = c.SendLine("echo pty-linux-ok")
+		require.NoError(t, err)
+		_, err = c.Expect(expect.String("pty-linux-ok"))
+		require.NoError(t, err)
+		_, err = c.SendLine("exit")
+		require.NoError(t, err)
+		_, err = c.ExpectEOF()
+		require.NoError(t, err, "process did not exit cleanly after remote exit")
+	})
+
+	t.Run("survives idle over ping interval", func(t *testing.T) {
+		if testing.Short() {
+			t.Skip("75s idle — skipped under -short")
+		}
+		c := ptySpawn(t, "agent", "term", agentID)
+		_, err := c.Expect(expect.String("$ "))
+		require.NoError(t, err)
+		time.Sleep(ptyIdleWait)
+		_, err = c.SendLine("echo post-idle-ok")
+		require.NoError(t, err)
+		_, err = c.Expect(expect.String("post-idle-ok"))
+		require.NoError(t, err, "session died during idle — pong handler not refreshing deadline")
+		_, err = c.SendLine("exit")
+		require.NoError(t, err)
+		_, err = c.ExpectEOF()
+		require.NoError(t, err)
+	})
+}
+
+func TestTerminalPtyWindows(t *testing.T) {
+	agentID := os.Getenv(ptyEnvWindowsAgent)
+	if agentID == "" {
+		t.Skipf("%s not set — bring up an agent via CLI_WindowsAgentTerminal and export its id", ptyEnvWindowsAgent)
+	}
+
+	t.Run("powershell prompt echo exit", func(t *testing.T) {
+		c := ptySpawn(t, "agent", "term", agentID)
+		_, err := c.Expect(expect.String("PS "))
+		require.NoError(t, err, "no PowerShell prompt seen")
+		_, err = c.SendLine("Write-Host pty-ps-ok")
+		require.NoError(t, err)
+		_, err = c.Expect(expect.String("pty-ps-ok"))
+		require.NoError(t, err, "Write-Host output not seen — Enter keystroke not submitting on PS")
+		_, err = c.SendLine("exit")
+		require.NoError(t, err)
+		_, err = c.ExpectEOF()
+		require.NoError(t, err, "process did not exit cleanly after PS exit")
+	})
+}
+
+// Regresses the deadline-scope decision: Exec must not inherit the
+// interactive read deadline, or silent long commands time out before ctx.
+func TestTerminalPtyExecSilentLong(t *testing.T) {
+	if testing.Short() {
+		t.Skip("170s exec — skipped under -short")
+	}
+	agentID := os.Getenv(ptyEnvLinuxAgent)
+	if agentID == "" {
+		t.Skipf("%s not set", ptyEnvLinuxAgent)
+	}
+
+	cmd := exec.Command(ptyBinary(t), "agent", "exec", agentID,
+		"sleep 170; echo done-after-170s",
+		"--timeout", "4m")
+	cmd.Env = ptyEnv()
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "silent long exec failed: %s", out)
+	require.Contains(t, string(out), "done-after-170s")
+}

--- a/api/terminal_pty_test.go
+++ b/api/terminal_pty_test.go
@@ -24,6 +24,7 @@ const (
 
 	ptyDefaultHost = "https://cli.teamcity.com"
 	ptyIdleWait    = 75 * time.Second // > pingInterval (60s) so a missed pong would be visible
+	ptyExitWait    = 30 * time.Second // grace period for the spawned binary to exit after remote EOF
 )
 
 func ptyBinary(t *testing.T) string {
@@ -73,7 +74,31 @@ func ptyEnv() []string {
 	return env
 }
 
-func ptySpawn(t *testing.T, args ...string) *expect.Console {
+// ptyProc bundles the pty console with the spawned `teamcity` process so
+// callers can assert the process exited cleanly after the remote shell EOFs.
+// Without the exit-status assertion, a subprocess that prints the expected
+// output but crashes on teardown would still pass these tests.
+type ptyProc struct {
+	*expect.Console
+	cmd     *exec.Cmd
+	done    chan struct{}
+	waitErr error
+}
+
+// AssertCleanExit waits for the spawned `teamcity` process to exit and fails
+// the test if it either times out or returns a non-zero status. Call after
+// `ExpectEOF`.
+func (p *ptyProc) AssertCleanExit(t *testing.T) {
+	t.Helper()
+	select {
+	case <-p.done:
+		require.NoError(t, p.waitErr, "teamcity process exited with error")
+	case <-time.After(ptyExitWait):
+		t.Fatalf("teamcity process did not exit within %s after shell EOF", ptyExitWait)
+	}
+}
+
+func ptySpawn(t *testing.T, args ...string) *ptyProc {
 	t.Helper()
 	c, err := expect.NewConsole(expect.WithDefaultTimeout(45 * time.Second))
 	require.NoError(t, err)
@@ -86,13 +111,24 @@ func ptySpawn(t *testing.T, args ...string) *expect.Console {
 	cmd.Stderr = c.Tty()
 	require.NoError(t, cmd.Start())
 
+	p := &ptyProc{Console: c, cmd: cmd, done: make(chan struct{})}
+	go func() {
+		p.waitErr = cmd.Wait()
+		close(p.done)
+	}()
+
 	t.Cleanup(func() {
+		select {
+		case <-p.done:
+			return
+		default:
+		}
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
-			_, _ = cmd.Process.Wait()
 		}
+		<-p.done
 	})
-	return c
+	return p
 }
 
 func TestTerminalPtyLinux(t *testing.T) {
@@ -102,35 +138,37 @@ func TestTerminalPtyLinux(t *testing.T) {
 	}
 
 	t.Run("prompt echo exit", func(t *testing.T) {
-		c := ptySpawn(t, "agent", "term", agentID)
-		_, err := c.Expect(expect.String("$ "))
+		p := ptySpawn(t, "agent", "term", agentID)
+		_, err := p.Expect(expect.String("$ "))
 		require.NoError(t, err, "no shell prompt seen")
-		_, err = c.SendLine("echo pty-linux-ok")
+		_, err = p.SendLine("echo pty-linux-ok")
 		require.NoError(t, err)
-		_, err = c.Expect(expect.String("pty-linux-ok"))
+		_, err = p.Expect(expect.String("pty-linux-ok"))
 		require.NoError(t, err)
-		_, err = c.SendLine("exit")
+		_, err = p.SendLine("exit")
 		require.NoError(t, err)
-		_, err = c.ExpectEOF()
+		_, err = p.ExpectEOF()
 		require.NoError(t, err, "process did not exit cleanly after remote exit")
+		p.AssertCleanExit(t)
 	})
 
 	t.Run("survives idle over ping interval", func(t *testing.T) {
 		if testing.Short() {
 			t.Skip("75s idle — skipped under -short")
 		}
-		c := ptySpawn(t, "agent", "term", agentID)
-		_, err := c.Expect(expect.String("$ "))
+		p := ptySpawn(t, "agent", "term", agentID)
+		_, err := p.Expect(expect.String("$ "))
 		require.NoError(t, err)
 		time.Sleep(ptyIdleWait)
-		_, err = c.SendLine("echo post-idle-ok")
+		_, err = p.SendLine("echo post-idle-ok")
 		require.NoError(t, err)
-		_, err = c.Expect(expect.String("post-idle-ok"))
+		_, err = p.Expect(expect.String("post-idle-ok"))
 		require.NoError(t, err, "session died during idle — pong handler not refreshing deadline")
-		_, err = c.SendLine("exit")
+		_, err = p.SendLine("exit")
 		require.NoError(t, err)
-		_, err = c.ExpectEOF()
+		_, err = p.ExpectEOF()
 		require.NoError(t, err)
+		p.AssertCleanExit(t)
 	})
 }
 
@@ -141,17 +179,18 @@ func TestTerminalPtyWindows(t *testing.T) {
 	}
 
 	t.Run("powershell prompt echo exit", func(t *testing.T) {
-		c := ptySpawn(t, "agent", "term", agentID)
-		_, err := c.Expect(expect.String("PS "))
+		p := ptySpawn(t, "agent", "term", agentID)
+		_, err := p.Expect(expect.String("PS "))
 		require.NoError(t, err, "no PowerShell prompt seen")
-		_, err = c.SendLine("Write-Host pty-ps-ok")
+		_, err = p.SendLine("Write-Host pty-ps-ok")
 		require.NoError(t, err)
-		_, err = c.Expect(expect.String("pty-ps-ok"))
+		_, err = p.Expect(expect.String("pty-ps-ok"))
 		require.NoError(t, err, "Write-Host output not seen — Enter keystroke not submitting on PS")
-		_, err = c.SendLine("exit")
+		_, err = p.SendLine("exit")
 		require.NoError(t, err)
-		_, err = c.ExpectEOF()
+		_, err = p.ExpectEOF()
 		require.NoError(t, err, "process did not exit cleanly after PS exit")
+		p.AssertCleanExit(t)
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7
+	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d
 	github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de
 	github.com/buildkite/shellwords v1.0.1
@@ -58,6 +59,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GK
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
-github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
-github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Adds the first integration coverage for the interactive `agent term` path and for exec behaviors that unit tests can't observe. Gated by a new `terminal_pty` build tag and a new `test_terminal_pty` CI job that only runs when `internal/terminal/` or `api/terminal*` files changed.

## Summary

- New test file `api/terminal_pty_test.go` (`//go:build terminal_pty`) drives the built `teamcity` binary under a real pty via [Netflix/go-expect](https://github.com/Netflix/go-expect) + [creack/pty](https://github.com/creack/pty) against live agents on `cli.teamcity.com`.
- New `.teamcity.yml` job `test_terminal_pty` that gates on changed files, triggers the existing `CLI_LinuxAgentTerminal` and `CLI_WindowsAgentTerminal` builds to bring up agents, polls `teamcity agent list --connected --json` for Ubuntu / Windows names, and runs the tagged tests with `gotestsum`.

## Changes

**`test(terminal): add pty-based integration tests for agent term and exec`**
- `api/terminal_pty_test.go` — 4 test bodies, all under `//go:build terminal_pty`:
  - **`TestTerminalPtyLinux/prompt echo exit`** — baseline: bash prompt → `echo` → `exit` → `ExpectEOF`. Regression-guards the close-frame handling.
  - **`TestTerminalPtyLinux/survives idle over ping interval`** — idles 75s (> `pingInterval` = 60s), then sends a command and asserts the session is still responsive. Regression-guards the pong handler / `SetReadDeadline` refresh logic introduced to recover hung term sessions.
  - **`TestTerminalPtyWindows/powershell prompt echo exit`** — drives a PS prompt, asserts `Write-Host` output is seen after Enter. Regression-guards the CR line-ending and `echo ""` template fixes — any regression on Enter-keystroke semantics or the echo-no-args prompt will fail this test.
  - **`TestTerminalPtyExecSilentLong`** — `agent exec … "sleep 170; echo done-after-170s"`. Regression-guards the deadline-scope decision (`RunInteractive`-only, not `Exec`): if Exec ever re-inherits a read deadline shorter than the ctx, silent long commands would `i/o timeout` before completing.
- `go.mod` / `go.sum` — `go-expect` becomes direct (tagged file imports it); `creack/pty` stays indirect.

**`ci(terminal): add test_terminal_pty job gated on terminal file changes`**
- Single-step job (Ubuntu-24.04-Large) that:
  1. Gates via `teamcity run changes` with regex `^\s+\S+\s+(internal/terminal/|api/terminal)`. If the build has change info and none of it touches terminal code → `exit 0` before any apt-install work.
  2. Installs Go 1.26 + jq.
  3. Triggers `CLI_LinuxAgentTerminal` and `CLI_WindowsAgentTerminal` (`teamcity run start --json --no-input`).
  4. Polls `teamcity agent list --connected --json` for up to 15 min, extracting Linux (`Ubuntu|Linux` name) and Windows agent ids via `jq`.
  5. Exports `TC_PTY_LINUX_AGENT_ID` / `TC_PTY_WINDOWS_AGENT_ID` and runs `gotestsum -- -count=1 -tags=terminal_pty ./api -run 'TestTerminalPty' -timeout 15m`.
- Whole job is one step because `exit 0` in a multi-step script passes the step but still runs subsequent ones; collapsing lets the gate short-circuit the whole build cleanly without needing `##teamcity[buildStop]` (which marks the build cancelled, not passed).

## Design Decisions

**Why a new build tag and not `integration`?** Existing integration tests under `//go:build integration` run against testcontainers-spawned TeamCity, are hermetic, and run on every Linux CI job. The pty tests need live agents (cloud agents on `cli.teamcity.com`) and are slow (75s and 170s body times). Bundling them into `integration` would lengthen every Linux CI job by 4+ minutes. The `terminal_pty` tag keeps them opt-in and scoped to the file surface they cover.

**Why spawn the binary instead of calling `terminal.Conn` directly?** `RunInteractive` calls `term.StdStreams()` and `term.MakeRaw(fd)` on real `os.Stdin`/`os.Stdout`, and hard-fails with `"terminal command requires an interactive terminal"` if the fd isn't a tty. That makes in-process testing require a `RunInteractive` refactor to take `io.Reader`/`io.Writer` parameters. Spawning the binary under a pty is less invasive and exercises the full code path including `term.MakeRaw`/`RestoreTerminal`, which is itself platform-specific behavior worth regression-guarding. The refactor remains a worthwhile follow-up.

**Why keep `TestTerminalPtyExecSilentLong` in this file even though it doesn't use a pty?** It runs against the same live-agent infrastructure and is gated by the same `terminal_pty` tag / CI job. Keeping it grouped with the interactive tests means the CI `-run 'TestTerminalPty'` filter catches it and it shares the agent-lifecycle overhead.

**Agent-matching heuristic.** `jq` filters for `.name | test("(Ubuntu|Linux)"; "i")` and `.name | test("Windows"; "i")`. Relies on the TC-cloud naming convention observed in practice (`Ubuntu-24.04-…`, `Windows-Server-…`). If the agents spun up by `CLI_{Linux,Windows}AgentTerminal` expose a more specific marker (pool name, tag, typeId, env var in the build config), the filter should be tightened — flag this on review and I'll update. The current heuristic is the smallest thing that works given only the public `agent list --json` output.

## Test Plan

- [x] `go build ./...` — green
- [x] `go build -tags=terminal_pty ./api/...` — green
- [x] `go test -count=1 ./internal/terminal/...` — existing terminal unit tests unaffected
- [x] `just lint` — 0 issues (the pty file is behind the tag so it is not scanned in default lint)
- [x] Unit tests pass (``just unit``) — N/A for this PR (tests themselves are tag-gated)
- [x] Linter passes (``just lint``)
- [ ] Acceptance tests pass (``just acceptance``) — N/A, different surface
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A
- [x] If adding a data-producing command: includes `--json` support — N/A
- [x] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A

**Live validation before opening this PR** (manually, with tip-of-#261 binary against `cli.teamcity.com`):
- Bash prompt → `echo X` → `X` → `exit` → clean EOF ✓
- PS prompt → `Write-Host X` → `X` → `exit` → clean EOF ✓
- PS 75s idle → post-idle command executes → `exit` clean ✓
- Linux silent `sleep 170` exec returns `done-after-170s` after full 170s ✓

## Follow-ups

- Consider refactoring `RunInteractive` to accept `io.Reader`/`io.Writer` so the non-pty portions of the flow become in-process unit-testable without spawning a binary.
- Tighten the agent-matching heuristic once the `CLI_{Linux,Windows}AgentTerminal` build configs expose a stable identifier.