### PR TITLE
feat(cmd): group root commands and unify help text across commands

### DIFF
--- a/acceptance/testdata/help/help.txtar
+++ b/acceptance/testdata/help/help.txtar
@@ -3,6 +3,9 @@
 # Root help contains all commands and global flags
 exec teamcity --help
 stdout 'TeamCity CLI'
+stdout 'CORE COMMANDS'
+stdout 'INFRASTRUCTURE'
+stdout 'CONFIGURATION'
 stdout 'auth'
 stdout 'project'
 stdout 'run'

--- a/docs/topics/teamcity-cli-commands.md
+++ b/docs/topics/teamcity-cli-commands.md
@@ -1357,7 +1357,7 @@ Description
 </td>
 <td>
 
-Check for CLI updates and show how to upgrade
+Check for CLI updates
 
 </td>
 </tr>

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -25,17 +25,36 @@ See: https://www.jetbrains.com/help/teamcity/build-agent.html`,
 		RunE: cmdutil.SubcommandRequired,
 	}
 
-	cmd.AddCommand(newAgentListCmd(f))
-	cmd.AddCommand(newAgentViewCmd(f))
-	cmd.AddCommand(newAgentJobsCmd(f))
-	cmd.AddCommand(newAgentMoveCmd(f))
-	cmd.AddCommand(newAgentActionCmd(f, agentActions["enable"]))
-	cmd.AddCommand(newAgentActionCmd(f, agentActions["disable"]))
-	cmd.AddCommand(newAgentActionCmd(f, agentActions["authorize"]))
-	cmd.AddCommand(newAgentActionCmd(f, agentActions["deauthorize"]))
-	cmd.AddCommand(newAgentTerminalCmd(f))
-	cmd.AddCommand(newAgentExecCmd(f))
-	cmd.AddCommand(newAgentRebootCmd(f))
+	cmd.AddGroup(
+		&cobra.Group{ID: "view", Title: "VIEW"},
+		&cobra.Group{ID: "state", Title: "STATE"},
+		&cobra.Group{ID: "shell", Title: "SHELL"},
+	)
+
+	addInGroup := func(groupID string, cmds ...*cobra.Command) {
+		for _, c := range cmds {
+			c.GroupID = groupID
+			cmd.AddCommand(c)
+		}
+	}
+
+	addInGroup("view",
+		newAgentListCmd(f),
+		newAgentViewCmd(f),
+		newAgentJobsCmd(f),
+	)
+	addInGroup("state",
+		newAgentActionCmd(f, agentActions["enable"]),
+		newAgentActionCmd(f, agentActions["disable"]),
+		newAgentActionCmd(f, agentActions["authorize"]),
+		newAgentActionCmd(f, agentActions["deauthorize"]),
+		newAgentMoveCmd(f),
+		newAgentRebootCmd(f),
+	)
+	addInGroup("shell",
+		newAgentTerminalCmd(f),
+		newAgentExecCmd(f),
+	)
 
 	return cmd
 }

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -14,9 +14,15 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "agent",
 		Short: "Manage build agents",
-		Long:  `List, view, and manage TeamCity build agents.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List, view, and manage TeamCity build agents.
+
+Build agents run the jobs assigned by the TeamCity server. Use these
+commands to inspect agent state, toggle availability, and open a shell
+to a running agent.
+
+See: https://www.jetbrains.com/help/teamcity/build-agent.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newAgentListCmd(f))

--- a/internal/cmd/agent/agent_jobs.go
+++ b/internal/cmd/agent/agent_jobs.go
@@ -23,8 +23,12 @@ func newAgentJobsCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "jobs <agent>",
 		Short: "Show jobs an agent can run",
-		Long:  `List build configurations (jobs) that are compatible or incompatible with an agent.`,
-		Args:  cobra.ExactArgs(1),
+		Long: `Show jobs that are compatible with an agent.
+
+Pass --incompatible to show jobs that would not run on this agent,
+with the requirement reasons (missing parameters, unmet tool
+versions, pool restrictions, etc.).`,
+		Args: cobra.ExactArgs(1),
 		Example: `  teamcity agent jobs 1
   teamcity agent jobs Agent-Linux-01
   teamcity agent jobs Agent-Linux-01 --incompatible

--- a/internal/cmd/agent/agent_reboot.go
+++ b/internal/cmd/agent/agent_reboot.go
@@ -13,7 +13,6 @@ func newAgentMoveCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "move <agent> <pool-id>",
 		Short: "Move an agent to a different pool",
