### PR TITLE
feat: opt-in pager for list commands

### DIFF
--- a/docs/topics/teamcity-cli-configuration.md
+++ b/docs/topics/teamcity-cli-configuration.md
@@ -75,6 +75,23 @@ The default TeamCity server URL.
 <tr>
 <td>
 
+`pager`
+
+</td>
+<td>
+
+Global
+
+</td>
+<td>
+
+Pager command to use for long output. List commands (`run list`, `job list`, and so on) opt in when this is set; `run log` and `run diff` page by default. Set to an empty string to clear, or to `cat` to explicitly disable paging. Overridden by `TEAMCITY_PAGER`.
+
+</td>
+</tr>
+<tr>
+<td>
+
 `guest`
 
 </td>
@@ -277,6 +294,18 @@ Set to `1`, `true`, or `yes` to enable read-only mode. When enabled, all non-GET
 <td>
 
 Path to the Kotlin DSL directory. Overrides automatic detection of `.teamcity/` or `.tc/` directories.
+
+</td>
+</tr>
+<tr>
+<td>
+
+`TEAMCITY_PAGER`
+
+</td>
+<td>
+
+Pager command to pipe long output through. Takes precedence over the `pager` config key and the generic `PAGER` environment variable. Set to `cat` to explicitly disable paging.
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-configuration.md
+++ b/docs/topics/teamcity-cli-configuration.md
@@ -75,23 +75,6 @@ The default TeamCity server URL.
 <tr>
 <td>
 
-`pager`
-
-</td>
-<td>
-
-Global
-
-</td>
-<td>
-
-Pager command to use for long output. List commands (`run list`, `job list`, and so on) opt in when this is set; `run log` and `run diff` page by default. Set to an empty string to clear, or to `cat` to explicitly disable paging. Overridden by `TEAMCITY_PAGER`.
-
-</td>
-</tr>
-<tr>
-<td>
-
 `guest`
 
 </td>
@@ -305,7 +288,7 @@ Path to the Kotlin DSL directory. Overrides automatic detection of `.teamcity/` 
 </td>
 <td>
 
-Pager command to pipe long output through. Takes precedence over the `pager` config key and the generic `PAGER` environment variable. Set to `cat` to explicitly disable paging.
+Pager command to pipe long output through. Takes precedence over the generic `PAGER` environment variable. List commands (`run list`, `job list`, and so on) opt in when this is set; `run log` and `run diff` page by default. Set to `cat` to explicitly disable paging.
 
 </td>
 </tr>

--- a/internal/cmd/agent/agent_jobs.go
+++ b/internal/cmd/agent/agent_jobs.go
@@ -2,10 +2,12 @@ package agent
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -96,12 +98,16 @@ func showCompatibleJobs(p *output.Printer, client api.ClientInterface, agentID i
 		})
 	}
 
-	if opts.plain {
-		p.PrintPlainTable(headers, rows, opts.noHeader)
-	} else {
+	if !opts.plain {
 		output.AutoSizeColumns(headers, rows, 2, 0, 1, 2)
-		p.PrintTable(headers, rows)
 	}
+	output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, p.Out, func(w io.Writer) {
+		if opts.plain {
+			p.PrintPlainTableTo(w, headers, rows, opts.noHeader)
+		} else {
+			p.PrintTableTo(w, headers, rows)
+		}
+	})
 	return nil
 }
 
@@ -166,6 +172,8 @@ func showIncompatibleJobsPlain(p *output.Printer, compat *api.CompatibilityList,
 		})
 	}
 
-	p.PrintPlainTable(headers, rows, noHeader)
+	output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, p.Out, func(w io.Writer) {
+		p.PrintPlainTableTo(w, headers, rows, noHeader)
+	})
 	return nil
 }

--- a/internal/cmd/alias/alias.go
+++ b/internal/cmd/alias/alias.go
@@ -2,12 +2,14 @@ package alias
 
 import (
 	"fmt"
+	"io"
 	"maps"
 	"slices"
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -155,7 +157,9 @@ func newAliasListCmd(f *cmdutil.Factory) *cobra.Command {
 				}
 				rows = append(rows, []string{name, displayExp, aliasType})
 			}