-		Long:  `Move an agent to a different agent pool.`,
 		Args:  cobra.ExactArgs(2),
 		Example: `  teamcity agent move 1 0
   teamcity agent move Agent-Linux-01 2`,

--- a/internal/cmd/agent/terminal.go
+++ b/internal/cmd/agent/terminal.go
@@ -20,8 +20,12 @@ func newAgentTerminalCmd(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
 		Use:   "term <agent>",
 		Short: "Open interactive terminal to agent",
-		Long:  `Open an interactive shell session to a TeamCity build agent.`,
-		Args:  cobra.ExactArgs(1),
+		Long: `Open an interactive shell session to a TeamCity build agent.
+
+Requires the agent to be connected, authorized, and enabled. The
+session runs over a WebSocket and exits when the remote shell exits
+or the connection drops.`,
+		Args: cobra.ExactArgs(1),
 		Example: `  teamcity agent term 1
   teamcity agent term Agent-Linux-01`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -40,8 +44,12 @@ func newAgentExecCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "exec <agent> <command>",
 		Short: "Execute command on agent",
-		Long:  `Execute a command on a TeamCity build agent and return the output.`,
-		Args:  cobra.MinimumNArgs(2),
+		Long: `Run a one-shot command on an agent and return its output.
+
+Use 'teamcity agent term' for an interactive shell. Commands longer
+than the default timeout (5m) need --timeout; use -- to separate
+agent-side commands from teamcity flags.`,
+		Args: cobra.MinimumNArgs(2),
 		Example: `  teamcity agent exec 1 "ls -la"
   teamcity agent exec Agent-Linux-01 "cat /etc/os-release"
   teamcity agent exec Agent-Linux-01 --timeout 10m -- long-running-script.sh`,

--- a/internal/cmd/alias/alias.go
+++ b/internal/cmd/alias/alias.go
@@ -15,9 +15,13 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "alias",
 		Short: "Manage command aliases",
-		Long:  "Create, list, and delete command shortcuts.",
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `Create, list, and delete command shortcuts.
+
+Aliases expand to full teamcity commands, so you can type 'tc rl'
+instead of 'tc run list'. Aliases support positional placeholders
+($1, $2, ...) and shell-style expansions via the --shell flag.`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newAliasSetCmd(f))

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -50,7 +50,9 @@ are handled automatically.
 This command is useful for:
 - Accessing API features not yet supported by the CLI
 - Scripting and automation
-- Debugging and exploration`,
+- Debugging and exploration
+
+See: https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentation.html`,
 		Args: cobra.ExactArgs(1),
 		Example: `  # Get server info
   teamcity api '/app/rest/server'

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -9,9 +9,15 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "auth",
 		Short: "Authenticate with TeamCity",
-		Long:  `Manage authentication state for TeamCity servers.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `Log in, log out, and inspect authentication state for TeamCity servers.
+
+Credentials are stored in the system keyring by default and can be
+overridden via TEAMCITY_URL and TEAMCITY_TOKEN environment variables
+for CI/CD usage.
+
+See: https://www.jetbrains.com/help/teamcity/configuring-your-personal-settings.html#Managing+Access+Tokens`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newAuthLoginCmd(f))

--- a/internal/cmd/auth/auth.go
+++ b/internal/cmd/auth/auth.go
@@ -15,7 +15,7 @@ Credentials are stored in the system keyring by default and can be
 overridden via TEAMCITY_URL and TEAMCITY_TOKEN environment variables
 for CI/CD usage.
 
-See: https://www.jetbrains.com/help/teamcity/configuring-your-personal-settings.html#Managing+Access+Tokens`,
+See: https://www.jetbrains.com/help/teamcity/managing-your-user-account.html#Managing+Access+Tokens`,
 		Args: cobra.NoArgs,
 		RunE: cmdutil.SubcommandRequired,
 	}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -19,9 +19,14 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
 		Short: "Manage CLI configuration",
-		Long:  "Get, set, and list CLI configuration values.",
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `Get, set, and list CLI configuration values.
+
+Configuration is stored in ~/.teamcity/config.toml and covers the
+default server, per-server flags (guest, read-only), and aliases.
+Environment variables (TEAMCITY_URL, TEAMCITY_TOKEN, ...) override
+the persisted values at runtime.`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newListCmd(f))

--- a/internal/cmd/job/job.go
+++ b/internal/cmd/job/job.go
@@ -11,9 +11,16 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:     "job",
 		Aliases: []string{"buildtype"},
 		Short:   "Manage jobs (build configurations)",
-		Long:    `List and manage TeamCity jobs (build configurations).`,
-		Args:    cobra.NoArgs,
-		RunE:    cmdutil.SubcommandRequired,
+		Long: `List and manage TeamCity jobs (build configurations).
+
+A job (referred to as a build configuration in the TeamCity UI) is the
+recipe that turns source revisions into builds: VCS roots, build steps,
+parameters, and triggers. Use these commands to browse jobs, inspect
+their parameters and dependencies, and pause or resume them.
+
+See: https://www.jetbrains.com/help/teamcity/creating-and-editing-build-configurations.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newJobListCmd(f))

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -21,8 +21,12 @@ func newJobListCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &jobListOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "list",
-		Short:   "List jobs",
+		Use:   "list",
+		Short: "List jobs",
+		Long: `List jobs across all projects or in a specific project.
+
+Jobs backed by pipelines are hidden by default; pass --all to include
+them alongside classic build configurations.`,
 		Aliases: []string{"ls"},
 		Example: `  teamcity job list
   teamcity job list --project Falcon

--- a/internal/cmd/param/param.go
+++ b/internal/cmd/param/param.go
@@ -77,7 +77,6 @@ func newParamListCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI) *co
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("list <%s-id>", resource),
 		Short: fmt.Sprintf("List %s parameters", resource),
-		Long:  fmt.Sprintf("List all parameters for a %s.", resource),
 		Args:  cobra.ExactArgs(1),
 		Example: fmt.Sprintf(`  teamcity %s param list MyID
   teamcity %s param list MyID --json
@@ -146,7 +145,6 @@ func newParamGetCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI) *cob
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("get <%s-id> <name>", resource),
 		Short: fmt.Sprintf("Get a %s parameter value", resource),
-		Long:  fmt.Sprintf("Get the value of a specific %s parameter.", resource),
 		Args:  cobra.ExactArgs(2),
 		Example: fmt.Sprintf(`  teamcity %s param get MyID MY_PARAM
   teamcity %s param get MyID VERSION`, resource, resource),
@@ -193,8 +191,11 @@ func newParamSetCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI) *cob
 	cmd := &cobra.Command{
 		Use:   fmt.Sprintf("set <%s-id> <name> <value>", resource),
 		Short: fmt.Sprintf("Set a %s parameter value", resource),
-		Long:  fmt.Sprintf("Set or update a %s parameter value.", resource),
-		Args:  cobra.ExactArgs(3),
+		Long: fmt.Sprintf(`Set or update a %s parameter.
+
+Use --secure to mark the parameter as a password. Secure values are
+stored encrypted server-side and masked in logs and UI output.`, resource),
+		Args: cobra.ExactArgs(3),
 		Example: fmt.Sprintf(`  teamcity %s param set MyID MY_PARAM "my value"
   teamcity %s param set MyID SECRET_KEY "****" --secure`, resource, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -225,7 +226,6 @@ func newParamDeleteCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI) *
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("delete <%s-id> <name>", resource),
 		Short:   fmt.Sprintf("Delete a %s parameter", resource),
-		Long:    fmt.Sprintf("Delete a parameter from a %s.", resource),
 		Args:    cobra.ExactArgs(2),
 		Example: fmt.Sprintf(`  teamcity %s param delete MyID MY_PARAM`, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/param/param.go
+++ b/internal/cmd/param/param.go
@@ -46,9 +46,15 @@ func NewCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:   "param",
 		Short: fmt.Sprintf("Manage %s parameters", resource),
-		Long:  fmt.Sprintf("List, get, set, and delete %s parameters.", resource),
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: fmt.Sprintf(`List, get, set, and delete %s parameters.
+
+Parameters are typed key-value pairs attached to a %s. They drive
+build behavior, can reference other parameters, and may be marked
+as password (secure) so their values never appear in logs.
+
+See: https://www.jetbrains.com/help/teamcity/configuring-build-parameters.html`, resource, resource),
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newParamListCmd(f, resource, paramAPI))

--- a/internal/cmd/pipeline/pipeline.go
+++ b/internal/cmd/pipeline/pipeline.go
@@ -9,9 +9,15 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pipeline",
 		Short: "Manage pipelines (YAML configurations)",