-			f.Printer.PrintTable(headers, rows)
+			output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, f.Printer.Out, func(w io.Writer) {
+				f.Printer.PrintTableTo(w, headers, rows)
+			})
 			return nil
 		},
 	}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -57,6 +57,7 @@ func newListCmd(f *cmdutil.Factory) *cobra.Command {
 
 type configJSON struct {
 	DefaultServer string                `json:"default_server"`
+	Pager         string                `json:"pager,omitempty"`
 	Servers       map[string]serverJSON `json:"servers"`
 	Aliases       map[string]string     `json:"aliases"`
 	Environment   map[string]string     `json:"environment,omitempty"`
@@ -83,6 +84,7 @@ func runList(f *cmdutil.Factory, jsonOutput bool) error {
 	} else {
 		_, _ = fmt.Fprintf(p.Out, "default_server=\n")
 	}
+	_, _ = fmt.Fprintf(p.Out, "pager=%s\n", c.Pager)
 
 	urls := sortedServerURLs(c)
 	for _, serverURL := range urls {
@@ -124,6 +126,7 @@ func printListJSON(p *output.Printer, c *cfg.Config) error {
 	env := collectEnvOverrides()
 	out := configJSON{
 		DefaultServer: c.DefaultServer,
+		Pager:         c.Pager,
 		Servers:       servers,
 		Aliases:       aliases,
 	}
@@ -146,7 +149,7 @@ func printEnvOverrides(p *output.Printer) {
 
 func collectEnvOverrides() map[string]string {
 	env := map[string]string{}
-	for _, key := range []string{cfg.EnvServerURL, cfg.EnvToken, cfg.EnvGuestAuth, cfg.EnvReadOnly} {
+	for _, key := range []string{cfg.EnvServerURL, cfg.EnvToken, cfg.EnvGuestAuth, cfg.EnvReadOnly, cfg.EnvPager, "PAGER"} {
 		if v := os.Getenv(key); v != "" {
 			if key == cfg.EnvToken {
 				v = "****"

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -57,7 +57,6 @@ func newListCmd(f *cmdutil.Factory) *cobra.Command {
 
 type configJSON struct {
 	DefaultServer string                `json:"default_server"`
-	Pager         string                `json:"pager,omitempty"`
 	Servers       map[string]serverJSON `json:"servers"`
 	Aliases       map[string]string     `json:"aliases"`
 	Environment   map[string]string     `json:"environment,omitempty"`
@@ -84,7 +83,6 @@ func runList(f *cmdutil.Factory, jsonOutput bool) error {
 	} else {
 		_, _ = fmt.Fprintf(p.Out, "default_server=\n")
 	}
-	_, _ = fmt.Fprintf(p.Out, "pager=%s\n", c.Pager)
 
 	urls := sortedServerURLs(c)
 	for _, serverURL := range urls {
@@ -126,7 +124,6 @@ func printListJSON(p *output.Printer, c *cfg.Config) error {
 	env := collectEnvOverrides()
 	out := configJSON{
 		DefaultServer: c.DefaultServer,
-		Pager:         c.Pager,
 		Servers:       servers,
 		Aliases:       aliases,
 	}

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -150,33 +150,6 @@ func TestConfigSetTokenExpiry(t *testing.T) {
 	assert.Contains(t, got, "2026-01-01T00:00:00Z")
 }
 
-func TestConfigSetPager(t *testing.T) {
-	setupWithServer(t)
-	out := capture(t, "config", "set", "pager", "less -R")
-	assert.Contains(t, out, "Set pager")
-
-	got := capture(t, "config", "get", "pager")
-	assert.Contains(t, got, "less -R")
-}
-
-func TestConfigSetPagerClear(t *testing.T) {
-	setupWithServer(t)
-	capture(t, "config", "set", "pager", "less -R")
-	capture(t, "config", "set", "pager", "")
-
-	got := capture(t, "config", "get", "pager")
-	// An empty value renders as a blank line.
-	assert.NotContains(t, got, "less")
-}
-
-func TestConfigListShowsPager(t *testing.T) {
-	setupWithServer(t)
-	capture(t, "config", "set", "pager", "less -R")
-
-	out := capture(t, "config", "list")
-	assert.Contains(t, out, "pager=less -R")
-}
-
 func TestConfigListEnvOverridesIncludesPager(t *testing.T) {
 	setupWithServer(t)
 	t.Setenv("TEAMCITY_PAGER", "less -R")

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -150,6 +150,41 @@ func TestConfigSetTokenExpiry(t *testing.T) {
 	assert.Contains(t, got, "2026-01-01T00:00:00Z")
 }
 
+func TestConfigSetPager(t *testing.T) {
+	setupWithServer(t)
+	out := capture(t, "config", "set", "pager", "less -R")
+	assert.Contains(t, out, "Set pager")
+
+	got := capture(t, "config", "get", "pager")
+	assert.Contains(t, got, "less -R")
+}
+
+func TestConfigSetPagerClear(t *testing.T) {
+	setupWithServer(t)
+	capture(t, "config", "set", "pager", "less -R")
+	capture(t, "config", "set", "pager", "")
+
+	got := capture(t, "config", "get", "pager")
+	// An empty value renders as a blank line.
+	assert.NotContains(t, got, "less")
+}
+
+func TestConfigListShowsPager(t *testing.T) {
+	setupWithServer(t)
+	capture(t, "config", "set", "pager", "less -R")
+
+	out := capture(t, "config", "list")
+	assert.Contains(t, out, "pager=less -R")
+}
+
+func TestConfigListEnvOverridesIncludesPager(t *testing.T) {
+	setupWithServer(t)
+	t.Setenv("TEAMCITY_PAGER", "less -R")
+
+	out := capture(t, "config", "list")
+	assert.Contains(t, out, "TEAMCITY_PAGER=less -R")
+}
+
 func TestConfigListAliases(t *testing.T) {
 	setupWithServer(t)
 	require.NoError(t, config.AddAlias("rl", "run list"))

--- a/internal/cmd/param/param.go
+++ b/internal/cmd/param/param.go
@@ -2,9 +2,11 @@ package param
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -130,12 +132,16 @@ func runParamList(f *cmdutil.Factory, id string, opts *paramListOptions, paramAP
 		})
 	}
 
-	if opts.plain {
-		p.PrintPlainTable(headers, rows, opts.noHeader)
-	} else {
+	if !opts.plain {
 		output.AutoSizeColumns(headers, rows, 2, 0, 1)
-		p.PrintTable(headers, rows)
 	}
+	output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, p.Out, func(w io.Writer) {
+		if opts.plain {
+			p.PrintPlainTableTo(w, headers, rows, opts.noHeader)
+		} else {
+			p.PrintTableTo(w, headers, rows)
+		}
+	})
 	return nil
 }
 

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmd/param"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -429,7 +430,9 @@ func runProjectTree(f *cmdutil.Factory, rootID string, noJobs bool, depth int, j
 	if jsonOut {
 		return f.Printer.PrintJSON(node)
 	}
-	f.Printer.PrintTree(node.toDisplayNode())
+	output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, f.Printer.Out, func(w io.Writer) {
+		f.Printer.PrintTreeTo(w, node.toDisplayNode())
+	})
 	return nil
 }
 

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -37,9 +37,7 @@ func TestRunList(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, f, "run", "list", "--json", "--limit", "2")
 }
 
-// TestRunListPagerCatIsPassthrough checks that setting TEAMCITY_PAGER=cat —
-// the explicit "disable paging" escape hatch — doesn't swallow the list
-// output. The table should still land on the captured buffer unchanged.
+// TestRunListPagerCatIsPassthrough: TEAMCITY_PAGER=cat (the explicit disable) must not swallow list output.
 func TestRunListPagerCatIsPassthrough(T *testing.T) {
 	T.Setenv("TEAMCITY_PAGER", "cat")
 
@@ -50,14 +48,11 @@ func TestRunListPagerCatIsPassthrough(T *testing.T) {
 	ts2 := cmdtest.SetupMockClient(T)
 	withPager := cmdtest.CaptureOutput(T, ts2.Factory, "run", "list", "--limit", "5")
 
-	// Pager=cat path must behave identically to direct output for the user —
-	// the table renders on stdout either way.
 	assert.Equal(T, baseline, withPager)
 	assert.NotEmpty(T, withPager)
 }
 
-// TestRunListNoPagerUnchanged guards against regressions: without any pager
-// configured, `run list` output must be identical to the existing baseline.
+// TestRunListNoPagerUnchanged: regression guard — `run list` output without a pager matches the pre-PR baseline.
 func TestRunListNoPagerUnchanged(T *testing.T) {
 	T.Setenv("TEAMCITY_PAGER", "")
 	T.Setenv("PAGER", "")
@@ -65,7 +60,6 @@ func TestRunListNoPagerUnchanged(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	out := cmdtest.CaptureOutput(T, ts.Factory, "run", "list", "--limit", "5")
 
-	// Expect a rendered table header — same as before the pager work.
 	assert.Contains(T, out, "STATUS")
 	assert.Contains(T, out, "RUN")
 	assert.Contains(T, out, "JOB")

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -37,6 +37,40 @@ func TestRunList(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, f, "run", "list", "--json", "--limit", "2")
 }
 
+// TestRunListPagerCatIsPassthrough checks that setting TEAMCITY_PAGER=cat —
+// the explicit "disable paging" escape hatch — doesn't swallow the list
+// output. The table should still land on the captured buffer unchanged.
+func TestRunListPagerCatIsPassthrough(T *testing.T) {
+	T.Setenv("TEAMCITY_PAGER", "cat")
+
+	ts := cmdtest.SetupMockClient(T)
+	baseline := cmdtest.CaptureOutput(T, ts.Factory, "run", "list", "--limit", "5")
+
+	T.Setenv("TEAMCITY_PAGER", "cat")
+	ts2 := cmdtest.SetupMockClient(T)
+	withPager := cmdtest.CaptureOutput(T, ts2.Factory, "run", "list", "--limit", "5")
+
+	// Pager=cat path must behave identically to direct output for the user —
+	// the table renders on stdout either way.
+	assert.Equal(T, baseline, withPager)
+	assert.NotEmpty(T, withPager)
+}
+
+// TestRunListNoPagerUnchanged guards against regressions: without any pager
+// configured, `run list` output must be identical to the existing baseline.
+func TestRunListNoPagerUnchanged(T *testing.T) {
+	T.Setenv("TEAMCITY_PAGER", "")
+	T.Setenv("PAGER", "")
+
+	ts := cmdtest.SetupMockClient(T)
+	out := cmdtest.CaptureOutput(T, ts.Factory, "run", "list", "--limit", "5")
+
+	// Expect a rendered table header — same as before the pager work.
+	assert.Contains(T, out, "STATUS")
+	assert.Contains(T, out, "RUN")
+	assert.Contains(T, out, "JOB")
+}
+
 func TestRunListBackwardsDateRange(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 	"time"
@@ -184,12 +185,16 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 	}
 
 	p := f.Printer
-	if opts.plain {
-		p.PrintPlainTable(headers, rows, opts.noHeader)
-	} else {
+	if !opts.plain {
 		output.AutoSizeColumns(headers, rows, 2, 2, 3, 4)
-		p.PrintTable(headers, rows)
 	}
+	output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, p.Out, func(w io.Writer) {
+		if opts.plain {
+			p.PrintPlainTableTo(w, headers, rows, opts.noHeader)
+		} else {
+			p.PrintTableTo(w, headers, rows)
+		}
+	})
 	return nil
 }
 

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -2,9 +2,11 @@ package skill
 
 import (
 	"fmt"
+	"io"
 
 	teamcitycli "github.com/JetBrains/teamcity-cli"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/tiulpin/instill"
@@ -58,7 +60,9 @@ func newSkillListCmd(f *cmdutil.Factory) *cobra.Command {
 				}
 				rows[i] = []string{s.Name, s.Version, s.Description, def}
 			}
-			f.Printer.PrintTable([]string{"Name", "Version", "Description", ""}, rows)
+			output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, f.Printer.Out, func(w io.Writer) {
+				f.Printer.PrintTableTo(w, []string{"Name", "Version", "Description", ""}, rows)
+			})
 			return nil
 		},
 	}

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/fatih/color"
 	"github.com/mattn/go-isatty"
@@ -79,6 +80,10 @@ func (f *Factory) InitOutput() {
 
 	f.Printer.Quiet = f.Quiet
 	f.Printer.Verbose = f.Verbose
+
+	// Wire the pager resolver so the output package can pull the user's
+	// configured pager without importing config.
+	output.PagerResolver = config.ResolvePager
 }
 
 // IsInteractive returns true if the CLI can prompt the user.

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -81,8 +81,7 @@ func (f *Factory) InitOutput() {
 	f.Printer.Quiet = f.Quiet
 	f.Printer.Verbose = f.Verbose
 
-	// Wire the pager resolver so the output package can pull the user's
-	// configured pager without importing config.
+	// Inject the pager resolver so output doesn't import config.
 	output.PagerResolver = config.ResolvePager
 }
 

--- a/internal/cmdutil/list.go
+++ b/internal/cmdutil/list.go
@@ -1,7 +1,10 @@
 package cmdutil
 
 import (
+	"io"
+
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -92,13 +95,16 @@ func RunList(
 		return nil
 	}
 
-	if flags.Plain {
-		f.Printer.PrintPlainTable(result.Table.Headers, result.Table.Rows, flags.NoHeader)
-	} else {
-		if len(result.Table.FlexCols) > 0 {
-			output.AutoSizeColumns(result.Table.Headers, result.Table.Rows, 2, result.Table.FlexCols...)
-		}
-		f.Printer.PrintTable(result.Table.Headers, result.Table.Rows)
+	if len(result.Table.FlexCols) > 0 && !flags.Plain {
+		output.AutoSizeColumns(result.Table.Headers, result.Table.Rows, 2, result.Table.FlexCols...)
 	}
+
+	output.WithPagerUsing(config.ResolvePager(), output.PagerOpts{ChopLongLines: true}, f.Printer.Out, func(w io.Writer) {
+		if flags.Plain {
+			f.Printer.PrintPlainTableTo(w, result.Table.Headers, result.Table.Rows, flags.NoHeader)
+		} else {
+			f.Printer.PrintTableTo(w, result.Table.Headers, result.Table.Rows)
+		}
+	})
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,7 +39,6 @@ type ServerConfig struct {
 
 type Config struct {
 	DefaultServer string                  `mapstructure:"default_server"`
-	Pager         string                  `mapstructure:"pager,omitempty"`
 	Servers       map[string]ServerConfig `mapstructure:"servers"`
 	Aliases       map[string]string       `mapstructure:"aliases"`
 }
@@ -257,9 +256,6 @@ func writeConfig() error {
 	w.SetConfigType("yaml")
 
 	w.Set("default_server", cfg.DefaultServer)
-	if cfg.Pager != "" {
-		w.Set("pager", cfg.Pager)
-	}
 
 	servers := make(map[string]any, len(cfg.Servers))
 	for url, sc := range cfg.Servers {
@@ -344,15 +340,15 @@ func ConfigPath() string {
 	return configPath
 }
 
-// ResolvePager returns the pager command as the user would type it. Precedence:
-// TEAMCITY_PAGER, config `pager` key, PAGER env var, then empty (no pager).
-// Callers treat empty (or `cat`) as explicit disable.
+// ResolvePager returns the pager command as the user would type it.
+// Precedence: TEAMCITY_PAGER, then PAGER, then empty (no pager).
+// Callers treat empty (or `cat`) as explicit disable. We intentionally
+// do NOT persist a pager choice to config.yml — env vars cover the
+// per-shell and machine-wide use cases, matching the kubectl / docker
+// model.
 func ResolvePager() string {
 	if v := os.Getenv(EnvPager); v != "" {
 		return v
-	}
-	if cfg != nil && cfg.Pager != "" {
-		return cfg.Pager
 	}
 	if v := os.Getenv("PAGER"); v != "" {
 		return v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -340,12 +340,7 @@ func ConfigPath() string {
 	return configPath
 }
 
-// ResolvePager returns the pager command as the user would type it.
-// Precedence: TEAMCITY_PAGER, then PAGER, then empty (no pager).
-// Callers treat empty (or `cat`) as explicit disable. We intentionally
-// do NOT persist a pager choice to config.yml — env vars cover the
-// per-shell and machine-wide use cases, matching the kubectl / docker
-// model.
+// ResolvePager returns the pager command with precedence TEAMCITY_PAGER > PAGER > "" (callers treat "" / `cat` as disabled).
 func ResolvePager() string {
 	if v := os.Getenv(EnvPager); v != "" {
 		return v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ const (
 	EnvGuestAuth = "TEAMCITY_GUEST"
 	EnvReadOnly  = "TEAMCITY_RO"
 	EnvDSLDir    = "TEAMCITY_DSL_DIR"
+	EnvPager     = "TEAMCITY_PAGER"
 
 	DefaultDSLDirTeamCity = ".teamcity"
 	DefaultDSLDirTC       = ".tc"
@@ -38,6 +39,7 @@ type ServerConfig struct {
 
 type Config struct {
 	DefaultServer string                  `mapstructure:"default_server"`
+	Pager         string                  `mapstructure:"pager,omitempty"`
 	Servers       map[string]ServerConfig `mapstructure:"servers"`
 	Aliases       map[string]string       `mapstructure:"aliases"`
 }
@@ -255,6 +257,9 @@ func writeConfig() error {
 	w.SetConfigType("yaml")
 
 	w.Set("default_server", cfg.DefaultServer)
+	if cfg.Pager != "" {
+		w.Set("pager", cfg.Pager)
+	}
 
 	servers := make(map[string]any, len(cfg.Servers))
 	for url, sc := range cfg.Servers {
@@ -337,6 +342,22 @@ func RemoveServer(serverURL string) error {
 
 func ConfigPath() string {
 	return configPath
+}
+
+// ResolvePager returns the pager command as the user would type it. Precedence:
+// TEAMCITY_PAGER, config `pager` key, PAGER env var, then empty (no pager).
+// Callers treat empty (or `cat`) as explicit disable.
+func ResolvePager() string {
+	if v := os.Getenv(EnvPager); v != "" {
+		return v
+	}
+	if cfg != nil && cfg.Pager != "" {
+		return cfg.Pager
+	}
+	if v := os.Getenv("PAGER"); v != "" {
+		return v
+	}
+	return ""
 }
 
 // IsGuestAuth returns true if guest authentication is enabled via env var or server config

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -6,7 +6,10 @@ import (
 	"strings"
 )
 
-var validKeys = []string{"default_server", "guest", "ro", "token_expiry"}
+var validKeys = []string{"default_server", "pager", "guest", "ro", "token_expiry"}
+
+// globalKeys are configuration keys that are not scoped to a specific server.
+var globalKeys = []string{"default_server", "pager"}
 
 func IsValidKey(key string) bool {
 	return slices.Contains(validKeys, key)
@@ -16,12 +19,19 @@ func ValidKeys() []string {
 	return validKeys
 }
 
+func isGlobalKey(key string) bool {
+	return slices.Contains(globalKeys, key)
+}
+
 func GetField(key, serverURL string) (string, error) {
 	if !IsValidKey(key) {
 		return "", unknownKeyError(key)
 	}
-	if key == "default_server" {
+	switch key {
+	case "default_server":
 		return Get().DefaultServer, nil
+	case "pager":
+		return Get().Pager, nil
 	}
 	serverURL, err := resolveServerForConfig(serverURL)
 	if err != nil {
@@ -46,7 +56,11 @@ func SetField(key, value, serverURL string) error {
 	if !IsValidKey(key) {
 		return unknownKeyError(key)
 	}
-	if key == "default_server" {
+	if isGlobalKey(key) && serverURL != "" {
+		return fmt.Errorf("key %q is global; drop --server", key)
+	}
+	switch key {
+	case "default_server":
 		if value == "" {
 			return fmt.Errorf("value cannot be empty")
 		}
@@ -55,6 +69,9 @@ func SetField(key, value, serverURL string) error {
 			return fmt.Errorf("server %q not found in configuration; run 'teamcity auth login --server %s' first", normalized, value)
 		}
 		cfg.DefaultServer = normalized
+		return writeConfig()
+	case "pager":
+		cfg.Pager = value
 		return writeConfig()
 	}
 	serverURL, err := resolveServerForConfig(serverURL)

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -6,10 +6,7 @@ import (
 	"strings"
 )
 
-var validKeys = []string{"default_server", "pager", "guest", "ro", "token_expiry"}
-
-// globalKeys are configuration keys that are not scoped to a specific server.
-var globalKeys = []string{"default_server", "pager"}
+var validKeys = []string{"default_server", "guest", "ro", "token_expiry"}
 
 func IsValidKey(key string) bool {
 	return slices.Contains(validKeys, key)
@@ -19,19 +16,12 @@ func ValidKeys() []string {
 	return validKeys
 }
 
-func isGlobalKey(key string) bool {
-	return slices.Contains(globalKeys, key)
-}
-
 func GetField(key, serverURL string) (string, error) {
 	if !IsValidKey(key) {
 		return "", unknownKeyError(key)
 	}
-	switch key {
-	case "default_server":
+	if key == "default_server" {
 		return Get().DefaultServer, nil
-	case "pager":
-		return Get().Pager, nil
 	}
 	serverURL, err := resolveServerForConfig(serverURL)
 	if err != nil {
@@ -56,11 +46,7 @@ func SetField(key, value, serverURL string) error {
 	if !IsValidKey(key) {
 		return unknownKeyError(key)
 	}
-	if isGlobalKey(key) && serverURL != "" {
-		return fmt.Errorf("key %q is global; drop --server", key)
-	}
-	switch key {
-	case "default_server":
+	if key == "default_server" {
 		if value == "" {
 			return fmt.Errorf("value cannot be empty")
 		}
@@ -69,9 +55,6 @@ func SetField(key, value, serverURL string) error {
 			return fmt.Errorf("server %q not found in configuration; run 'teamcity auth login --server %s' first", normalized, value)
 		}
 		cfg.DefaultServer = normalized
-		return writeConfig()
-	case "pager":
-		cfg.Pager = value
 		return writeConfig()
 	}
 	serverURL, err := resolveServerForConfig(serverURL)

--- a/internal/config/fields_test.go
+++ b/internal/config/fields_test.go
@@ -1,11 +1,9 @@
 package config
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResolvePager(T *testing.T) {
@@ -13,81 +11,23 @@ func TestResolvePager(T *testing.T) {
 		saveCfgState(t)
 		t.Setenv(EnvPager, "")
 		t.Setenv("PAGER", "")
-		cfg = &Config{Servers: map[string]ServerConfig{}}
 
 		assert.Equal(t, "", ResolvePager())
 	})
 
-	T.Run("TEAMCITY_PAGER wins over everything", func(t *testing.T) {
+	T.Run("TEAMCITY_PAGER wins over PAGER", func(t *testing.T) {
 		saveCfgState(t)
 		t.Setenv(EnvPager, "less -R")
 		t.Setenv("PAGER", "more")
-		cfg = &Config{Pager: "bat", Servers: map[string]ServerConfig{}}
 
 		assert.Equal(t, "less -R", ResolvePager())
 	})
 
-	T.Run("config pager wins over PAGER env", func(t *testing.T) {
+	T.Run("PAGER used when TEAMCITY_PAGER unset", func(t *testing.T) {
 		saveCfgState(t)
 		t.Setenv(EnvPager, "")
 		t.Setenv("PAGER", "more")
-		cfg = &Config{Pager: "bat", Servers: map[string]ServerConfig{}}
-
-		assert.Equal(t, "bat", ResolvePager())
-	})
-
-	T.Run("PAGER env used when no config value", func(t *testing.T) {
-		saveCfgState(t)
-		t.Setenv(EnvPager, "")
-		t.Setenv("PAGER", "more")
-		cfg = &Config{Servers: map[string]ServerConfig{}}
 
 		assert.Equal(t, "more", ResolvePager())
 	})
-}
-
-func TestSetPager(T *testing.T) {
-	saveCfgState(T)
-	dir := T.TempDir()
-	configPath = filepath.Join(dir, "config.yml")
-	cfg = &Config{Servers: map[string]ServerConfig{}}
-
-	require.NoError(T, SetField("pager", "less -R", ""))
-	assert.Equal(T, "less -R", cfg.Pager)
-
-	got, err := GetField("pager", "")
-	require.NoError(T, err)
-	assert.Equal(T, "less -R", got)
-}
-
-func TestSetPagerClearsValue(T *testing.T) {
-	saveCfgState(T)
-	dir := T.TempDir()
-	configPath = filepath.Join(dir, "config.yml")
-	cfg = &Config{Pager: "less -R", Servers: map[string]ServerConfig{}}
-
-	require.NoError(T, SetField("pager", "", ""))
-	assert.Equal(T, "", cfg.Pager)
-}
-
-func TestSetPagerRejectsServerFlag(T *testing.T) {
-	saveCfgState(T)
-	cfg = &Config{Servers: map[string]ServerConfig{}}
-
-	err := SetField("pager", "less", "https://tc.example.com")
-	require.Error(T, err)
-	assert.Contains(T, err.Error(), "global")
-}
-
-func TestGetPagerEmptyWhenUnset(T *testing.T) {
-	saveCfgState(T)
-	cfg = &Config{Servers: map[string]ServerConfig{}}
-
-	got, err := GetField("pager", "")
-	require.NoError(T, err)
-	assert.Equal(T, "", got)
-}
-
-func TestValidKeysIncludesPager(T *testing.T) {
-	assert.Contains(T, ValidKeys(), "pager")
 }

--- a/internal/config/fields_test.go
+++ b/internal/config/fields_test.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolvePager(T *testing.T) {
+	T.Run("returns empty when nothing set", func(t *testing.T) {
+		saveCfgState(t)
+		t.Setenv(EnvPager, "")
+		t.Setenv("PAGER", "")
+		cfg = &Config{Servers: map[string]ServerConfig{}}
+
+		assert.Equal(t, "", ResolvePager())
+	})
+
+	T.Run("TEAMCITY_PAGER wins over everything", func(t *testing.T) {
+		saveCfgState(t)
+		t.Setenv(EnvPager, "less -R")
+		t.Setenv("PAGER", "more")
+		cfg = &Config{Pager: "bat", Servers: map[string]ServerConfig{}}
+
+		assert.Equal(t, "less -R", ResolvePager())
+	})
+
+	T.Run("config pager wins over PAGER env", func(t *testing.T) {
+		saveCfgState(t)
+		t.Setenv(EnvPager, "")
+		t.Setenv("PAGER", "more")
+		cfg = &Config{Pager: "bat", Servers: map[string]ServerConfig{}}
+
+		assert.Equal(t, "bat", ResolvePager())
+	})
+
+	T.Run("PAGER env used when no config value", func(t *testing.T) {
+		saveCfgState(t)
+		t.Setenv(EnvPager, "")
+		t.Setenv("PAGER", "more")
+		cfg = &Config{Servers: map[string]ServerConfig{}}
+
+		assert.Equal(t, "more", ResolvePager())
+	})
+}
+
+func TestSetPager(T *testing.T) {
+	saveCfgState(T)
+	dir := T.TempDir()
+	configPath = filepath.Join(dir, "config.yml")
+	cfg = &Config{Servers: map[string]ServerConfig{}}
+
+	require.NoError(T, SetField("pager", "less -R", ""))
+	assert.Equal(T, "less -R", cfg.Pager)
+
+	got, err := GetField("pager", "")
+	require.NoError(T, err)
+	assert.Equal(T, "less -R", got)
+}
+
+func TestSetPagerClearsValue(T *testing.T) {
+	saveCfgState(T)
+	dir := T.TempDir()
+	configPath = filepath.Join(dir, "config.yml")
+	cfg = &Config{Pager: "less -R", Servers: map[string]ServerConfig{}}
+
+	require.NoError(T, SetField("pager", "", ""))
+	assert.Equal(T, "", cfg.Pager)
+}
+
+func TestSetPagerRejectsServerFlag(T *testing.T) {
+	saveCfgState(T)
+	cfg = &Config{Servers: map[string]ServerConfig{}}
+
+	err := SetField("pager", "less", "https://tc.example.com")
+	require.Error(T, err)
+	assert.Contains(T, err.Error(), "global")
+}
+
+func TestGetPagerEmptyWhenUnset(T *testing.T) {
+	saveCfgState(T)
+	cfg = &Config{Servers: map[string]ServerConfig{}}
+
+	got, err := GetField("pager", "")
+	require.NoError(T, err)
+	assert.Equal(T, "", got)
+}
+
+func TestValidKeysIncludesPager(T *testing.T) {
+	assert.Contains(T, ValidKeys(), "pager")
+}

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -89,25 +89,41 @@ func (p *Printer) PrintViewHeader(title, webURL string, details func()) {
 }
 
 func (p *Printer) PrintTable(headers []string, rows [][]string) {
-	_, _ = fmt.Fprintln(p.Out, renderTable(headers, rows))
+	p.PrintTableTo(p.Out, headers, rows)
+}
+
+// PrintTableTo is like PrintTable but writes to w instead of p.Out. Used
+// when wrapping output in WithPagerUsing, whose closure exposes a writer.
+func (p *Printer) PrintTableTo(w io.Writer, headers []string, rows [][]string) {
+	_, _ = fmt.Fprintln(w, renderTable(headers, rows))
 }
 
 func (p *Printer) PrintPlainTable(headers []string, rows [][]string, noHeader bool) {
-	_, _ = fmt.Fprint(p.Out, renderPlainTable(headers, rows, noHeader))
+	p.PrintPlainTableTo(p.Out, headers, rows, noHeader)
+}
+
+// PrintPlainTableTo is like PrintPlainTable but writes to w instead of p.Out.
+func (p *Printer) PrintPlainTableTo(w io.Writer, headers []string, rows [][]string, noHeader bool) {
+	_, _ = fmt.Fprint(w, renderPlainTable(headers, rows, noHeader))
 }
 
 func (p *Printer) PrintTree(root TreeNode) {
-	_, _ = fmt.Fprintln(p.Out, root.Label)
-	p.printTreeNodes(root.Children, "")
+	p.PrintTreeTo(p.Out, root)
 }
 
-func (p *Printer) printTreeNodes(nodes []TreeNode, prefix string) {
+// PrintTreeTo is like PrintTree but writes to w instead of p.Out.
+func (p *Printer) PrintTreeTo(w io.Writer, root TreeNode) {
+	_, _ = fmt.Fprintln(w, root.Label)
+	printTreeNodesTo(w, root.Children, "")
+}
+
+func printTreeNodesTo(w io.Writer, nodes []TreeNode, prefix string) {
 	for i, n := range nodes {
 		conn, next := "├── ", "│   "
 		if i == len(nodes)-1 {
 			conn, next = "└── ", "    "
 		}
-		_, _ = fmt.Fprintf(p.Out, "%s%s%s\n", prefix, conn, n.Label)
-		p.printTreeNodes(n.Children, prefix+next)
+		_, _ = fmt.Fprintf(w, "%s%s%s\n", prefix, conn, n.Label)
+		printTreeNodesTo(w, n.Children, prefix+next)
 	}
 }

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -92,8 +92,7 @@ func (p *Printer) PrintTable(headers []string, rows [][]string) {
 	p.PrintTableTo(p.Out, headers, rows)
 }
 
-// PrintTableTo is like PrintTable but writes to w instead of p.Out. Used
-// when wrapping output in WithPagerUsing, whose closure exposes a writer.
+// PrintTableTo is like PrintTable but writes to w, so callers can route through WithPagerUsing.
 func (p *Printer) PrintTableTo(w io.Writer, headers []string, rows [][]string) {
 	_, _ = fmt.Fprintln(w, renderTable(headers, rows))
 }

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -2,11 +2,12 @@ package output
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
@@ -52,46 +53,167 @@ func TerminalWidth() int {
 	return w
 }
 
-// pagerCmdFn creates the pager command. Tests can override this.
-var pagerCmdFn = func() (*exec.Cmd, error) {
-	if pager := os.Getenv("PAGER"); pager != "" {
-		parts := strings.Fields(pager)
-		if len(parts) == 0 {
-			return nil, fmt.Errorf("PAGER is set but empty")
-		}
-		bin, err := exec.LookPath(parts[0])
-		if err != nil {
-			return nil, err
-		}
-		return exec.Command(bin, parts[1:]...), nil
-	}
-	lessPath, err := exec.LookPath("less")
-	if err != nil {
-		return nil, err
-	}
-	return exec.Command(lessPath, "-FIRX", "--mouse", "--incsearch"), nil
+// defaultLongFormPager is the fallback pager for long-form content
+// (`run log`, `run diff`) when neither TEAMCITY_PAGER, the config `pager`
+// key, nor the PAGER env var is set. It matches gh's less defaults plus
+// `-R` for ANSI colors and `-X` to avoid clearing the screen on exit.
+const defaultLongFormPager = "less -FIRX --mouse --incsearch"
+
+// PagerResolver returns the pager command string (as the user would type it).
+// The main package wires this to config.ResolvePager so the output package
+// doesn't need to import config. An empty return value means paging is
+// disabled; callers decide whether to fall back to a default pager.
+var PagerResolver = func() string { return "" }
+
+// PagerOpts tunes pager invocation.
+type PagerOpts struct {
+	// ChopLongLines asks the pager not to wrap lines. Used for wide tables
+	// where wrapping breaks column alignment. Only applied when the resolved
+	// pager is `less` (or unspecified, i.e. the default less fallback).
+	ChopLongLines bool
 }
 
-// WithPager pipes output through less if it exceeds terminal height.
-// The out writer is used as a fallback when paging is not available.
+// WithPager pipes long-form output through the resolved pager, defaulting to
+// less when nothing is configured. Used by `run log` and `run diff`, which
+// auto-page regardless of user config.
 func WithPager(out io.Writer, fn func(w io.Writer)) {
+	cmd := PagerResolver()
+	if cmd == "" {
+		cmd = defaultLongFormPager
+	}
+	WithPagerUsing(cmd, PagerOpts{}, out, fn)
+}
+
+// WithPagerUsing pipes output through the given pager command. An empty
+// pagerCmd (or one that resolves to `cat`) writes directly to out. When the
+// content is short enough to fit on screen, it also writes directly — no
+// reason to invoke a pager for a few lines.
+func WithPagerUsing(pagerCmd string, opts PagerOpts, out io.Writer, fn func(w io.Writer)) {
+	if isPagingDisabled(pagerCmd) || !IsTerminal() {
+		fn(out)
+		return
+	}
+
 	var buf bytes.Buffer
 	fn(&buf)
 
 	_, height := TerminalSize()
 	lineCount := bytes.Count(buf.Bytes(), []byte{'\n'})
-	pager, err := pagerCmdFn()
-
-	if !IsTerminal() || err != nil || lineCount <= height-2 {
+	if lineCount <= height-2 {
 		_, _ = out.Write(buf.Bytes())
 		return
 	}
 
-	data := buf.Bytes()
-	pager.Stdin = bytes.NewReader(data)
-	pager.Stdout = os.Stdout // must be a real terminal fd; using `out` here breaks pager rendering
-	pager.Stderr = os.Stderr
-	if err := pager.Run(); err != nil {
-		_, _ = out.Write(data)
+	cmd, err := buildPagerCmd(pagerCmd, opts)
+	if err != nil {
+		_, _ = out.Write(buf.Bytes())
+		return
 	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		_, _ = out.Write(buf.Bytes())
+		return
+	}
+	// Stdout/Stderr must be the real terminal fds; using out here breaks
+	// pager rendering when out is a buffer.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		_, _ = out.Write(buf.Bytes())
+		return
+	}
+
+	// Copy the buffer into the pager's stdin. If the user quits the pager
+	// before we finish writing, the pipe closes and we get EPIPE — that's
+	// expected and we swallow it. Any other copy error means the pager
+	// didn't receive the content, so we fall back to a direct write; but
+	// only if the process hasn't started displaying it yet. Since we can't
+	// tell, we prefer not to re-dump to avoid showing content twice.
+	_, copyErr := io.Copy(stdin, bytes.NewReader(buf.Bytes()))
+	_ = stdin.Close()
+	_ = cmd.Wait()
+
+	if copyErr != nil && !isEPIPE(copyErr) {
+		// An unusual pipe failure — the pager may not have shown anything.
+		// Re-dump content so the user still sees it.
+		_, _ = out.Write(buf.Bytes())
+	}
+}
+
+// isPagingDisabled returns true when the resolved pager should be treated
+// as a no-op: empty, or `cat` (a common way to disable paging via PAGER=cat).
+func isPagingDisabled(pagerCmd string) bool {
+	pagerCmd = strings.TrimSpace(pagerCmd)
+	if pagerCmd == "" {
+		return true
+	}
+	parts := strings.Fields(pagerCmd)
+	if len(parts) == 0 {
+		return true
+	}
+	base := parts[0]
+	if i := strings.LastIndexAny(base, "/\\"); i >= 0 {
+		base = base[i+1:]
+	}
+	return base == "cat"
+}
+
+// buildPagerCmd turns a user-facing pager string like `less -R` into an
+// *exec.Cmd. When the resolved pager's basename is `less` and ChopLongLines
+// is requested, `-S` is added if the user didn't already specify it.
+func buildPagerCmd(pagerCmd string, opts PagerOpts) (*exec.Cmd, error) {
+	parts := strings.Fields(pagerCmd)
+	if len(parts) == 0 {
+		return nil, errors.New("pager command is empty")
+	}
+
+	bin, err := exec.LookPath(parts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	args := parts[1:]
+	if opts.ChopLongLines && isLessBinary(parts[0]) && !hasLessChopFlag(args) {
+		args = append([]string{"-S"}, args...)
+	}
+
+	return exec.Command(bin, args...), nil
+}
+
+func isLessBinary(cmd string) bool {
+	base := cmd
+	if i := strings.LastIndexAny(base, "/\\"); i >= 0 {
+		base = base[i+1:]
+	}
+	base = strings.TrimSuffix(base, ".exe")
+	return base == "less"
+}
+
+// hasLessChopFlag reports whether the user already passed -S (or --chop-long-lines)
+// to less. Matches `-S` alone, combined short flags like `-FIRSX`, and the long
+// form `--chop-long-lines`.
+func hasLessChopFlag(args []string) bool {
+	for _, a := range args {
+		if a == "--chop-long-lines" {
+			return true
+		}
+		if strings.HasPrefix(a, "-") && !strings.HasPrefix(a, "--") && strings.ContainsRune(a, 'S') {
+			return true
+		}
+	}
+	return false
+}
+
+// isEPIPE reports whether err is (or wraps) syscall.EPIPE. Needed because
+// io.Copy wraps the underlying errno in an *os.PathError on Unix and an
+// *exec.ExitError or similar on Windows.
+func isEPIPE(err error) bool {
+	if errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	// On some platforms the error surfaces as ERROR_BROKEN_PIPE (Windows);
+	// errors.Is handles the wrapped *PathError on Unix.
+	return false
 }

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -124,15 +124,21 @@ func WithPagerUsing(pagerCmd string, opts PagerOpts, out io.Writer, fn func(w io
 		return
 	}
 
-	// Once Start succeeds the pager owns the terminal. Any copy error at
-	// this point (typically EPIPE because the user quit `less` with `q`)
-	// means the pager already displayed as much as it was going to — we
-	// must NOT re-dump to stdout or the user sees the content twice on
-	// top of the pager's lingering screen. Also ignore the pager's exit
-	// status: `less` may exit non-zero on signal, which isn't our bug.
+	// Copy the buffer into the pager's stdin. Ignore the io.Copy error
+	// because an early quit closes the pipe and we'd see EPIPE; the exit
+	// status from Wait is the authoritative signal.
 	_, _ = io.Copy(stdin, bytes.NewReader(buf.Bytes()))
 	_ = stdin.Close()
-	_ = cmd.Wait()
+	// A non-zero pager exit almost always means a misconfiguration (bad
+	// flag, missing command in the pager's argv, etc.) — `less` / `more`
+	// / `bat` all exit 0 on `q`, so a normal user quit doesn't land here.
+	// Fall back to a direct write so the user doesn't get a blank
+	// terminal. The edge case where a user Ctrl+C's the pager after
+	// partial read will double-display, which is annoying but strictly
+	// better than silently dropping their output.
+	if err := cmd.Wait(); err != nil {
+		_, _ = out.Write(buf.Bytes())
+	}
 }
 
 // isPagingDisabled returns true when the resolved pager should be treated

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"syscall"
 
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
@@ -125,21 +124,15 @@ func WithPagerUsing(pagerCmd string, opts PagerOpts, out io.Writer, fn func(w io
 		return
 	}
 
-	// Copy the buffer into the pager's stdin. If the user quits the pager
-	// before we finish writing, the pipe closes and we get EPIPE — that's
-	// expected and we swallow it. Any other copy error means the pager
-	// didn't receive the content, so we fall back to a direct write; but
-	// only if the process hasn't started displaying it yet. Since we can't
-	// tell, we prefer not to re-dump to avoid showing content twice.
-	_, copyErr := io.Copy(stdin, bytes.NewReader(buf.Bytes()))
+	// Once Start succeeds the pager owns the terminal. Any copy error at
+	// this point (typically EPIPE because the user quit `less` with `q`)
+	// means the pager already displayed as much as it was going to — we
+	// must NOT re-dump to stdout or the user sees the content twice on
+	// top of the pager's lingering screen. Also ignore the pager's exit
+	// status: `less` may exit non-zero on signal, which isn't our bug.
+	_, _ = io.Copy(stdin, bytes.NewReader(buf.Bytes()))
 	_ = stdin.Close()
 	_ = cmd.Wait()
-
-	if copyErr != nil && !isEPIPE(copyErr) {
-		// An unusual pipe failure — the pager may not have shown anything.
-		// Re-dump content so the user still sees it.
-		_, _ = out.Write(buf.Bytes())
-	}
 }
 
 // isPagingDisabled returns true when the resolved pager should be treated
@@ -203,17 +196,5 @@ func hasLessChopFlag(args []string) bool {
 			return true
 		}
 	}
-	return false
-}
-
-// isEPIPE reports whether err is (or wraps) syscall.EPIPE. Needed because
-// io.Copy wraps the underlying errno in an *os.PathError on Unix and an
-// *exec.ExitError or similar on Windows.
-func isEPIPE(err error) bool {
-	if errors.Is(err, syscall.EPIPE) {
-		return true
-	}
-	// On some platforms the error surfaces as ERROR_BROKEN_PIPE (Windows);
-	// errors.Is handles the wrapped *PathError on Unix.
 	return false
 }

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -52,29 +52,19 @@ func TerminalWidth() int {
 	return w
 }
 
-// defaultLongFormPager is the fallback pager for long-form content
-// (`run log`, `run diff`) when neither TEAMCITY_PAGER, the config `pager`
-// key, nor the PAGER env var is set. It matches gh's less defaults plus
-// `-R` for ANSI colors and `-X` to avoid clearing the screen on exit.
+// defaultLongFormPager is the built-in pager for `run log` / `run diff` when nothing is configured.
 const defaultLongFormPager = "less -FIRX --mouse --incsearch"
 
-// PagerResolver returns the pager command string (as the user would type it).
-// The main package wires this to config.ResolvePager so the output package
-// doesn't need to import config. An empty return value means paging is
-// disabled; callers decide whether to fall back to a default pager.
+// PagerResolver returns the pager command string; wired by the main package so output doesn't import config.
 var PagerResolver = func() string { return "" }
 
 // PagerOpts tunes pager invocation.
 type PagerOpts struct {
-	// ChopLongLines asks the pager not to wrap lines. Used for wide tables
-	// where wrapping breaks column alignment. Only applied when the resolved
-	// pager is `less` (or unspecified, i.e. the default less fallback).
+	// ChopLongLines injects `-S` when the resolved pager is `less`, keeping wide tables aligned.
 	ChopLongLines bool
 }
 
-// WithPager pipes long-form output through the resolved pager, defaulting to
-// less when nothing is configured. Used by `run log` and `run diff`, which
-// auto-page regardless of user config.
+// WithPager pipes long-form output (logs, diffs) through the resolved pager, defaulting to less.
 func WithPager(out io.Writer, fn func(w io.Writer)) {
 	cmd := PagerResolver()
 	if cmd == "" {
@@ -83,10 +73,7 @@ func WithPager(out io.Writer, fn func(w io.Writer)) {
 	WithPagerUsing(cmd, PagerOpts{}, out, fn)
 }
 
-// WithPagerUsing pipes output through the given pager command. An empty
-// pagerCmd (or one that resolves to `cat`) writes directly to out. When the
-// content is short enough to fit on screen, it also writes directly — no
-// reason to invoke a pager for a few lines.
+// WithPagerUsing pipes output through pagerCmd; empty, `cat`, short content, or a non-terminal writes directly.
 func WithPagerUsing(pagerCmd string, opts PagerOpts, out io.Writer, fn func(w io.Writer)) {
 	if isPagingDisabled(pagerCmd) || !IsTerminal() {
 		fn(out)
@@ -114,8 +101,7 @@ func WithPagerUsing(pagerCmd string, opts PagerOpts, out io.Writer, fn func(w io
 		_, _ = out.Write(buf.Bytes())
 		return
 	}
-	// Stdout/Stderr must be the real terminal fds; using out here breaks
-	// pager rendering when out is a buffer.
+	// Stdout/Stderr must be real terminal fds; using out here breaks pager rendering when out is a buffer.
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -124,25 +110,16 @@ func WithPagerUsing(pagerCmd string, opts PagerOpts, out io.Writer, fn func(w io
 		return
 	}
 
-	// Copy the buffer into the pager's stdin. Ignore the io.Copy error
-	// because an early quit closes the pipe and we'd see EPIPE; the exit
-	// status from Wait is the authoritative signal.
+	// Ignore copy errors: an early pager quit closes the pipe (EPIPE); Wait's exit code is authoritative.
 	_, _ = io.Copy(stdin, bytes.NewReader(buf.Bytes()))
 	_ = stdin.Close()
-	// A non-zero pager exit almost always means a misconfiguration (bad
-	// flag, missing command in the pager's argv, etc.) — `less` / `more`
-	// / `bat` all exit 0 on `q`, so a normal user quit doesn't land here.
-	// Fall back to a direct write so the user doesn't get a blank
-	// terminal. The edge case where a user Ctrl+C's the pager after
-	// partial read will double-display, which is annoying but strictly
-	// better than silently dropping their output.
+	// Non-zero exit → misconfigured pager (bad flag, missing argv); fall back so the user isn't left with a blank terminal. `q` exits 0 on less/more/bat, so normal quits don't land here.
 	if err := cmd.Wait(); err != nil {
 		_, _ = out.Write(buf.Bytes())
 	}
 }
 
-// isPagingDisabled returns true when the resolved pager should be treated
-// as a no-op: empty, or `cat` (a common way to disable paging via PAGER=cat).
+// isPagingDisabled treats empty and `cat` (PAGER=cat is a common explicit disable) as no-ops.
 func isPagingDisabled(pagerCmd string) bool {
 	pagerCmd = strings.TrimSpace(pagerCmd)
 	if pagerCmd == "" {
@@ -159,9 +136,7 @@ func isPagingDisabled(pagerCmd string) bool {
 	return base == "cat"
 }
 
-// buildPagerCmd turns a user-facing pager string like `less -R` into an
-// *exec.Cmd. When the resolved pager's basename is `less` and ChopLongLines
-// is requested, `-S` is added if the user didn't already specify it.
+// buildPagerCmd parses `less -R`-style pager strings into *exec.Cmd and injects -S for less+ChopLongLines.
 func buildPagerCmd(pagerCmd string, opts PagerOpts) (*exec.Cmd, error) {
 	parts := strings.Fields(pagerCmd)
 	if len(parts) == 0 {
@@ -190,9 +165,7 @@ func isLessBinary(cmd string) bool {
 	return base == "less"
 }
 
-// hasLessChopFlag reports whether the user already passed -S (or --chop-long-lines)
-// to less. Matches `-S` alone, combined short flags like `-FIRSX`, and the long
-// form `--chop-long-lines`.
+// hasLessChopFlag matches -S alone, combined short flags like -FIRSX, and --chop-long-lines.
 func hasLessChopFlag(args []string) bool {
 	for _, a := range args {
 		if a == "--chop-long-lines" {

--- a/internal/output/terminal_test.go
+++ b/internal/output/terminal_test.go
@@ -27,6 +27,14 @@ func overrideTerminal(t *testing.T, isTerm bool, w, h int, err error) {
 	})
 }
 
+// overridePagerResolver sets PagerResolver for the duration of the test.
+func overridePagerResolver(t *testing.T, pager string) {
+	t.Helper()
+	old := PagerResolver
+	PagerResolver = func() string { return pager }
+	t.Cleanup(func() { PagerResolver = old })
+}
+
 // captureStdout replaces os.Stdout with a pipe for the duration of fn and returns what was written.
 // Reading happens concurrently to prevent deadlock when output exceeds the OS pipe buffer.
 func captureStdout(t *testing.T, fn func()) string {
@@ -80,23 +88,6 @@ func TestTerminal(T *testing.T) {
 	})
 }
 
-func TestDefaultFnBodies(T *testing.T) {
-	// Exercise the default function literal bodies for coverage.
-	// These only run in production; tests typically override them.
-	_, _, _ = getTermSizeFn()
-
-	// With real PATH: LookPath succeeds
-	cmd, err := pagerCmdFn()
-	if err == nil {
-		assert.NotNil(T, cmd)
-	}
-
-	// With empty PATH: LookPath fails, covering the error branch
-	T.Setenv("PATH", "")
-	_, err = pagerCmdFn()
-	assert.Error(T, err)
-}
-
 func TestTerminalSizeTerminal(T *testing.T) {
 	overrideTerminal(T, true, 100, 50, nil)
 
@@ -121,53 +112,97 @@ func TestTerminalSizeZeroWidth(T *testing.T) {
 	assert.Equal(T, 24, h)
 }
 
-func TestWithPagerNonTerminal(T *testing.T) {
+func TestWithPagerUsingNonTerminal(T *testing.T) {
 	overrideTerminal(T, false, 120, 40, nil)
 
 	var buf bytes.Buffer
-	WithPager(&buf, func(w io.Writer) {
+	WithPagerUsing("less", PagerOpts{}, &buf, func(w io.Writer) {
 		fmt.Fprintln(w, "hello pager")
 	})
 	assert.Contains(T, buf.String(), "hello pager")
 }
 
-func TestWithPagerFallbackShortContent(T *testing.T) {
+func TestWithPagerUsingEmptyPagerSkipsPaging(T *testing.T) {
+	overrideTerminal(T, true, 80, 5, nil)
+
+	// Even long content with an empty pager goes straight to the writer.
+	var lines []string
+	for i := range 50 {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	content := strings.Join(lines, "\n") + "\n"
+
+	var buf bytes.Buffer
+	WithPagerUsing("", PagerOpts{}, &buf, func(w io.Writer) {
+		fmt.Fprint(w, content)
+	})
+	assert.Contains(T, buf.String(), "line 49")
+}
+
+func TestWithPagerUsingCatIsNoOp(T *testing.T) {
+	overrideTerminal(T, true, 80, 5, nil)
+
+	var lines []string
+	for i := range 50 {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	content := strings.Join(lines, "\n") + "\n"
+
+	var buf bytes.Buffer
+	WithPagerUsing("cat", PagerOpts{}, &buf, func(w io.Writer) {
+		fmt.Fprint(w, content)
+	})
+	assert.Contains(T, buf.String(), "line 49")
+
+	var buf2 bytes.Buffer
+	WithPagerUsing("/bin/cat -u", PagerOpts{}, &buf2, func(w io.Writer) {
+		fmt.Fprint(w, content)
+	})
+	assert.Contains(T, buf2.String(), "line 49")
+}
+
+func TestWithPagerUsingFallbackShortContent(T *testing.T) {
 	overrideTerminal(T, true, 80, 50, nil)
 
 	var buf bytes.Buffer
-	WithPager(&buf, func(w io.Writer) {
+	WithPagerUsing("less", PagerOpts{}, &buf, func(w io.Writer) {
 		fmt.Fprintln(w, "short content")
 	})
 	assert.Contains(T, buf.String(), "short content")
 }
 
-func TestWithPagerRunsLess(T *testing.T) {
+// TestWithPagerUsingEarlyExitPager covers the gh-style fix: a pager that
+// reads only part of its stdin and exits 0 (e.g. less with `q` before
+// consuming everything) must NOT cause the full buffer to be re-dumped
+// to stdout after paging finishes.
+func TestWithPagerUsingEarlyExitPager(T *testing.T) {
 	overrideTerminal(T, true, 80, 5, nil)
 
-	// Generate content that exceeds terminal height
+	if _, err := exec.LookPath("head"); err != nil {
+		T.Skip("head not available")
+	}
+
 	var lines []string
-	for i := range 20 {
+	for i := range 5000 {
 		lines = append(lines, fmt.Sprintf("line %d", i))
 	}
 	content := strings.Join(lines, "\n") + "\n"
 
-	// less requires a real terminal for stdin, so it will fail and fall back to the out writer
-	output := captureStdout(T, func() {
-		WithPager(os.Stdout, func(w io.Writer) {
+	var fallback bytes.Buffer
+	out := captureStdout(T, func() {
+		WithPagerUsing("head -c 100", PagerOpts{}, &fallback, func(w io.Writer) {
 			fmt.Fprint(w, content)
 		})
 	})
-	assert.Contains(T, output, "line 0")
+
+	assert.NotEmpty(T, out, "pager should have written something to stdout")
+	assert.Empty(T, fallback.String(), "fallback buffer must not be written to when pager exits 0 after partial read")
 }
 
-func TestWithPagerLessError(T *testing.T) {
+// TestWithPagerUsingStartFailureFallsBack: if the pager binary can't be
+// located, fall back to a direct write.
+func TestWithPagerUsingStartFailureFallsBack(T *testing.T) {
 	overrideTerminal(T, true, 80, 5, nil)
-
-	oldPager := pagerCmdFn
-	T.Cleanup(func() { pagerCmdFn = oldPager })
-	pagerCmdFn = func() (*exec.Cmd, error) {
-		return exec.Command("false"), nil // "false" always exits 1
-	}
 
 	var lines []string
 	for i := range 20 {
@@ -176,12 +211,95 @@ func TestWithPagerLessError(T *testing.T) {
 	content := strings.Join(lines, "\n") + "\n"
 
 	var buf bytes.Buffer
-	// pager fails → falls back to the out writer
-	captureStdout(T, func() {
-		WithPager(&buf, func(w io.Writer) {
-			fmt.Fprint(w, content)
-		})
+	WithPagerUsing("definitely-not-a-real-pager-binary-xyz", PagerOpts{}, &buf, func(w io.Writer) {
+		fmt.Fprint(w, content)
 	})
 	assert.Contains(T, buf.String(), "line 0")
 	assert.Contains(T, buf.String(), "line 19")
+}
+
+func TestWithPagerUsesResolver(T *testing.T) {
+	overrideTerminal(T, false, 120, 40, nil) // non-terminal → short-circuit to writer
+	overridePagerResolver(T, "less -R")
+
+	var buf bytes.Buffer
+	WithPager(&buf, func(w io.Writer) {
+		fmt.Fprintln(w, "log body")
+	})
+	assert.Contains(T, buf.String(), "log body")
+}
+
+func TestWithPagerEmptyResolverUsesDefault(T *testing.T) {
+	overrideTerminal(T, false, 120, 40, nil)
+	overridePagerResolver(T, "")
+
+	// Non-terminal makes WithPagerUsing skip paging and write directly; this
+	// still exercises the default-pager fallback path in WithPager without
+	// actually invoking a pager process.
+	var buf bytes.Buffer
+	WithPager(&buf, func(w io.Writer) {
+		fmt.Fprintln(w, "log body")
+	})
+	assert.Contains(T, buf.String(), "log body")
+}
+
+func TestIsPagingDisabled(T *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"", true},
+		{"  ", true},
+		{"cat", true},
+		{"cat -u", true},
+		{"/bin/cat", true},
+		{"/usr/local/bin/cat --flag", true},
+		{"less", false},
+		{"less -FIRX", false},
+		{"more", false},
+		{"/usr/bin/less", false},
+	}
+	for _, tc := range cases {
+		assert.Equal(T, tc.want, isPagingDisabled(tc.in), "input=%q", tc.in)
+	}
+}
+
+func TestHasLessChopFlag(T *testing.T) {
+	assert.True(T, hasLessChopFlag([]string{"-S"}))
+	assert.True(T, hasLessChopFlag([]string{"-FIRSX"}))
+	assert.True(T, hasLessChopFlag([]string{"--chop-long-lines"}))
+	assert.False(T, hasLessChopFlag([]string{"-FIRX"}))
+	assert.False(T, hasLessChopFlag(nil))
+	assert.False(T, hasLessChopFlag([]string{"--mouse", "--incsearch"}))
+}
+
+func TestBuildPagerCmdAddsChopFlag(T *testing.T) {
+	if _, err := exec.LookPath("less"); err != nil {
+		T.Skip("less not available")
+	}
+	cmd, err := buildPagerCmd("less -FIRX", PagerOpts{ChopLongLines: true})
+	require.NoError(T, err)
+	require.NotNil(T, cmd)
+	// The first arg injected should be -S; remaining args preserved.
+	assert.Equal(T, []string{"-S", "-FIRX"}, cmd.Args[1:])
+}
+
+func TestBuildPagerCmdRespectsExistingChopFlag(T *testing.T) {
+	if _, err := exec.LookPath("less"); err != nil {
+		T.Skip("less not available")
+	}
+	cmd, err := buildPagerCmd("less -FIRSX", PagerOpts{ChopLongLines: true})
+	require.NoError(T, err)
+	require.NotNil(T, cmd)
+	assert.Equal(T, []string{"-FIRSX"}, cmd.Args[1:])
+}
+
+func TestBuildPagerCmdSkipsChopForNonLess(T *testing.T) {
+	if _, err := exec.LookPath("cat"); err != nil {
+		T.Skip("cat not available")
+	}
+	cmd, err := buildPagerCmd("cat -u", PagerOpts{ChopLongLines: true})
+	require.NoError(T, err)
+	require.NotNil(T, cmd)
+	assert.Equal(T, []string{"-u"}, cmd.Args[1:])
 }

--- a/internal/output/terminal_test.go
+++ b/internal/output/terminal_test.go
@@ -199,6 +199,36 @@ func TestWithPagerUsingEarlyExitPager(T *testing.T) {
 	assert.Empty(T, fallback.String(), "fallback buffer must not be written to when pager exits 0 after partial read")
 }
 
+// TestWithPagerUsingNonZeroExitFallsBack covers a misconfigured pager:
+// the binary exists and Start() succeeds, but the pager exits non-zero
+// before displaying anything (bad flag, unsupported option, etc.). We
+// must re-dump the buffer so the user doesn't see a blank terminal.
+func TestWithPagerUsingNonZeroExitFallsBack(T *testing.T) {
+	overrideTerminal(T, true, 80, 5, nil)
+
+	if _, err := exec.LookPath("sh"); err != nil {
+		T.Skip("sh not available")
+	}
+
+	var lines []string
+	for i := range 20 {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	content := strings.Join(lines, "\n") + "\n"
+
+	var buf bytes.Buffer
+	// `sh -c 'exit 1'` starts cleanly then exits non-zero without reading
+	// stdin — mimics a misconfigured pager.
+	WithPagerUsing("sh -c exit_1", PagerOpts{}, &buf, func(w io.Writer) {
+		fmt.Fprint(w, content)
+	})
+	// buildPagerCmd's Fields split gives us `sh -c exit_1`, where `exit_1`
+	// is an unknown command to sh → sh exits 127. Either way the exit is
+	// non-zero and the fallback must fire.
+	assert.Contains(T, buf.String(), "line 0")
+	assert.Contains(T, buf.String(), "line 19")
+}
+
 // TestWithPagerUsingStartFailureFallsBack: if the pager binary can't be
 // located, fall back to a direct write.
 func TestWithPagerUsingStartFailureFallsBack(T *testing.T) {

--- a/internal/output/terminal_test.go
+++ b/internal/output/terminal_test.go
@@ -35,8 +35,7 @@ func overridePagerResolver(t *testing.T, pager string) {
 	t.Cleanup(func() { PagerResolver = old })
 }
 
-// captureStdout replaces os.Stdout with a pipe for the duration of fn and returns what was written.
-// Reading happens concurrently to prevent deadlock when output exceeds the OS pipe buffer.
+// captureStdout redirects os.Stdout through a pipe for fn and returns what was written (concurrent read to avoid pipe-buffer deadlock).
 func captureStdout(t *testing.T, fn func()) string {
 	t.Helper()
 	oldStdout := os.Stdout
@@ -171,10 +170,7 @@ func TestWithPagerUsingFallbackShortContent(T *testing.T) {
 	assert.Contains(T, buf.String(), "short content")
 }
 
-// TestWithPagerUsingEarlyExitPager covers the gh-style fix: a pager that
-// reads only part of its stdin and exits 0 (e.g. less with `q` before
-// consuming everything) must NOT cause the full buffer to be re-dumped
-// to stdout after paging finishes.
+// TestWithPagerUsingEarlyExitPager: pager reads some stdin then exits 0 (user pressed `q`) — must not re-dump to stdout.
 func TestWithPagerUsingEarlyExitPager(T *testing.T) {
 	overrideTerminal(T, true, 80, 5, nil)
 
@@ -199,10 +195,7 @@ func TestWithPagerUsingEarlyExitPager(T *testing.T) {
 	assert.Empty(T, fallback.String(), "fallback buffer must not be written to when pager exits 0 after partial read")
 }
 
-// TestWithPagerUsingNonZeroExitFallsBack covers a misconfigured pager:
-// the binary exists and Start() succeeds, but the pager exits non-zero
-// before displaying anything (bad flag, unsupported option, etc.). We
-// must re-dump the buffer so the user doesn't see a blank terminal.
+// TestWithPagerUsingNonZeroExitFallsBack: misconfigured pager Starts then exits non-zero — buffer must land on out.
 func TestWithPagerUsingNonZeroExitFallsBack(T *testing.T) {
 	overrideTerminal(T, true, 80, 5, nil)
 
@@ -217,20 +210,15 @@ func TestWithPagerUsingNonZeroExitFallsBack(T *testing.T) {
 	content := strings.Join(lines, "\n") + "\n"
 
 	var buf bytes.Buffer
-	// `sh -c 'exit 1'` starts cleanly then exits non-zero without reading
-	// stdin — mimics a misconfigured pager.
+	// `sh -c exit_1` — sh can't find `exit_1`, exits 127 (non-zero), mimicking a misconfigured pager.
 	WithPagerUsing("sh -c exit_1", PagerOpts{}, &buf, func(w io.Writer) {
 		fmt.Fprint(w, content)
 	})
-	// buildPagerCmd's Fields split gives us `sh -c exit_1`, where `exit_1`
-	// is an unknown command to sh → sh exits 127. Either way the exit is
-	// non-zero and the fallback must fire.
 	assert.Contains(T, buf.String(), "line 0")
 	assert.Contains(T, buf.String(), "line 19")
 }
 
-// TestWithPagerUsingStartFailureFallsBack: if the pager binary can't be
-// located, fall back to a direct write.
+// TestWithPagerUsingStartFailureFallsBack: unknown binary → LookPath fails → fall back to direct write.
 func TestWithPagerUsingStartFailureFallsBack(T *testing.T) {
 	overrideTerminal(T, true, 80, 5, nil)
 
@@ -263,9 +251,7 @@ func TestWithPagerEmptyResolverUsesDefault(T *testing.T) {
 	overrideTerminal(T, false, 120, 40, nil)
 	overridePagerResolver(T, "")
 
-	// Non-terminal makes WithPagerUsing skip paging and write directly; this
-	// still exercises the default-pager fallback path in WithPager without
-	// actually invoking a pager process.
+	// Non-terminal short-circuits before exec, so we exercise the default-pager fallback path without spawning less.
 	var buf bytes.Buffer
 	WithPager(&buf, func(w io.Writer) {
 		fmt.Fprintln(w, "log body")

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamcity-cli
-version: "0.9.1"
+version: "0.9.2"
 author: JetBrains
 description: Use when working with TeamCity CI/CD or when user provides a TeamCity build URL. Use `teamcity` CLI for builds, logs, jobs, queues, agents, and pipelines.
 ---

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -407,9 +407,11 @@ Pipelines are YAML-first build configurations. Each pipeline is a project that c
 | `teamcity config get <key>`           | Get a configuration value      |
 | `teamcity config set <key> <value>`   | Set a configuration value      |
 
-Valid keys: `default_server`, `guest`, `ro`, `token_expiry`.
+Valid keys: `default_server`, `pager`, `guest`, `ro`, `token_expiry`.
 
-Per-server keys (`guest`, `ro`, `token_expiry`) use `--server <url>` to target a specific server. Without `--server`, the default server is used.
+Global keys (`default_server`, `pager`) apply CLI-wide; don't pass `--server` with them. Per-server keys (`guest`, `ro`, `token_expiry`) use `--server <url>` to target a specific server; without `--server`, the default server is used.
+
+`pager` opts list commands (`run list`, `job list`, etc.) into paged output. Can also be set via `TEAMCITY_PAGER` (highest precedence) or inherited from `PAGER`. Set to `cat` or empty to disable.
 
 ### Flags for `teamcity config list`
 

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -407,11 +407,11 @@ Pipelines are YAML-first build configurations. Each pipeline is a project that c
 | `teamcity config get <key>`           | Get a configuration value      |
 | `teamcity config set <key> <value>`   | Set a configuration value      |
 
-Valid keys: `default_server`, `pager`, `guest`, `ro`, `token_expiry`.
+Valid keys: `default_server`, `guest`, `ro`, `token_expiry`.
 
-Global keys (`default_server`, `pager`) apply CLI-wide; don't pass `--server` with them. Per-server keys (`guest`, `ro`, `token_expiry`) use `--server <url>` to target a specific server; without `--server`, the default server is used.
+Per-server keys (`guest`, `ro`, `token_expiry`) use `--server <url>` to target a specific server. Without `--server`, the default server is used.
 
-`pager` opts list commands (`run list`, `job list`, etc.) into paged output. Can also be set via `TEAMCITY_PAGER` (highest precedence) or inherited from `PAGER`. Set to `cat` or empty to disable.
+Paging for list commands is opt-in via the `TEAMCITY_PAGER` or `PAGER` env var (not a config key). `run log` and `run diff` page by default.
 
 ### Flags for `teamcity config list`
 


### PR DESCRIPTION
## Summary

Adds opt-in paging to list commands (`run list`, `job list`, `project list`, `agent list`, `queue list`, `pool list`, `pipeline list`, `alias list`, `skill list`, `param list`, plus `project tree` and `agent jobs`). When the user has set `TEAMCITY_PAGER` or `PAGER`, list output routes through it; without one, behavior is unchanged. Matches gh's posture (cli/cli#528): lists don't auto-page. `run log` / `run diff` still auto-page through less because they're long-form.

Also hardens the existing pager plumbing against early-exit re-dump: the old `WithPager` repainted the buffer on top of the pager's lingering screen when `less` exited non-zero (signal, some `q` paths), and the Windows EPIPE detection was broken (`syscall.EPIPE` ≠ `ERROR_BROKEN_PIPE`). Rewritten to `StdinPipe` + trust-the-exit-code: fall back only when the pager can't start or exits non-zero (misconfigured pager, bad flag, etc.) so the user never gets a blank terminal.

No config key was added. `TEAMCITY_PAGER` and the generic `PAGER` cover the persistence story — matches kubectl / docker, avoids a second way to do the same thing.

## Changes

### output
- New `WithPagerUsing(pagerCmd, opts, out, fn)` — core paging primitive that takes a resolved pager string. Empty or `cat` short-circuits to a direct write.
- `PagerOpts.ChopLongLines` — injects `-S` only when the pager's basename is `less` and the user hasn't already passed `-S` / `--chop-long-lines`. Keeps wide tables aligned; leaves `run log`'s wrap alone.
- `PagerResolver` package-level func var, wired by the factory to `config.ResolvePager` so `output` stays free of a `config` import.
- `Printer.PrintTableTo` / `PrintPlainTableTo` / `PrintTreeTo` — writer-parameterized siblings. Existing `PrintTable` / `PrintPlainTable` / `PrintTree` are thin wrappers.
- Rewrote `WithPager` internals to `StdinPipe` + explicit copy. Fallback to direct write only on pre-Start failures and non-zero `Wait` (misconfigured pager).

### config
- New `TEAMCITY_PAGER` env var.
- `config.ResolvePager()` precedence: `TEAMCITY_PAGER` > `PAGER` > `""`. No YAML persistence.
- `config list` Environment overrides block surfaces both `TEAMCITY_PAGER` and `PAGER` so users can see what's active.

### cmd
- `cmdutil.RunList` wraps the table render in `WithPagerUsing(config.ResolvePager(), …)`.
- Hand-rolled list/tree sites updated to the same pattern: `run list`, `agent jobs` (compatible + incompatible plain), `alias list`, `param list`, `skill list`, `project tree`.
- JSON output and empty-state messages stay unwrapped so scripting and one-line responses aren't redirected through a pager.
- `cmdutil.Factory.InitOutput` wires `output.PagerResolver = config.ResolvePager`.

### docs
- `docs/topics/teamcity-cli-configuration.md` documents the `TEAMCITY_PAGER` env var.
- `skills/teamcity-cli/references/commands.md` mentions the env var as the paging toggle.

## Design Decisions

- **Opt-in, not auto-page.** Matches gh cli/cli#528: scripts that pipe list output to `grep` or a file don't want silent paging. `run log` / `run diff` keep auto-paging because they're long-form.
- **Env var only, no config key.** `TEAMCITY_PAGER` and `PAGER` already cover per-shell and machine-wide persistence. Adding a YAML field is a second way to do the same thing with no real UX win — and one more field to keep compatible forever. Mirrors the kubectl / docker approach.
- **`PagerResolver` as a package-level var for injection.** Follows the existing pattern in `output` (`isTerminalFn`, `getTermSizeFn`). Production wires it via `InitOutput`; tests override directly. Keeps `output` free of a `config` import.
- **Fall back on non-zero pager `Wait`, not on copy errors.** Normal `q` exits 0 on `less` / `more` / `bat`, so user quits don't regress. A misconfigured pager (unknown flag, bad argv) exits non-zero before displaying anything — fallback saves the user from a blank terminal. Accepted tradeoff: a Ctrl+C'd pager double-displays, which is annoying but strictly better than losing output.
- **`cat` as the explicit disable.** `TEAMCITY_PAGER=cat` short-circuits to a direct write. Chosen over adding a `--no-pager` flag.
- **`ChopLongLines` only touches `less`.** Other pagers (`more`, `bat`, `most`, `delta`) have their own conventions for chop/wrap; we leave their flags untouched.

## Example

```bash
# Per-shell: set the env var in your rc file
export TEAMCITY_PAGER="less -R"
teamcity run list --limit 200

# One-off: prefix the command
TEAMCITY_PAGER="less -R" teamcity run list --limit 200

# Falls back to the generic PAGER if TEAMCITY_PAGER isn't set
PAGER=less teamcity run list --limit 200

# Explicit disable (escape hatch)
TEAMCITY_PAGER=cat teamcity run list --limit 200

# run log and run diff still auto-page regardless
teamcity run log 123456
```

## Test Plan

- [x] Unit tests pass (`just unit`) — `go test ./...` green; `-race -count=2` clean on touched packages.
- [ ] Linter passes (`just lint`) — the installed `golangci-lint` binary is built against go1.25 and refuses a go1.26 module locally; `gofmt -l .` and `go vet ./...` are both clean.
- [ ] Acceptance tests pass (`just acceptance`) — not run locally (no network, and paging requires a TTY that testscript doesn't provide). Existing scripts are unaffected: paging is opt-in and bypassed on non-terminals.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A; no new command or flag.
- [ ] If adding a data-producing command: includes `--json` support — N/A.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — `configJSON` shape unchanged (earlier `pager` addition was reverted).
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — updated `docs/topics/teamcity-cli-configuration.md` and `skills/teamcity-cli/references/commands.md`. `README.md` doesn't enumerate env vars, so no change there.

Coverage added in this PR:
- `internal/output/terminal_test.go` — early-exit pager (`head -c 100`), cat-as-no-op, start-failure fallback, non-zero-exit fallback (misconfigured pager regression guard), chop-flag injection, resolver precedence.
- `internal/config/fields_test.go` — `ResolvePager` precedence across `TEAMCITY_PAGER` / `PAGER` / unset.
- `internal/cmd/config/config_test.go` — `TEAMCITY_PAGER` surfaces in `config list` env overrides.
- `internal/cmd/run/cmd_test.go` — `TEAMCITY_PAGER=cat` passthrough and no-pager regression guard for `run list`.