-		Long:  `List, view, validate, and manage TeamCity pipelines.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List, view, validate, and manage TeamCity pipelines.
+
+Pipelines are YAML-defined workflows that orchestrate one or more jobs
+end-to-end. Use these commands to validate pipeline YAML against the
+server schema, push changes, and pull the current definition.
+
+See: https://www.jetbrains.com/help/teamcity/pipelines.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newPipelineListCmd(f))

--- a/internal/cmd/pipeline/pipeline.go
+++ b/internal/cmd/pipeline/pipeline.go
@@ -15,7 +15,7 @@ Pipelines are YAML-defined workflows that orchestrate one or more jobs
 end-to-end. Use these commands to validate pipeline YAML against the
 server schema, push changes, and pull the current definition.
 
-See: https://www.jetbrains.com/help/teamcity/pipelines.html`,
+See: https://www.jetbrains.com/help/teamcity/create-and-edit-pipelines.html`,
 		Args: cobra.NoArgs,
 		RunE: cmdutil.SubcommandRequired,
 	}

--- a/internal/cmd/pool/pool.go
+++ b/internal/cmd/pool/pool.go
@@ -9,9 +9,15 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pool",
 		Short: "Manage agent pools",
-		Long:  `List agent pools and manage project assignments.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List agent pools and manage project assignments.
+
+Agent pools group build agents and bind them to specific projects,
+so a project's builds only run on approved agents. Use these commands
+to inspect pools and link or unlink projects.
+
+See: https://www.jetbrains.com/help/teamcity/configuring-agent-pools.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newPoolListCmd(f))

--- a/internal/cmd/project/cloud.go
+++ b/internal/cmd/project/cloud.go
@@ -14,9 +14,15 @@ func newCloudCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Manage cloud profiles, images, and instances",
-		Long:  `List and manage cloud profiles, images, and instances for a project.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List and manage cloud profiles, images, and instances for a project.
+
+A cloud profile binds a project to a cloud provider (AWS, GCP, Azure,
+Kubernetes, ...) and defines one or more images that TeamCity uses to
+start ephemeral build agents on demand.
+
+See: https://www.jetbrains.com/help/teamcity/agent-cloud-profile.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newCloudProfileCmd(f))

--- a/internal/cmd/project/connection.go
+++ b/internal/cmd/project/connection.go
@@ -13,9 +13,15 @@ func newConnectionCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "connection",
 		Short: "Manage project connections",
-		Long:  `List OAuth and other connections configured in a project.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List OAuth and other connections configured in a project.
+
+Connections let TeamCity talk to external services (GitHub, GitLab,
+Bitbucket, Slack, Jira, Docker registries, ...) without storing
+credentials in individual jobs.
+
+See: https://www.jetbrains.com/help/teamcity/configuring-connections.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newConnectionListCmd(f))

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -20,9 +20,16 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "project",
 		Short: "Manage projects",
-		Long:  `List and view TeamCity projects.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List, view, and manage TeamCity projects.
+
+A project groups related jobs, pipelines, VCS roots, parameters, and
+cloud profiles. Use these commands to navigate the project hierarchy
+and manage project-scoped resources (VCS roots, SSH keys, secure
+tokens, versioned settings, cloud integrations, and connections).
+
+See: https://www.jetbrains.com/help/teamcity/creating-and-editing-projects.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newProjectListCmd(f))

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -57,7 +57,6 @@ func newProjectListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List projects",
-		Long:    `List all TeamCity projects.`,
 		Aliases: []string{"ls"},
 		Example: `  teamcity project list
   teamcity project list --parent Falcon
@@ -115,7 +114,6 @@ func newProjectViewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "view <project-id>",
 		Short:   "View project details",
-		Long:    `View details of a TeamCity project.`,
 		Aliases: []string{"show"},
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity project view Falcon

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -16,9 +16,15 @@ func newSSHCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ssh",
 		Short: "Manage SSH keys",
-		Long:  `List, upload, generate, and delete SSH keys in a project.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List, upload, generate, and delete SSH keys in a project.
+
+SSH keys uploaded to a project can be used by VCS roots and build
+steps to authenticate with remote services without exposing private
+keys in configuration or source control.
+
+See: https://www.jetbrains.com/help/teamcity/ssh-keys-management.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newSSHListCmd(f))

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -21,9 +21,15 @@ func newVcsCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "vcs",
 		Short: "Manage VCS roots",
-		Long:  `List, view, create, test, and delete VCS roots in a project.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List, view, create, test, and delete VCS roots in a project.
+
+A VCS root defines how TeamCity connects to a version control
+repository (Git, Mercurial, Perforce, SVN, ...) so that jobs can
+check out sources and react to changes.
+
+See: https://www.jetbrains.com/help/teamcity/vcs-root.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newVcsListCmd(f))

--- a/internal/cmd/queue/list.go
+++ b/internal/cmd/queue/list.go
@@ -20,7 +20,6 @@ func newQueueListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list",
 		Short:   "List queued runs",
-		Long:    `List all runs in the TeamCity queue.`,
 		Aliases: []string{"ls"},
 		Example: `  teamcity queue list
   teamcity queue list --job Falcon_Build

--- a/internal/cmd/queue/queue.go
+++ b/internal/cmd/queue/queue.go
@@ -9,9 +9,15 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "queue",
 		Short: "Manage build queue",
-		Long:  `List and manage the TeamCity build queue.`,
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `List and manage the TeamCity build queue.
+
+The queue holds runs that are waiting for a compatible agent. Use
+these commands to inspect pending runs, reorder them, approve guarded
+runs, or remove entries.
+
+See: https://www.jetbrains.com/help/teamcity/build-queue.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newQueueListCmd(f))

--- a/internal/cmd/queue/remove.go
+++ b/internal/cmd/queue/remove.go
@@ -19,7 +19,6 @@ func newQueueRemoveCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:     "remove <id>",
 		Aliases: []string{"rm"},
 		Short:   "Remove a run from the queue",
-		Long:    `Remove a queued run from the TeamCity queue.`,
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity queue remove 12345
   teamcity queue remove 12345 --yes`,

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -63,6 +63,13 @@ Report issues:  https://jb.gg/tc/issues`,
 	cmd.SetVersionTemplate("teamcity version {{.Version}}\n")
 	cmd.SuggestionsMinimumDistance = 2
 
+	cmd.AddGroup(
+		&cobra.Group{ID: "core", Title: "CORE COMMANDS"},
+		&cobra.Group{ID: "infra", Title: "INFRASTRUCTURE"},
+		&cobra.Group{ID: "config", Title: "CONFIGURATION"},
+		&cobra.Group{ID: "misc", Title: "ADDITIONAL COMMANDS"},
+	)
+
 	cmd.PersistentFlags().BoolVar(&f.NoColor, "no-color", false, "Disable colored output")
 	cmd.PersistentFlags().BoolVarP(&f.Quiet, "quiet", "q", false, "Suppress non-essential output")
 	cmd.PersistentFlags().BoolVarP(&f.Verbose, "verbose", "V", false, "Show detailed output including debug info")
@@ -83,19 +90,19 @@ Report issues:  https://jb.gg/tc/issues`,
 		}
 	}
 
-	cmd.AddCommand(auth.NewCmd(f))
-	cmd.AddCommand(project.NewCmd(f))
-	cmd.AddCommand(job.NewCmd(f))
-	cmd.AddCommand(run.NewCmd(f))
-	cmd.AddCommand(queue.NewCmd(f))
-	cmd.AddCommand(agent.NewCmd(f))
-	cmd.AddCommand(pool.NewCmd(f))
-	cmd.AddCommand(pipeline.NewCmd(f))
-	cmd.AddCommand(apicmd.NewCmd(f))
-	cmd.AddCommand(skill.NewCmd(f))
-	cmd.AddCommand(configcmd.NewCmd(f))
-	cmd.AddCommand(alias.NewCmd(f))
-	cmd.AddCommand(updatecmd.NewCmd(f))
+	addGrouped(cmd, "core", run.NewCmd(f), job.NewCmd(f), project.NewCmd(f), pipeline.NewCmd(f))
+	addGrouped(cmd, "infra", queue.NewCmd(f), agent.NewCmd(f), pool.NewCmd(f))
+	addGrouped(cmd, "config",
+		auth.NewCmd(f),
+		configcmd.NewCmd(f),
+		alias.NewCmd(f),
+		apicmd.NewCmd(f),
+		skill.NewCmd(f),
+		updatecmd.NewCmd(f),
+	)
+
+	cmd.SetHelpCommandGroupID("misc")
+	cmd.SetCompletionCommandGroupID("misc")
 
 	return cmd
 }
@@ -152,6 +159,14 @@ func tryAutoReauth(f *cmdutil.Factory) {
 func isCategory(err error, cat api.Category) bool {
 	var ue api.UserError
 	return errors.As(err, &ue) && ue.Category() == cat
+}
+
+// addGrouped registers subcommands under a shared group ID on the parent command.
+func addGrouped(parent *cobra.Command, groupID string, cmds ...*cobra.Command) {
+	for _, c := range cmds {
+		c.GroupID = groupID
+		parent.AddCommand(c)
+	}
 }
 
 // RegisterAliases forwards to alias.RegisterAliases.

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -23,7 +23,6 @@ func newRunChangesCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "changes <id>",
 		Short: "Show VCS changes",
-		Long:  `Show the VCS changes (commits) included in a run.`,
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity run changes 12345
   teamcity run changes 12345 --no-files

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -19,8 +19,12 @@ func newRunCancelCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cancel <id>",
 		Short: "Cancel a run",
-		Long:  `Cancel a running or queued run.`,
-		Args:  cobra.ExactArgs(1),
+		Long: `Cancel a running or queued run.
+
+Prompts for confirmation when run interactively without --yes or
+--comment. The cancellation comment is stored on the run and shown
+in the TeamCity UI.`,
+		Args: cobra.ExactArgs(1),
 		Example: `  teamcity run cancel 12345
   teamcity run cancel 12345 --comment "Canceling for hotfix"
   teamcity run cancel 12345 --yes`,

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -29,8 +29,12 @@ func newRunDownloadCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "download <id>",
 		Short: "Download artifacts",
-		Long:  `Download artifacts from a completed run.`,
-		Args:  cobra.ExactArgs(1),
+		Long: `Download artifacts from a completed run.
+
+Filter by --artifact (glob) and --path (subdirectory within the run's
+artifact tree). Use --output to choose the local destination directory
+(defaults to the current directory).`,
+		Args: cobra.ExactArgs(1),
 		Example: `  teamcity run download 12345
   teamcity run download 12345 --path build/assets
   teamcity run download 12345 -o ./artifacts

--- a/internal/cmd/run/metadata.go
+++ b/internal/cmd/run/metadata.go
@@ -43,8 +43,12 @@ pinned run stays visible in the UI and can be unpinned with
 
 func newRunUnpinCmd(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
-		Use:     "unpin <id>",
-		Short:   "Unpin a run",
+		Use:   "unpin <id>",
+		Short: "Unpin a run",
+		Long: `Remove the pin from a run, re-enabling cleanup by retention policies.
+
+The mirror of 'teamcity run pin'. A pinned run stays until it is
+unpinned; once unpinned, normal retention rules apply again.`,
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity run unpin 12345`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/metadata.go
+++ b/internal/cmd/run/metadata.go
@@ -14,8 +14,12 @@ func newRunPinCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pin <id>",
 		Short: "Pin to prevent cleanup",
-		Long:  `Pin a run to prevent it from being automatically cleaned up by retention policies.`,
-		Args:  cobra.ExactArgs(1),
+		Long: `Pin a run to exclude it from cleanup by retention policies.
+
+Use --comment to record the reason (e.g. "release candidate"). A
+pinned run stays visible in the UI and can be unpinned with
+'teamcity run unpin'.`,
+		Args: cobra.ExactArgs(1),
 		Example: `  teamcity run pin 12345
   teamcity run pin 12345 --comment "Release candidate"`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -41,7 +45,6 @@ func newRunUnpinCmd(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
 		Use:     "unpin <id>",
 		Short:   "Unpin a run",
-		Long:    `Remove the pin from a run, allowing it to be cleaned up by retention policies.`,
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity run unpin 12345`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -62,8 +65,11 @@ func newRunTagCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tag <id> <tag>...",
 		Short: "Add tags",
-		Long:  `Add one or more tags for categorization and filtering.`,
-		Args:  cobra.MinimumNArgs(2),
+		Long: `Add one or more tags to a run.
+
+Tags are free-form labels for categorization and filtering. Use
+'teamcity run list --tag <tag>' to find runs by tag.`,
+		Args: cobra.MinimumNArgs(2),
 		Example: `  teamcity run tag 12345 release
   teamcity run tag 12345 release v1.0 production`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -104,7 +110,6 @@ func newRunUntagCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "untag <id> <tag>...",
 		Short: "Remove tags",
-		Long:  `Remove one or more tags.`,
 		Args:  cobra.MinimumNArgs(2),
 		Example: `  teamcity run untag 12345 release
   teamcity run untag 12345 release v1.0`,

--- a/internal/cmd/run/restart.go
+++ b/internal/cmd/run/restart.go
@@ -20,8 +20,12 @@ func newRunRestartCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restart <id>",
 		Short: "Restart a run",
-		Long:  `Restart a run with the same configuration.`,
-		Args:  cobra.ExactArgs(1),
+		Long: `Re-queue a run with the same job, branch, revision, and parameters.
+
+The new run is a fresh build (new ID, new number) that reuses the
+source configuration from the original. Use --watch to stream the
+restarted run until it completes.`,
+		Args: cobra.ExactArgs(1),
 		Example: `  teamcity run restart 12345
   teamcity run restart 12345 --watch`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -10,9 +10,16 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:     "run",
 		Aliases: []string{"build"},
 		Short:   "Manage runs (builds)",
-		Long:    `List, view, start, and manage TeamCity runs (builds).`,
-		Args:    cobra.NoArgs,
-		RunE:    cmdutil.SubcommandRequired,
+		Long: `List, view, start, and manage TeamCity runs (builds).
+
+A run (called a build in the TeamCity UI) is a single execution of a
+job. Use these commands to trigger runs, watch them live, download
+artifacts and logs, inspect test results and VCS changes, and manage
+run metadata (tags, comments, pins).
+
+See: https://www.jetbrains.com/help/teamcity/build-results-page.html`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newRunListCmd(f))

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -22,24 +22,46 @@ See: https://www.jetbrains.com/help/teamcity/build-results-page.html`,
 		RunE: cmdutil.SubcommandRequired,
 	}
 
-	cmd.AddCommand(newRunListCmd(f))
-	cmd.AddCommand(newRunViewCmd(f))
-	cmd.AddCommand(newRunStartCmd(f))
-	cmd.AddCommand(newRunCancelCmd(f))
-	cmd.AddCommand(newRunWatchCmd(f))
-	cmd.AddCommand(newRunRestartCmd(f))
-	cmd.AddCommand(newRunDownloadCmd(f))
-	cmd.AddCommand(newRunArtifactsCmd(f))
-	cmd.AddCommand(newRunLogCmd(f))
-	cmd.AddCommand(newRunPinCmd(f))
-	cmd.AddCommand(newRunUnpinCmd(f))
-	cmd.AddCommand(newRunTagCmd(f))
-	cmd.AddCommand(newRunUntagCmd(f))
-	cmd.AddCommand(newRunCommentCmd(f))
-	cmd.AddCommand(newRunChangesCmd(f))
-	cmd.AddCommand(newRunTestsCmd(f))
-	cmd.AddCommand(newRunTreeCmd(f))
-	cmd.AddCommand(newRunDiffCmd(f))
+	cmd.AddGroup(
+		&cobra.Group{ID: "lifecycle", Title: "LIFECYCLE"},
+		&cobra.Group{ID: "artifacts", Title: "ARTIFACTS & LOGS"},
+		&cobra.Group{ID: "metadata", Title: "METADATA"},
+		&cobra.Group{ID: "analysis", Title: "ANALYSIS"},
+	)
+
+	addInGroup := func(groupID string, cmds ...*cobra.Command) {
+		for _, c := range cmds {
+			c.GroupID = groupID
+			cmd.AddCommand(c)
+		}
+	}
+
+	addInGroup("lifecycle",
+		newRunListCmd(f),
+		newRunViewCmd(f),
+		newRunStartCmd(f),
+		newRunCancelCmd(f),
+		newRunWatchCmd(f),
+		newRunRestartCmd(f),
+		newRunDiffCmd(f),
+		newRunTreeCmd(f),
+	)
+	addInGroup("artifacts",
+		newRunArtifactsCmd(f),
+		newRunDownloadCmd(f),
+		newRunLogCmd(f),
+	)
+	addInGroup("metadata",
+		newRunPinCmd(f),
+		newRunUnpinCmd(f),
+		newRunTagCmd(f),
+		newRunUntagCmd(f),
+		newRunCommentCmd(f),
+	)
+	addInGroup("analysis",
+		newRunChangesCmd(f),
+		newRunTestsCmd(f),
+	)
 
 	cmdutil.AliasAwareHelp(cmd, "run", "build")
 	return cmd

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -16,9 +16,13 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "skill",
 		Short: "Manage AI coding agent skills",
-		Long:  "Install, update, or remove TeamCity skills for AI coding agents (Claude Code, Cursor, etc.).",
-		Args:  cobra.NoArgs,
-		RunE:  cmdutil.SubcommandRequired,
+		Long: `Install, update, or remove TeamCity skills for AI coding agents.
+
+Skills teach AI coding agents (Claude Code, Cursor, and others) how
+to drive the teamcity CLI effectively. Skills can be installed
+globally for the current user or locally into a project.`,
+		Args: cobra.NoArgs,
+		RunE: cmdutil.SubcommandRequired,
 	}
 
 	cmd.AddCommand(newSkillListCmd(f))

--- a/internal/cmd/update/update.go
+++ b/internal/cmd/update/update.go
@@ -18,7 +18,7 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Check for CLI updates",
 		Long: `Check for CLI updates and show how to upgrade.
 
-Queries the GitHub Releases feed for the latest teamcity CLI
+Queries the releases feed for the latest TeamCity CLI
 version. When a newer release exists, prints the upgrade command
 matching the install method detected on this machine (Homebrew,
 Scoop, Winget, Chocolatey, or raw binary).`,

--- a/internal/cmd/update/update.go
+++ b/internal/cmd/update/update.go
@@ -14,8 +14,14 @@ import (
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
-		Use:     "update",
-		Short:   "Check for CLI updates and show how to upgrade",
+		Use:   "update",
+		Short: "Check for CLI updates",
+		Long: `Check for CLI updates and show how to upgrade.
+
+Queries the GitHub Releases feed for the latest teamcity CLI
+version. When a newer release exists, prints the upgrade command
+matching the install method detected on this machine (Homebrew,
+Scoop, Winget, Chocolatey, or raw binary).`,
 		Args:    cobra.NoArgs,
 		Example: `  teamcity update`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

Fixes #228. Groups the root command list into named sections per the [CLI Guidelines](https://clig.dev/#help) and unifies the `Long` help text across every top-level command, adding canonical links to the TeamCity documentation where a resource page applies.

## Changes

- **`internal/cmd/root.go`** — declare four groups (`CORE COMMANDS`, `INFRASTRUCTURE`, `CONFIGURATION`, `ADDITIONAL COMMANDS`) via `cobra.AddGroup`; assign each subcommand a `GroupID` through a small `addGrouped` helper; pin the built-in `help` and `completion` commands to `ADDITIONAL COMMANDS`.
- **Top-level commands (`agent`, `auth`, `job`, `pipeline`, `pool`, `project`, `queue`, `run`, `api`)** — rewrite `Long` in a consistent "one-line summary + short explainer + `See: <docs URL>`" shape, linking to the canonical `jetbrains.com/help/teamcity/` page for each resource.
- **Nested project subcommands (`vcs`, `ssh`, `cloud`, `connection`) and `param`** — same treatment, including docs links.
- **CLI-only commands (`alias`, `config`, `skill`, `update`)** — extended `Long` with a short explainer but no TeamCity docs link (none applies). Gave `update` a proper `Long` and tightened its `Short` from `"Check for CLI updates and show how to upgrade"` → `"Check for CLI updates"` to fit the new group layout.
- **`acceptance/testdata/help/help.txtar`** — assert the new group headings appear in root help.
- **`docs/topics/teamcity-cli-commands.md`** — regenerated via `just docs-generate` (picks up the new `update` short).

## Design Decisions

- Used `cobra.AddGroup` rather than a custom help template, matching the "Proposed solution" in #228: it scales as new commands arrive and stays Cobra-idiomatic.
- Chose four groups instead of the three in the issue so `help` and `completion` don't visually clutter the `CONFIGURATION` block; they live in `ADDITIONAL COMMANDS` via `SetHelpCommandGroupID` / `SetCompletionCommandGroupID`.
- Standardized the docs-link format as a trailing `See: <URL>` line rather than inline links, consistent with the existing pattern in `project settings` and `project token`.
- Left the curated "Common commands" block printed by bare `teamcity` untouched — it's a separate onboarding surface from `--help`.

## Example

```
$ teamcity --help
...
CORE COMMANDS
  job         Manage jobs (build configurations)
  pipeline    Manage pipelines (YAML configurations)
  project     Manage projects
  run         Manage runs (builds)

INFRASTRUCTURE
  agent       Manage build agents
  pool        Manage agent pools
  queue       Manage build queue

CONFIGURATION
  alias       Manage command aliases
  api         Make an authenticated API request
  auth        Authenticate with TeamCity
  config      Manage CLI configuration
  skill       Manage AI coding agent skills
  update      Check for CLI updates

ADDITIONAL COMMANDS
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
```

```
$ teamcity agent --help
List, view, and manage TeamCity build agents.

Build agents run the jobs assigned by the TeamCity server. Use these
commands to inspect agent state, toggle availability, and open a shell
to a running agent.

See: https://www.jetbrains.com/help/teamcity/build-agent.html
...
```

## Test Plan

- [x] Unit tests pass (`just unit`) — `go test ./...` clean locally.
- [ ] Linter passes (`just lint`) — local `golangci-lint` 2.5.0 is built against Go 1.25 and refuses the repo's Go 1.26 target; relying on CI for the lint gate.
- [ ] Acceptance tests pass (`just acceptance`) — not run locally; the updated `help.txtar` asserts the new group headings.
- [x] If adding a new command/flag: N/A (help-text-only change).
- [x] If adding a data-producing command: N/A.
- [x] If modifying `--json` output: N/A.
- [x] If changing docs-visible behavior: regenerated `docs/topics/teamcity-cli-commands.md`. `skills/` and `README.md` do not reference the changed `Short`/`Long` strings, so no updates needed there.