### PR TITLE
refactor: hygiene pass — lints, modern Go, cleanup

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,8 @@ linters:
     - nolintlint
     - intrange
     - errorlint
+    - perfsprint
+    - usestdlibvars
   settings:
     gocritic:
       enabled-tags:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ linters:
     - revive
     - misspell
     - nolintlint
+    - intrange
+    - errorlint
   settings:
     gocritic:
       enabled-tags:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ All new features and bug fixes must include tests. We have a solid integration t
 - **Test env vars**: `t.Setenv(k, v)` only; use `t.Setenv(k, "")` to clear. Never `os.Unsetenv` — it doesn't restore.
 - **Test cwd**: small `chdir(t, dir)` helper using `t.Cleanup` to restore. Don't return defer functions.
 - **Test surface split**: unit tests cover internal helpers (parsers, cascades, etc.); acceptance scripts (`acceptance/testdata/<sub>/*.txtar`) cover the user-facing binary surface. Don't duplicate — if a `.txtar` asserts `--clear` removes a file, no parallel unit test for the same.
-- **Test isolation**: `cmdtest.NewTestServer` calls `Factory.SkipLinkLookup()` so unit tests don't pick up the host's `teamcity.toml`. Pattern this for any future per-cwd config you add.
+- **Test isolation**: `cmdtest.NewTestServer` sets `TEAMCITY_URL` and `TEAMCITY_TOKEN` via `t.Setenv` so unit tests don't pick up the host's `config.yml`. Pattern this for any future per-cwd config you add.
 
 ### JSON output contract
 
@@ -290,7 +290,7 @@ Follow these rules when adding flags:
 |-------------------------------|------------|---------------|
 | Limit number of results       | `--limit`  | `-n`          |
 | Filter by branch              | `--branch` | `-b`          |
-| Skip confirmation prompt      | `--force`  | `-f`          |
+| Skip confirmation prompt      | `--yes`    | `-y`          |
 | JSON output                   | `--json`   | —             |
 | Suppress non-essential output | `--quiet`  | `-q` (global) |
 
@@ -333,7 +333,9 @@ Command old-cmd is deprecated, use "new-cmd" instead (will be removed in v2.0)
 
 The command still runs — users are warned but not broken. Remove it in the target version.
 
-No flags or commands are deprecated today; these are the patterns for when the first deprecation is needed.
+Currently deprecated flags:
+- `--after-build` on `agent reboot` (use `--graceful`)
+- `--force` on `agent reboot`, `pipeline delete`, `project ssh delete`, `project vcs delete`, `queue remove`, `run cancel` (use `--yes`)
 
 ## Submit a pull request
 

--- a/api/agents.go
+++ b/api/agents.go
@@ -149,13 +149,13 @@ func (c *Client) RebootAgent(ctx context.Context, id int, afterBuild bool) error
 	}
 
 	formData := url.Values{}
-	formData.Set("agent", fmt.Sprintf("%d", id))
+	formData.Set("agent", strconv.Itoa(id))
 	if afterBuild {
 		formData.Set("rebootAfterBuild", "true")
 	}
 
-	endpoint := fmt.Sprintf("%s/remoteAccess/reboot.html", c.BaseURL)
-	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(formData.Encode()))
+	endpoint := c.BaseURL + "/remoteAccess/reboot.html"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(formData.Encode()))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/api/builds.go
+++ b/api/builds.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -120,7 +122,7 @@ func (c *Client) ResolveBuildID(ctx context.Context, ref string) (string, error)
 	if builds.Count == 0 {
 		return "", fmt.Errorf("no build found with number %s", ref)
 	}
-	return fmt.Sprintf("%d", builds.Builds[0].ID), nil
+	return strconv.Itoa(builds.Builds[0].ID), nil
 }
 
 // GetBuild returns a single build by ID or #number
@@ -130,7 +132,7 @@ func (c *Client) GetBuild(ctx context.Context, ref string) (*Build, error) {
 		return nil, err
 	}
 
-	path := fmt.Sprintf("/app/rest/builds/id:%s", id)
+	path := "/app/rest/builds/id:" + id
 
 	var build Build
 	if err := c.get(ctx, path, &build); err != nil {
@@ -375,14 +377,14 @@ func (c *Client) CancelBuild(buildID string, comment string) error {
 	}
 
 	if build.State == "finished" {
-		return fmt.Errorf("cannot cancel finished build")
+		return errors.New("cannot cancel finished build")
 	}
 
 	if build.State == "queued" {
 		return c.RemoveFromQueue(id)
 	}
 
-	path := fmt.Sprintf("/app/rest/builds/id:%s", id)
+	path := "/app/rest/builds/id:" + id
 
 	body := struct {
 		Comment        string `json:"comment"`

--- a/api/builds_artifacts.go
+++ b/api/builds_artifacts.go
@@ -88,7 +88,7 @@ func (c *Client) DownloadArtifactTo(ctx context.Context, buildID, artifactPath s
 	streamClient := &http.Client{Transport: c.HTTPClient.Transport}
 
 	resp, err := withRetry(ReadRetry, func() (*http.Response, error) {
-		req, err := http.NewRequestWithContext(ctx, "GET", reqURL, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func (c *Client) GetBuildLog(ctx context.Context, buildID string) (string, error
 	if err != nil {
 		return "", err
 	}
-	path := fmt.Sprintf("/downloadBuildLog.html?buildId=%s", id)
+	path := "/downloadBuildLog.html?buildId=" + id
 
 	resp, err := c.doGetStream(ctx, path)
 	if err != nil {

--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -17,10 +18,7 @@ func (c *Client) PinBuild(buildID string, comment string) error {
 	}
 	path := fmt.Sprintf("/app/rest/builds/id:%s/pin", id)
 
-	body := comment
-	if body == "" {
-		body = "Pinned via teamcity CLI"
-	}
+	body := cmp.Or(comment, "Pinned via teamcity CLI")
 
 	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(body), "text/plain")
 }

--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -57,7 +58,7 @@ func (c *Client) AddBuildTags(buildID string, tags []string) error {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 && resp.StatusCode != 201 && resp.StatusCode != 204 {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
 		return c.handleErrorResponse(resp)
 	}
 
@@ -191,7 +192,7 @@ func (c *Client) UploadDiffChanges(patch []byte, description string) (string, er
 		return "", err
 	}
 
-	if resp.StatusCode != 200 && resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
 		return "", errorFromBody(resp.StatusCode, resp.Body)
 	}
 

--- a/api/builds_metadata_test.go
+++ b/api/builds_metadata_test.go
@@ -12,7 +12,7 @@ import (
 func TestPinBuild(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
+		if r.Method == http.MethodGet {
 			// ResolveBuildID calls GetBuilds
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1, Number: "1"}}})
@@ -30,7 +30,7 @@ func TestPinBuild(t *testing.T) {
 func TestUnpinBuild(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
+		if r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
 			return
@@ -47,7 +47,7 @@ func TestUnpinBuild(t *testing.T) {
 func TestAddBuildTags(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
+		if r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
 			return
@@ -64,7 +64,7 @@ func TestAddBuildTags(t *testing.T) {
 func TestSetBuildComment(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
+		if r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
 			return
@@ -81,7 +81,7 @@ func TestSetBuildComment(t *testing.T) {
 func TestDeleteBuildComment(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "GET" {
+		if r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
 			return

--- a/api/builds_queue.go
+++ b/api/builds_queue.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -48,14 +49,14 @@ func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
 
 // RemoveFromQueue removes a build from the queue
 func (c *Client) RemoveFromQueue(id string) error {
-	path := fmt.Sprintf("/app/rest/buildQueue/id:%s", id)
+	path := "/app/rest/buildQueue/id:" + id
 	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
 }
 
 // SetQueuedBuildPosition moves a queued build to a specific position in the queue
 func (c *Client) SetQueuedBuildPosition(buildID string, position int) error {
-	path := fmt.Sprintf("/app/rest/buildQueue/order/%s", buildID)
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(fmt.Sprintf("%d", position)), "text/plain")
+	path := "/app/rest/buildQueue/order/" + buildID
+	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(strconv.Itoa(position)), "text/plain")
 }
 
 // MoveQueuedBuildToTop moves a queued build to the top of the queue

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -505,7 +506,7 @@ func TestDownloadArtifactTo(T *testing.T) {
 		content := []byte("test artifact content 12345")
 		client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 			assert.Contains(t, r.URL.Path, "/artifacts/content/")
-			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(content)))
+			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(content)
 		})

--- a/api/cloud.go
+++ b/api/cloud.go
@@ -108,7 +108,7 @@ func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList,
 }
 
 func (c *Client) GetCloudProfile(locator string) (*CloudProfile, error) {
-	path := fmt.Sprintf("/app/rest/cloud/profiles/%s", cloudLocator(locator, "id"))
+	path := "/app/rest/cloud/profiles/" + cloudLocator(locator, "id")
 
 	var result CloudProfile
 	if err := c.get(context.Background(), path, &result); err != nil {
@@ -146,7 +146,7 @@ func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error
 }
 
 func (c *Client) GetCloudImage(locator string) (*CloudImage, error) {
-	path := fmt.Sprintf("/app/rest/cloud/images/%s", cloudLocator(locator, "name"))
+	path := "/app/rest/cloud/images/" + cloudLocator(locator, "name")
 
 	var result CloudImage
 	if err := c.get(context.Background(), path, &result); err != nil {
@@ -184,7 +184,7 @@ func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceLi
 }
 
 func (c *Client) GetCloudInstance(locator string) (*CloudInstance, error) {
-	path := fmt.Sprintf("/app/rest/cloud/instances/%s", cloudLocator(locator, "id"))
+	path := "/app/rest/cloud/instances/" + cloudLocator(locator, "id")
 
 	var result CloudInstance
 	if err := c.get(context.Background(), path, &result); err != nil {

--- a/api/errors.go
+++ b/api/errors.go
@@ -96,7 +96,7 @@ func (e *NetworkError) Error() string {
 	if e.Cause != nil {
 		return fmt.Sprintf("cannot connect to %s: %v", e.URL, e.Cause)
 	}
-	return fmt.Sprintf("cannot connect to %s", e.URL)
+	return "cannot connect to " + e.URL
 }
 
 func (e *NetworkError) Unwrap() error    { return e.Cause }

--- a/api/errors_parse_test.go
+++ b/api/errors_parse_test.go
@@ -123,8 +123,8 @@ func TestErrorFromBody(T *testing.T) {
 	T.Run("401 → HTTPError with auth category", func(t *testing.T) {
 		t.Parallel()
 		err := errorFromBody(http.StatusUnauthorized, nil)
-		var he *HTTPError
-		require.True(t, errors.As(err, &he))
+		he, ok := errors.AsType[*HTTPError](err)
+		require.True(t, ok)
 		assert.Equal(t, CatAuth, he.Category())
 		assert.Contains(t, err.Error(), "authentication failed")
 	})
@@ -167,8 +167,8 @@ func TestErrorFromBody(T *testing.T) {
 		t.Parallel()
 		body := []byte(`{"errors":[{"message":"database down"}]}`)
 		err := errorFromBody(http.StatusInternalServerError, body)
-		var he *HTTPError
-		require.True(t, errors.As(err, &he))
+		he, ok := errors.AsType[*HTTPError](err)
+		require.True(t, ok)
 		assert.Equal(t, CatInternal, he.Category())
 		assert.Equal(t, "database down", err.Error())
 	})
@@ -183,7 +183,7 @@ func TestErrReadOnlySentinel(T *testing.T) {
 	wrapped := fmt.Errorf("%w: PUT /foo", ErrReadOnly)
 	assert.True(T, errors.Is(wrapped, ErrReadOnly))
 
-	var ue UserError
-	require.True(T, errors.As(wrapped, &ue))
+	ue, ok := errors.AsType[UserError](wrapped)
+	require.True(T, ok)
 	assert.Equal(T, CatReadOnly, ue.Category())
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -45,7 +47,7 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
 
 // GetBuildType returns a single build configuration by ID
 func (c *Client) GetBuildType(id string) (*BuildType, error) {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s", id)
+	path := "/app/rest/buildTypes/id:" + id
 
 	var buildType BuildType
 	if err := c.get(context.Background(), path, &buildType); err != nil {
@@ -59,13 +61,13 @@ func (c *Client) GetBuildType(id string) (*BuildType, error) {
 func (c *Client) SetBuildTypePaused(id string, paused bool) error {
 	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/paused", id)
 
-	resp, err := c.doRequestFull(context.Background(), "PUT", path, strings.NewReader(fmt.Sprintf("%t", paused)), "text/plain", "text/plain")
+	resp, err := c.doRequestFull(context.Background(), "PUT", path, strings.NewReader(strconv.FormatBool(paused)), "text/plain", "text/plain")
 	if err != nil {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 && resp.StatusCode != 204 {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		return c.handleErrorResponse(resp)
 	}
 

--- a/api/params.go
+++ b/api/params.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 )
 
 // ParameterList represents a list of parameters
@@ -75,42 +76,42 @@ func (c *Client) deleteParameter(basePath, name string) error {
 
 // GetProjectParameters returns parameters for a project
 func (c *Client) GetProjectParameters(projectID string) (*ParameterList, error) {
-	return c.getParameters(fmt.Sprintf("/app/rest/projects/id:%s", projectID))
+	return c.getParameters("/app/rest/projects/id:" + projectID)
 }
 
 // GetProjectParameter returns a specific parameter for a project
 func (c *Client) GetProjectParameter(projectID, name string) (*Parameter, error) {
-	return c.getParameter(fmt.Sprintf("/app/rest/projects/id:%s", projectID), name)
+	return c.getParameter("/app/rest/projects/id:"+projectID, name)
 }
 
 // SetProjectParameter sets a parameter for a project
 func (c *Client) SetProjectParameter(projectID, name, value string, secure bool) error {
-	return c.setParameter(fmt.Sprintf("/app/rest/projects/id:%s", projectID), name, value, secure)
+	return c.setParameter("/app/rest/projects/id:"+projectID, name, value, secure)
 }
 
 // DeleteProjectParameter deletes a parameter from a project
 func (c *Client) DeleteProjectParameter(projectID, name string) error {
-	return c.deleteParameter(fmt.Sprintf("/app/rest/projects/id:%s", projectID), name)
+	return c.deleteParameter("/app/rest/projects/id:"+projectID, name)
 }
 
 // GetBuildTypeParameters returns parameters for a build configuration
 func (c *Client) GetBuildTypeParameters(buildTypeID string) (*ParameterList, error) {
-	return c.getParameters(fmt.Sprintf("/app/rest/buildTypes/id:%s", buildTypeID))
+	return c.getParameters("/app/rest/buildTypes/id:" + buildTypeID)
 }
 
 // GetBuildTypeParameter returns a specific parameter for a build configuration
 func (c *Client) GetBuildTypeParameter(buildTypeID, name string) (*Parameter, error) {
-	return c.getParameter(fmt.Sprintf("/app/rest/buildTypes/id:%s", buildTypeID), name)
+	return c.getParameter("/app/rest/buildTypes/id:"+buildTypeID, name)
 }
 
 // SetBuildTypeParameter sets a parameter for a build configuration
 func (c *Client) SetBuildTypeParameter(buildTypeID, name, value string, secure bool) error {
-	return c.setParameter(fmt.Sprintf("/app/rest/buildTypes/id:%s", buildTypeID), name, value, secure)
+	return c.setParameter("/app/rest/buildTypes/id:"+buildTypeID, name, value, secure)
 }
 
 // DeleteBuildTypeParameter deletes a parameter from a build configuration
 func (c *Client) DeleteBuildTypeParameter(buildTypeID, name string) error {
-	return c.deleteParameter(fmt.Sprintf("/app/rest/buildTypes/id:%s", buildTypeID), name)
+	return c.deleteParameter("/app/rest/buildTypes/id:"+buildTypeID, name)
 }
 
 // GetParameterValue returns just the raw value of a parameter
@@ -121,7 +122,7 @@ func (c *Client) GetParameterValue(path string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return "", c.handleErrorResponse(resp)
 	}
 

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,7 +56,7 @@ func (c *Client) GetPipeline(id string) (*Pipeline, error) {
 // getPipelineRaw fetches the full pipeline state from /app/pipeline/{id}.
 // This non-REST endpoint returns YAML, VCS root details, triggers, and other settings.
 func (c *Client) getPipelineRaw(id string) (map[string]any, error) {
-	path := fmt.Sprintf("/app/pipeline/%s", id)
+	path := "/app/pipeline/" + id
 	var raw map[string]any
 	if err := c.get(context.Background(), path, &raw); err != nil {
 		return nil, err
@@ -95,7 +96,7 @@ func (c *Client) CreatePipeline(parentProjectID, name, yaml, vcsRootID string) (
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	path := fmt.Sprintf("/app/pipeline?parentProjectExtId=%s", url.QueryEscape(parentProjectID))
+	path := "/app/pipeline?parentProjectExtId=" + url.QueryEscape(parentProjectID)
 	var result Pipeline
 	if err := c.post(context.Background(), path, bytes.NewReader(body), &result); err != nil {
 		return nil, err
@@ -131,7 +132,7 @@ func (c *Client) UpdatePipelineYAML(id string, yamlContent string) error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	path := fmt.Sprintf("/app/pipeline/%s", id)
+	path := "/app/pipeline/" + id
 	var result json.RawMessage
 	return c.post(context.Background(), path, bytes.NewReader(body), &result)
 }
@@ -153,7 +154,7 @@ func (c *Client) GetBuildPipelineRun(buildID string) (*PipelineRun, error) {
 
 // DeletePipeline deletes a pipeline by removing its project.
 func (c *Client) DeletePipeline(id string) error {
-	return c.doNoContent(context.Background(), "DELETE", fmt.Sprintf("/app/rest/projects/id:%s", id), nil, "")
+	return c.doNoContent(context.Background(), "DELETE", "/app/rest/projects/id:"+id, nil, "")
 }
 
 // GetPipelineSchema fetches the pipeline JSON schema from the server.
@@ -170,7 +171,7 @@ func (c *Client) GetPipelineSchema() ([]byte, error) {
 
 	ct := resp.Header.Get("Content-Type")
 	if !strings.Contains(ct, "application/json") {
-		return nil, fmt.Errorf("schema endpoint not available on this server")
+		return nil, errors.New("schema endpoint not available on this server")
 	}
 
 	return io.ReadAll(resp.Body)

--- a/api/pkce.go
+++ b/api/pkce.go
@@ -109,7 +109,7 @@ func FindAvailableListener() (net.Listener, error) {
 }
 
 func IsPkceEnabled(ctx context.Context, serverURL string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, "POST", strings.TrimSuffix(serverURL, "/")+PkceIsEnabledPath, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(serverURL, "/")+PkceIsEnabledPath, nil)
 	if err != nil {
 		return false, err
 	}
@@ -176,7 +176,7 @@ func ExchangeCodeForToken(ctx context.Context, serverURL, code, verifier, redire
 	data.Set("code_verifier", verifier)
 	data.Set("redirect_uri", redirectURI)
 
-	req, err := http.NewRequestWithContext(ctx, "POST", strings.TrimSuffix(serverURL, "/")+PkceTokenPath, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(serverURL, "/")+PkceTokenPath, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, err
 	}

--- a/api/pools.go
+++ b/api/pools.go
@@ -15,7 +15,7 @@ func (c *Client) GetAgentPools(requestedFields []string) (*PoolList, error) {
 		fields = PoolFields.Default
 	}
 	fieldsParam := fmt.Sprintf("count,nextHref,agentPool(%s)", ToAPIFields(fields))
-	path := fmt.Sprintf("/app/rest/agentPools?fields=%s", url.QueryEscape(fieldsParam))
+	path := "/app/rest/agentPools?fields=" + url.QueryEscape(fieldsParam)
 
 	pools, err := collectPages(c, path, 0, func(p string) ([]Pool, string, error) {
 		var page PoolList

--- a/api/projects.go
+++ b/api/projects.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -46,7 +47,7 @@ func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
 
 // GetProject returns a single project by ID
 func (c *Client) GetProject(id string) (*Project, error) {
-	path := fmt.Sprintf("/app/rest/projects/id:%s", id)
+	path := "/app/rest/projects/id:" + id
 
 	var project Project
 	if err := c.get(context.Background(), path, &project); err != nil {
@@ -96,7 +97,7 @@ func (c *Client) CreateSecureToken(projectID, value string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return "", c.handleErrorResponse(resp)
 	}
 
@@ -119,7 +120,7 @@ func (c *Client) GetSecureValue(projectID, token string) (string, error) {
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return "", c.handleErrorResponse(resp)
 	}
 
@@ -167,7 +168,7 @@ func (c *Client) ExportProjectSettings(projectID, format string, useRelativeIds 
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return nil, c.handleErrorResponse(resp)
 	}
 

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -170,7 +170,7 @@ func TestWithRetry_HonorsRetryAfter(T *testing.T) {
 	resp.Body.Close()
 }
 
-// TestGetWithRetry_ContextCancelUnwraps pins that caller-cancelled ctx surfaces bare, not as NetworkError.
+// TestGetWithRetry_ContextCancelUnwraps pins that caller-canceled ctx surfaces bare, not as NetworkError.
 func TestGetWithRetry_ContextCancelUnwraps(T *testing.T) {
 	T.Parallel()
 
@@ -189,8 +189,8 @@ func TestGetWithRetry_ContextCancelUnwraps(T *testing.T) {
 
 	require.Error(T, err)
 	assert.True(T, errors.Is(err, context.Canceled), "expected context.Canceled, got %v", err)
-	var ne *NetworkError
-	assert.False(T, errors.As(err, &ne), "should not be wrapped as NetworkError")
+	_, ok := errors.AsType[*NetworkError](err)
+	assert.False(T, ok, "should not be wrapped as NetworkError")
 }
 
 // TestGetWithRetry_ExhaustionPreservesHTTPError pins that exhausted 429/5xx keeps the typed HTTP error.
@@ -207,8 +207,8 @@ func TestGetWithRetry_ExhaustionPreservesHTTPError(T *testing.T) {
 	err := client.getWithRetry(T.Context(), "/app/rest/server", &result, fastRetry)
 
 	require.Error(T, err)
-	var he *HTTPError
-	require.True(T, errors.As(err, &he), "expected *HTTPError, got %T: %v", err, err)
+	he, ok := errors.AsType[*HTTPError](err)
+	require.True(T, ok, "expected *HTTPError, got %T: %v", err, err)
 	assert.Equal(T, http.StatusServiceUnavailable, he.Status)
 	assert.Contains(T, err.Error(), "maintenance window")
 }

--- a/api/users.go
+++ b/api/users.go
@@ -18,7 +18,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 
 // GetUser returns a user by username
 func (c *Client) GetUser(username string) (*User, error) {
-	path := fmt.Sprintf("/app/rest/users/username:%s", username)
+	path := "/app/rest/users/username:" + username
 
 	var user User
 	if err := c.get(context.Background(), path, &user); err != nil {
@@ -76,7 +76,7 @@ type Token struct {
 
 // CreateAPIToken creates an API token for the current user
 func (c *Client) CreateAPIToken(name string) (*Token, error) {
-	path := fmt.Sprintf("/app/rest/users/current/tokens/%s", name)
+	path := "/app/rest/users/current/tokens/" + name
 
 	var token Token
 	if err := c.post(context.Background(), path, nil, &token); err != nil {
@@ -88,7 +88,7 @@ func (c *Client) CreateAPIToken(name string) (*Token, error) {
 
 // DeleteAPIToken deletes an API token for the current user
 func (c *Client) DeleteAPIToken(name string) error {
-	path := fmt.Sprintf("/app/rest/users/current/tokens/%s", name)
+	path := "/app/rest/users/current/tokens/" + name
 	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
 }
 

--- a/api/vcs_roots.go
+++ b/api/vcs_roots.go
@@ -38,7 +38,7 @@ func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
 
 // GetVcsRoot returns a VCS root by ID
 func (c *Client) GetVcsRoot(id string) (*VcsRoot, error) {
-	path := fmt.Sprintf("/app/rest/vcs-roots/id:%s", id)
+	path := "/app/rest/vcs-roots/id:" + id
 
 	var result VcsRoot
 	if err := c.get(context.Background(), path, &result); err != nil {
@@ -49,7 +49,7 @@ func (c *Client) GetVcsRoot(id string) (*VcsRoot, error) {
 
 // DeleteVcsRoot deletes a VCS root by ID
 func (c *Client) DeleteVcsRoot(id string) error {
-	path := fmt.Sprintf("/app/rest/vcs-roots/id:%s", id)
+	path := "/app/rest/vcs-roots/id:" + id
 	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
 }
 
@@ -75,7 +75,7 @@ func (c *Client) TestVcsConnection(req TestConnectionRequest, projectID string) 
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	path := fmt.Sprintf("/app/pipeline/repository/testConnection?parentProjectExtId=%s", projectID)
+	path := "/app/pipeline/repository/testConnection?parentProjectExtId=" + projectID
 	resp, err := c.doRequest(context.Background(), "POST", path, bytes.NewReader(body))
 	if err != nil {
 		return nil, err

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -119,7 +120,7 @@ func (opts *agentListOptions) fetch(client api.ClientInterface, fields []string)
 		}
 
 		rows = append(rows, []string{
-			fmt.Sprintf("%d", a.ID),
+			strconv.Itoa(a.ID),
 			a.Name,
 			poolName,
 			status,

--- a/internal/cmd/agent/agent_reboot.go
+++ b/internal/cmd/agent/agent_reboot.go
@@ -75,11 +75,11 @@ Note: Local agents (running on the same machine as the server) cannot be reboote
 	}
 
 	cmd.Flags().BoolVar(&opts.graceful, "graceful", false, "Wait for current work to finish before rebooting")
-	cmd.Flags().BoolVar(&opts.graceful, "after-build", false, "Deprecated: use --graceful")
-	_ = cmd.Flags().MarkDeprecated("after-build", "use --graceful instead")
+	cmd.Flags().BoolVar(&opts.graceful, "after-build", false, "")
+	cmdutil.DeprecateFlag(cmd, "after-build", "graceful", "v1.0.0")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
-	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
+	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
 
 	return cmd
 }

--- a/internal/cmd/agent/agent_state.go
+++ b/internal/cmd/agent/agent_state.go
@@ -29,7 +29,7 @@ var agentActions = map[string]agentAction{
 
 func newAgentActionCmd(f *cmdutil.Factory, a agentAction) *cobra.Command {
 	return &cobra.Command{
-		Use:   fmt.Sprintf("%s <agent>", a.use),
+		Use:   a.use + " <agent>",
 		Short: a.short,
 		Long:  a.long,
 		Args:  cobra.ExactArgs(1),

--- a/internal/cmd/alias/alias_test.go
+++ b/internal/cmd/alias/alias_test.go
@@ -94,7 +94,7 @@ func TestAliasSetOverwriteRegistered(t *testing.T) {
 	require.NoError(t, config.AddAlias("rl", "run list"))
 
 	root := cmd.NewCommand(nil)
-	alias.RegisterAliases(root,cmdutil.NewFactory())
+	alias.RegisterAliases(root, cmdutil.NewFactory())
 
 	root.SetArgs([]string{"alias", "set", "rl", "run list --limit=10"})
 	var out bytes.Buffer
@@ -176,7 +176,7 @@ func TestAliasExpansionEndToEnd(t *testing.T) {
 	require.NoError(t, config.AddAlias("fl", "run list --status=failure"))
 
 	root := cmd.NewCommand(nil)
-	alias.RegisterAliases(root,cmdutil.NewFactory())
+	alias.RegisterAliases(root, cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"fl"})
@@ -190,7 +190,7 @@ func TestAliasExpansionWithExtraArgs(t *testing.T) {
 	require.NoError(t, config.AddAlias("fl", "run list --status=failure"))
 
 	root := cmd.NewCommand(nil)
-	alias.RegisterAliases(root,cmdutil.NewFactory())
+	alias.RegisterAliases(root, cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"fl", "--limit", "5"})
@@ -204,7 +204,7 @@ func TestAliasExpansionWithPositionalArgs(t *testing.T) {
 	require.NoError(t, config.AddAlias("mybuilds", "run list --user=$1 --status=success"))
 
 	root := cmd.NewCommand(nil)
-	alias.RegisterAliases(root,cmdutil.NewFactory())
+	alias.RegisterAliases(root, cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"mybuilds", "admin"})
@@ -221,7 +221,7 @@ func TestAliasHelpFlag(t *testing.T) {
 	f := cmdutil.NewFactory()
 	f.Printer = &output.Printer{Out: &out, ErrOut: &out}
 	root := cmd.NewCommand(nil)
-	alias.RegisterAliases(root,f)
+	alias.RegisterAliases(root, f)
 
 	root.SetArgs([]string{"fl", "--help"})
 	root.SetOut(&out)
@@ -235,7 +235,7 @@ func TestAliasDepthLimit(t *testing.T) {
 	require.NoError(t, config.AddAlias("loop", "loop"))
 
 	root := cmd.NewCommand(nil)
-	alias.RegisterAliases(root,cmdutil.NewFactory())
+	alias.RegisterAliases(root, cmdutil.NewFactory())
 
 	root.SetArgs([]string{"loop"})
 	var out bytes.Buffer
@@ -264,7 +264,7 @@ func TestAwesomeAliasesEndToEnd(t *testing.T) {
 	for name := range aliases {
 		t.Run(name, func(t *testing.T) {
 			root := cmd.NewCommand(nil)
-			alias.RegisterAliases(root,cmdutil.NewFactory())
+			alias.RegisterAliases(root, cmdutil.NewFactory())
 
 			var out bytes.Buffer
 			root.SetArgs([]string{name})
@@ -280,7 +280,7 @@ func TestAliasSkipsBuiltinConflict(t *testing.T) {
 	require.NoError(t, config.AddAlias("run", "job list"))
 
 	root := cmd.NewCommand(nil)
-	alias.RegisterAliases(root,cmdutil.NewFactory())
+	alias.RegisterAliases(root, cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"run"})

--- a/internal/cmd/alias/alias_test.go
+++ b/internal/cmd/alias/alias_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
+	"github.com/JetBrains/teamcity-cli/internal/cmd/alias"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/config"
@@ -24,14 +25,14 @@ func setupAliasTest(t *testing.T) {
 func TestAliasSetAndList(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "fl", "run list --status=failure"})
 	require.NoError(t, root.Execute())
 
 	var out bytes.Buffer
 	f := cmdutil.NewFactory()
 	f.Printer = &output.Printer{Out: &out, ErrOut: &out}
-	root = cmd.NewRootCmdWithFactory(f)
+	root = cmd.NewCommand(f)
 	root.SetArgs([]string{"alias", "list", "--json"})
 	require.NoError(t, root.Execute())
 	assert.Contains(t, out.String(), "fl")
@@ -41,7 +42,7 @@ func TestAliasSetAndList(t *testing.T) {
 func TestAliasSetShellFlag(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "--shell", "failing", "teamcity run list | jq ."})
 	require.NoError(t, root.Execute())
 
@@ -53,7 +54,7 @@ func TestAliasSetShellFlag(t *testing.T) {
 func TestAliasSetBangPrefix(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "failing", "!tc run list | jq ."})
 	require.NoError(t, root.Execute())
 
@@ -63,7 +64,7 @@ func TestAliasSetBangPrefix(t *testing.T) {
 func TestAliasSetRejectsBuiltin(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "run", "job list"})
 	var out bytes.Buffer
 	root.SetOut(&out)
@@ -76,11 +77,11 @@ func TestAliasSetRejectsBuiltin(t *testing.T) {
 func TestAliasSetOverwrite(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "fl", "run list --status=failure"})
 	require.NoError(t, root.Execute())
 
-	root = cmd.NewRootCmd()
+	root = cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "fl", "run list --status=success"})
 	require.NoError(t, root.Execute())
 
@@ -92,8 +93,8 @@ func TestAliasSetOverwriteRegistered(t *testing.T) {
 	setupAliasE2E(t)
 	require.NoError(t, config.AddAlias("rl", "run list"))
 
-	root := cmd.NewRootCmd()
-	cmd.RegisterAliases(root, cmdutil.NewFactory())
+	root := cmd.NewCommand(nil)
+	alias.RegisterAliases(root,cmdutil.NewFactory())
 
 	root.SetArgs([]string{"alias", "set", "rl", "run list --limit=10"})
 	var out bytes.Buffer
@@ -108,11 +109,11 @@ func TestAliasSetOverwriteRegistered(t *testing.T) {
 func TestAliasDeleteCmd(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "fl", "run list"})
 	require.NoError(t, root.Execute())
 
-	root = cmd.NewRootCmd()
+	root = cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "delete", "fl"})
 	require.NoError(t, root.Execute())
 
@@ -123,7 +124,7 @@ func TestAliasDeleteCmd(t *testing.T) {
 func TestAliasDeleteNonexistentCmd(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "delete", "nope"})
 	var out bytes.Buffer
 	root.SetOut(&out)
@@ -139,7 +140,7 @@ func TestAliasListEmpty(t *testing.T) {
 	var out bytes.Buffer
 	f := cmdutil.NewFactory()
 	f.Printer = &output.Printer{Out: &out, ErrOut: &out}
-	root := cmd.NewRootCmdWithFactory(f)
+	root := cmd.NewCommand(f)
 	root.SetArgs([]string{"alias", "list"})
 	require.NoError(t, root.Execute())
 	assert.Contains(t, out.String(), "built-in")
@@ -148,14 +149,14 @@ func TestAliasListEmpty(t *testing.T) {
 func TestAliasListJSON(t *testing.T) {
 	setupAliasTest(t)
 
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	root.SetArgs([]string{"alias", "set", "fl", "run list"})
 	require.NoError(t, root.Execute())
 
 	var out bytes.Buffer
 	f := cmdutil.NewFactory()
 	f.Printer = &output.Printer{Out: &out, ErrOut: &out}
-	root = cmd.NewRootCmdWithFactory(f)
+	root = cmd.NewCommand(f)
 	root.SetArgs([]string{"alias", "list", "--json"})
 	require.NoError(t, root.Execute())
 	assert.Contains(t, out.String(), `"name"`)
@@ -174,8 +175,8 @@ func TestAliasExpansionEndToEnd(t *testing.T) {
 	setupAliasE2E(t)
 	require.NoError(t, config.AddAlias("fl", "run list --status=failure"))
 
-	root := cmd.NewRootCmd()
-	cmd.RegisterAliases(root, cmdutil.NewFactory())
+	root := cmd.NewCommand(nil)
+	alias.RegisterAliases(root,cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"fl"})
@@ -188,8 +189,8 @@ func TestAliasExpansionWithExtraArgs(t *testing.T) {
 	setupAliasE2E(t)
 	require.NoError(t, config.AddAlias("fl", "run list --status=failure"))
 
-	root := cmd.NewRootCmd()
-	cmd.RegisterAliases(root, cmdutil.NewFactory())
+	root := cmd.NewCommand(nil)
+	alias.RegisterAliases(root,cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"fl", "--limit", "5"})
@@ -202,8 +203,8 @@ func TestAliasExpansionWithPositionalArgs(t *testing.T) {
 	setupAliasE2E(t)
 	require.NoError(t, config.AddAlias("mybuilds", "run list --user=$1 --status=success"))
 
-	root := cmd.NewRootCmd()
-	cmd.RegisterAliases(root, cmdutil.NewFactory())
+	root := cmd.NewCommand(nil)
+	alias.RegisterAliases(root,cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"mybuilds", "admin"})
@@ -219,8 +220,8 @@ func TestAliasHelpFlag(t *testing.T) {
 	var out bytes.Buffer
 	f := cmdutil.NewFactory()
 	f.Printer = &output.Printer{Out: &out, ErrOut: &out}
-	root := cmd.NewRootCmd()
-	cmd.RegisterAliases(root, f)
+	root := cmd.NewCommand(nil)
+	alias.RegisterAliases(root,f)
 
 	root.SetArgs([]string{"fl", "--help"})
 	root.SetOut(&out)
@@ -233,8 +234,8 @@ func TestAliasDepthLimit(t *testing.T) {
 	setupAliasTest(t)
 	require.NoError(t, config.AddAlias("loop", "loop"))
 
-	root := cmd.NewRootCmd()
-	cmd.RegisterAliases(root, cmdutil.NewFactory())
+	root := cmd.NewCommand(nil)
+	alias.RegisterAliases(root,cmdutil.NewFactory())
 
 	root.SetArgs([]string{"loop"})
 	var out bytes.Buffer
@@ -262,8 +263,8 @@ func TestAwesomeAliasesEndToEnd(t *testing.T) {
 
 	for name := range aliases {
 		t.Run(name, func(t *testing.T) {
-			root := cmd.NewRootCmd()
-			cmd.RegisterAliases(root, cmdutil.NewFactory())
+			root := cmd.NewCommand(nil)
+			alias.RegisterAliases(root,cmdutil.NewFactory())
 
 			var out bytes.Buffer
 			root.SetArgs([]string{name})
@@ -278,8 +279,8 @@ func TestAliasSkipsBuiltinConflict(t *testing.T) {
 	setupAliasTest(t)
 	require.NoError(t, config.AddAlias("run", "job list"))
 
-	root := cmd.NewRootCmd()
-	cmd.RegisterAliases(root, cmdutil.NewFactory())
+	root := cmd.NewCommand(nil)
+	alias.RegisterAliases(root,cmdutil.NewFactory())
 
 	var out bytes.Buffer
 	root.SetArgs([]string{"run"})

--- a/internal/cmd/alias/expand.go
+++ b/internal/cmd/alias/expand.go
@@ -1,6 +1,7 @@
 package alias
 
 import (
+	"errors"
 	"fmt"
 	"os/exec"
 	"slices"
@@ -58,7 +59,7 @@ func newExpansionAliasCmd(p *output.Printer, name, expansion string) *cobra.Comm
 			}
 
 			if aliasDepth >= maxAliasDepth {
-				return fmt.Errorf("alias expansion depth limit exceeded (possible infinite loop)")
+				return errors.New("alias expansion depth limit exceeded (possible infinite loop)")
 			}
 			aliasDepth++
 			defer func() { aliasDepth-- }()

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -87,10 +88,10 @@ See: https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentatio
 
 func runAPI(f *cmdutil.Factory, endpoint string, opts *apiOptions) error {
 	if opts.paginate && opts.method != "GET" {
-		return fmt.Errorf("--paginate can only be used with GET requests")
+		return errors.New("--paginate can only be used with GET requests")
 	}
 	if opts.slurp && !opts.paginate {
-		return fmt.Errorf("--slurp requires --paginate")
+		return errors.New("--slurp requires --paginate")
 	}
 	if opts.method == "GET" && len(opts.fields) > 0 {
 		f.Printer.Warn("--field is ignored for GET requests. Use -X POST to send a request body.")
@@ -185,7 +186,7 @@ func runAPIPaginated(p *output.Printer, client api.ClientInterface, endpoint str
 			return fmt.Errorf("failed to detect array key: %w", err)
 		}
 		if arrayKey == "" {
-			return fmt.Errorf("--slurp requires response with array field (build, project, etc.)")
+			return errors.New("--slurp requires response with array field (build, project, etc.)")
 		}
 
 		merged, err := mergePages(pages, arrayKey)

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"crypto/subtle"
+	"errors"
 	"fmt"
 	"time"
 
@@ -130,7 +131,7 @@ func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage b
 			return api.RequiredFlag("token")
 		}
 
-		tokenURL := fmt.Sprintf("%s/profile.html?item=accessTokens", serverURL)
+		tokenURL := serverURL + "/profile.html?item=accessTokens"
 
 		_, _ = fmt.Fprintln(p.Out)
 		if pkceChecked {
@@ -287,7 +288,7 @@ func runPkceLogin(p *output.Printer, serverURL string) (*api.TokenResponse, erro
 			return nil, fmt.Errorf("authorization denied: %s", result.Error)
 		}
 		if subtle.ConstantTimeCompare([]byte(result.State), []byte(state)) != 1 {
-			return nil, fmt.Errorf("state mismatch: possible CSRF attack")
+			return nil, errors.New("state mismatch: possible CSRF attack")
 		}
 		_, _ = fmt.Fprintln(p.Out)
 

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -169,7 +169,7 @@ func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage b
 	}
 
 	f.WarnInsecureHTTP(serverURL, "authentication token")
-	p.Infof("Validating... ")
+	p.Progress("Validating... ")
 
 	client := api.NewClient(serverURL, token, api.WithDebugFunc(p.Debug), api.WithVersion(version.String()))
 	user, err := client.GetCurrentUser()
@@ -228,7 +228,7 @@ func runAuthLoginGuest(f *cmdutil.Factory, serverURL, token string) error {
 
 	p := f.Printer
 	f.WarnInsecureHTTP(serverURL, "guest access")
-	p.Infof("Validating guest access... ")
+	p.Progress("Validating guest access... ")
 
 	client := api.NewGuestClient(serverURL, api.WithDebugFunc(p.Debug), api.WithVersion(version.String()))
 	server, err := client.GetServer()

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -37,7 +38,7 @@ func runAuthLogout(f *cmdutil.Factory, serverFlag string) error {
 	} else {
 		serverURL = config.GetServerURL()
 		if serverURL == "" {
-			return fmt.Errorf("not logged in to any server")
+			return errors.New("not logged in to any server")
 		}
 	}
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -80,6 +80,37 @@ func TestGlobalFlags(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, f, "--no-color", "project", "list", "--limit", "1")
 }
 
+func TestGlobalFlagMutex(T *testing.T) {
+	T.Parallel()
+
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr bool
+	}{
+		{"verbose-debug coexist (aliases)", []string{"--verbose", "--debug", "completion", "bash"}, false},
+		{"quiet conflicts with verbose", []string{"--quiet", "--verbose", "completion", "bash"}, true},
+		{"quiet conflicts with debug", []string{"--quiet", "--debug", "completion", "bash"}, true},
+	}
+
+	for _, tc := range cases {
+		T.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rootCmd := cmd.NewRootCmd()
+			rootCmd.SetArgs(tc.args)
+			var out bytes.Buffer
+			rootCmd.SetOut(&out)
+			rootCmd.SetErr(&out)
+			err := rootCmd.Execute()
+			if tc.wantErr {
+				assert.Error(t, err, "expected mutex error for %v", tc.args)
+			} else {
+				require.NoError(t, err, "aliases must coexist: %v", tc.args)
+			}
+		})
+	}
+}
+
 func TestUnknownSubcommand(T *testing.T) {
 	T.Parallel()
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -47,7 +47,7 @@ func TestHelpCommands(T *testing.T) {
 	for _, args := range commands {
 		T.Run(args[0], func(t *testing.T) {
 			t.Parallel()
-			rootCmd := cmd.NewRootCmd()
+			rootCmd := cmd.NewCommand(nil)
 			rootCmd.SetArgs(args)
 			var out bytes.Buffer
 			rootCmd.SetOut(&out)
@@ -62,7 +62,7 @@ func TestHelpCommands(T *testing.T) {
 func TestUnknownCommand(T *testing.T) {
 	T.Parallel()
 
-	rootCmd := cmd.NewRootCmd()
+	rootCmd := cmd.NewCommand(nil)
 	rootCmd.SetArgs([]string{"nonexistent"})
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
@@ -96,7 +96,7 @@ func TestGlobalFlagMutex(T *testing.T) {
 	for _, tc := range cases {
 		T.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			rootCmd := cmd.NewRootCmd()
+			rootCmd := cmd.NewCommand(nil)
 			rootCmd.SetArgs(tc.args)
 			var out bytes.Buffer
 			rootCmd.SetOut(&out)
@@ -142,7 +142,7 @@ func TestParentCommandWithoutSubcommand(T *testing.T) {
 		T.Run(c, func(t *testing.T) {
 			t.Parallel()
 
-			rootCmd := cmd.NewRootCmd()
+			rootCmd := cmd.NewCommand(nil)
 			rootCmd.SetArgs([]string{c})
 			var out bytes.Buffer
 			rootCmd.SetOut(&out)
@@ -169,7 +169,7 @@ func TestInvalidIDs(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			f := ts.CloneFactory()
-			rootCmd := cmd.NewRootCmdWithFactory(f)
+			rootCmd := cmd.NewCommand(f)
 			rootCmd.SetArgs(tc.args)
 			var out bytes.Buffer
 			rootCmd.SetOut(&out)

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"maps"
 	"os"
@@ -250,12 +251,12 @@ func newSetCmd(f *cmdutil.Factory) *cobra.Command {
 
 func selectDefaultServer(f *cmdutil.Factory) (string, error) {
 	if !f.IsInteractive() {
-		return "", fmt.Errorf("value is required for key \"default_server\" in non-interactive mode")
+		return "", errors.New("value is required for key \"default_server\" in non-interactive mode")
 	}
 
 	c := cfg.Get()
 	if len(c.Servers) == 0 {
-		return "", fmt.Errorf("no servers configured; run 'teamcity auth login' first")
+		return "", errors.New("no servers configured; run 'teamcity auth login' first")
 	}
 
 	urls := sortedServerURLs(c)

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -32,7 +32,7 @@ func capture(t *testing.T, args ...string) string {
 	var buf bytes.Buffer
 	f := cmdutil.NewFactory()
 	f.Printer = &output.Printer{Out: &buf, ErrOut: &buf}
-	root := cmd.NewRootCmdWithFactory(f)
+	root := cmd.NewCommand(f)
 	root.SetArgs(args)
 	root.SetOut(&buf)
 	root.SetErr(&buf)
@@ -45,7 +45,7 @@ func captureErr(t *testing.T, args ...string) error {
 	var buf bytes.Buffer
 	f := cmdutil.NewFactory()
 	f.Printer = &output.Printer{Out: &buf, ErrOut: &buf}
-	root := cmd.NewRootCmdWithFactory(f)
+	root := cmd.NewCommand(f)
 	root.SetArgs(args)
 	root.SetOut(&buf)
 	root.SetErr(&buf)

--- a/internal/cmd/job/state.go
+++ b/internal/cmd/job/state.go
@@ -22,7 +22,7 @@ var jobStateActions = map[string]jobStateAction{
 
 func newJobStateCmd(f *cmdutil.Factory, a jobStateAction) *cobra.Command {
 	return &cobra.Command{
-		Use:     fmt.Sprintf("%s <job-id>", a.use),
+		Use:     a.use + " <job-id>",
 		Short:   a.short,
 		Long:    a.long,
 		Args:    cobra.ExactArgs(1),

--- a/internal/cmd/job/tree.go
+++ b/internal/cmd/job/tree.go
@@ -1,7 +1,7 @@
 package job
 
 import (
-	"fmt"
+	"errors"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -62,7 +62,7 @@ func newJobTreeCmd(f *cmdutil.Factory) *cobra.Command {
 
 func runJobTree(f *cmdutil.Factory, jobID string, depth int, only string, jsonOut bool) error {
 	if only != "" && only != "dependents" && only != "dependencies" {
-		return fmt.Errorf("--only must be 'dependents' or 'dependencies'")
+		return errors.New("--only must be 'dependents' or 'dependencies'")
 	}
 
 	client, err := f.Client()

--- a/internal/cmd/pipeline/create.go
+++ b/internal/cmd/pipeline/create.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
@@ -74,7 +75,7 @@ func runPipelineCreate(f *cmdutil.Factory, name string, opts *createOptions) err
 
 func selectVcsRoot(f *cmdutil.Factory, client api.ClientInterface, projectID string) (string, error) {
 	if !f.IsInteractive() {
-		return "", fmt.Errorf("--vcs-root is required (or use interactive mode)")
+		return "", errors.New("--vcs-root is required (or use interactive mode)")
 	}
 
 	roots, err := client.GetVcsRoots(api.VcsRootsOptions{Project: projectID, Limit: 100})

--- a/internal/cmd/pipeline/delete.go
+++ b/internal/cmd/pipeline/delete.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -46,7 +47,7 @@ func runPipelineDelete(f *cmdutil.Factory, id string, opts *deleteOptions) error
 
 	if !opts.yes {
 		if !f.IsInteractive() {
-			return fmt.Errorf("--yes is required in non-interactive mode")
+			return errors.New("--yes is required in non-interactive mode")
 		}
 		var confirm bool
 		prompt := &survey.Confirm{

--- a/internal/cmd/pipeline/delete.go
+++ b/internal/cmd/pipeline/delete.go
@@ -28,8 +28,8 @@ func newPipelineDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().BoolVar(&opts.yes, "force", false, "Deprecated: use --yes")
-	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
+	cmd.Flags().BoolVar(&opts.yes, "force", false, "")
+	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
 
 	return cmd
 }

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -1,7 +1,7 @@
 package pipeline
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -57,7 +57,7 @@ func (opts *pipelineListOptions) fetch(client api.ClientInterface, fields []stri
 		}
 		jobCount := ""
 		if p.Jobs != nil {
-			jobCount = fmt.Sprintf("%d", p.Jobs.Count)
+			jobCount = strconv.Itoa(p.Jobs.Count)
 		}
 
 		rows = append(rows, []string{

--- a/internal/cmd/pipeline/schema.go
+++ b/internal/cmd/pipeline/schema.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"crypto/sha256"
 	_ "embed"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,7 +50,7 @@ func loadCachedSchema(serverURL string) ([]byte, error) {
 	}
 
 	if time.Since(info.ModTime()) > schemaTTL {
-		return nil, fmt.Errorf("schema cache expired")
+		return nil, errors.New("schema cache expired")
 	}
 
 	return os.ReadFile(path)

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -140,7 +141,7 @@ func validateAgainstSchema(schemaData []byte, doc any) ([]validationError, error
 		return nil, nil
 	}
 
-	valErr, ok := err.(*jsonschema.ValidationError)
+	valErr, ok := errors.AsType[*jsonschema.ValidationError](err)
 	if !ok {
 		return nil, err
 	}

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -108,7 +108,7 @@ func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, error) {
 
 	c, ok := client.(*api.Client)
 	if !ok {
-		return nil, fmt.Errorf("schema caching requires a real API client")
+		return nil, errors.New("schema caching requires a real API client")
 	}
 
 	return fetchOrCacheSchema(c, opts.refreshSchema)

--- a/internal/cmd/pool/link.go
+++ b/internal/cmd/pool/link.go
@@ -39,7 +39,7 @@ var poolProjectActions = map[string]poolProjectAction{
 
 func newPoolProjectCmd(f *cmdutil.Factory, a poolProjectAction) *cobra.Command {
 	return &cobra.Command{
-		Use:     fmt.Sprintf("%s <pool-id> <project-id>", a.use),
+		Use:     a.use + " <pool-id> <project-id>",
 		Short:   a.short,
 		Long:    a.long,
 		Args:    cobra.ExactArgs(2),

--- a/internal/cmd/pool/list.go
+++ b/internal/cmd/pool/list.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -45,11 +46,11 @@ func fetchPools(client api.ClientInterface, fields []string) (*cmdutil.ListResul
 	for _, p := range pools.Pools {
 		maxAgents := "unlimited"
 		if p.MaxAgents > 0 {
-			maxAgents = fmt.Sprintf("%d", p.MaxAgents)
+			maxAgents = strconv.Itoa(p.MaxAgents)
 		}
 
 		rows = append(rows, []string{
-			fmt.Sprintf("%d", p.ID),
+			strconv.Itoa(p.ID),
 			p.Name,
 			maxAgents,
 		})

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"io"
 	"slices"
@@ -254,7 +255,7 @@ func runProjectTokenPut(f *cmdutil.Factory, projectID, value string, opts *proje
 	}
 
 	if value == "" {
-		return fmt.Errorf("value cannot be empty")
+		return errors.New("value cannot be empty")
 	}
 
 	token, err := client.CreateSecureToken(projectID, value)

--- a/internal/cmd/project/project_test.go
+++ b/internal/cmd/project/project_test.go
@@ -48,7 +48,7 @@ func TestProjectParam(T *testing.T) {
 func TestProjectToken(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 
-	rootCmd := cmd.NewRootCmdWithFactory(ts.Factory)
+	rootCmd := cmd.NewCommand(ts.Factory)
 	rootCmd.SetArgs([]string{"project", "token", "put", testProject, "test-secret-value"})
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -3,6 +3,7 @@ package project
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -355,7 +356,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 	}
 
 	if dslDir == "" {
-		return fmt.Errorf("no TeamCity DSL directory found\n\nLooking for .teamcity in current directory and parents.\nSpecify path explicitly: teamcity project settings validate ./path/to/settings")
+		return errors.New("no TeamCity DSL directory found\n\nLooking for .teamcity in current directory and parents.\nSpecify path explicitly: teamcity project settings validate ./path/to/settings")
 	}
 
 	pomPath := filepath.Join(dslDir, "pom.xml")
@@ -406,7 +407,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 			_, _ = fmt.Fprintln(p.Out)
 			p.Tip("Run with --verbose for full compiler output")
 		}
-		return fmt.Errorf("validation failed")
+		return errors.New("validation failed")
 	}
 
 	if opts.json {
@@ -428,7 +429,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 func findMaven() (string, error) {
 	mvn, err := exec.LookPath("mvn")
 	if err != nil {
-		return "", fmt.Errorf("maven not found\n\nInstall Maven to validate DSL locally.\nSee: https://maven.apache.org/install.html")
+		return "", errors.New("maven not found\n\nInstall Maven to validate DSL locally.\nSee: https://maven.apache.org/install.html")
 	}
 	return mvn, nil
 }

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -236,8 +236,8 @@ func newSSHDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
-	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
+	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
 
 	return cmd
 }

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -691,8 +691,8 @@ func newVcsDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
-	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
+	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
 
 	return cmd
 }

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -597,7 +598,7 @@ func runVcsTest(f *cmdutil.Factory, id string) error {
 	}
 
 	if !client.SupportsFeature("vcs_test_connection") {
-		return fmt.Errorf("connection testing requires TeamCity 2024.12 or later")
+		return errors.New("connection testing requires TeamCity 2024.12 or later")
 	}
 
 	root, err := client.GetVcsRoot(id)

--- a/internal/cmd/queue/action.go
+++ b/internal/cmd/queue/action.go
@@ -29,7 +29,7 @@ var queueActions = map[string]queueAction{
 
 func newQueueActionCmd(f *cmdutil.Factory, a queueAction) *cobra.Command {
 	return &cobra.Command{
-		Use:     fmt.Sprintf("%s <id>", a.use),
+		Use:     a.use + " <id>",
 		Short:   a.short,
 		Long:    a.long,
 		Args:    cobra.ExactArgs(1),

--- a/internal/cmd/queue/list.go
+++ b/internal/cmd/queue/list.go
@@ -1,7 +1,7 @@
 package queue
 
 import (
-	"fmt"
+	"strconv"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -63,7 +63,7 @@ func (opts *queueListOptions) fetch(client api.ClientInterface, fields []string)
 		}
 
 		rows = append(rows, []string{
-			fmt.Sprintf("%d", r.ID),
+			strconv.Itoa(r.ID),
 			r.BuildTypeID,
 			branch,
 			r.State,

--- a/internal/cmd/queue/remove.go
+++ b/internal/cmd/queue/remove.go
@@ -28,8 +28,8 @@ func newQueueRemoveCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
-	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
+	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
 
 	return cmd
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -152,8 +152,8 @@ func tryAutoReauth(f *cmdutil.Factory) {
 }
 
 func isCategory(err error, cat api.Category) bool {
-	var ue api.UserError
-	return errors.As(err, &ue) && ue.Category() == cat
+	ue, ok := errors.AsType[api.UserError](err)
+	return ok && ue.Category() == cat
 }
 
 // addGrouped registers subcommands under a shared group ID on the parent command.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -81,10 +81,8 @@ Report issues:  https://jb.gg/tc/issues`,
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		f.InitOutput()
-		if jsonFlag := cmd.Flags().Lookup("json"); jsonFlag != nil && jsonFlag.Changed {
-			if jsonFlag.Value.Type() != "bool" || jsonFlag.Value.String() != "false" {
-				f.JSONOutput = true
-			}
+		if jsonOutputEnabled(cmd) {
+			f.JSONOutput = true
 		}
 		if cmd.Name() != "update" && f.UpdateNotice == nil {
 			f.UpdateNotice = update.CheckInBackground(f.Printer.ErrOut, f.Quiet)
@@ -112,19 +110,15 @@ func Execute() error {
 	f := cmdutil.NewFactory()
 	rootCmd := buildRootCmd(f)
 
-	RegisterAliases(rootCmd, f)
+	alias.RegisterAliases(rootCmd, f)
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	executedCmd, err := rootCmd.ExecuteC()
 	if f.UpdateNotice != nil {
 		f.UpdateNotice()
 	}
-	if !f.JSONOutput && executedCmd != nil {
-		if jsonFlag := executedCmd.Flags().Lookup("json"); jsonFlag != nil && jsonFlag.Changed {
-			if jsonFlag.Value.Type() != "bool" || jsonFlag.Value.String() != "false" {
-				f.JSONOutput = true
-			}
-		}
+	if !f.JSONOutput && executedCmd != nil && jsonOutputEnabled(executedCmd) {
+		f.JSONOutput = true
 	}
 	if err != nil && isCategory(err, api.CatAuth) && !f.JSONOutput {
 		tryAutoReauth(f)
@@ -170,32 +164,23 @@ func addGrouped(parent *cobra.Command, groupID string, cmds ...*cobra.Command) {
 	}
 }
 
-// RegisterAliases forwards to alias.RegisterAliases.
-func RegisterAliases(rootCmd *cobra.Command, f *cmdutil.Factory) {
-	alias.RegisterAliases(rootCmd, f)
+// jsonOutputEnabled reports whether --json was set to a JSON-emitting value.
+// Handles both the bool --json shape (most commands) and the string
+// --json=fields shape used by list commands (see cmdutil.AddJSONFieldsFlag).
+func jsonOutputEnabled(cmd *cobra.Command) bool {
+	f := cmd.Flags().Lookup("json")
+	return f != nil && f.Changed && f.Value.String() != "false"
 }
 
-// RootCommand is an alias for cobra.Command for external access
-type RootCommand = cobra.Command
-
-// GetRootCmd returns a root command for doc generation and external access.
-func GetRootCmd() *RootCommand {
-	f := cmdutil.NewFactory()
-	return buildRootCmd(f)
-}
-
-// NewRootCmd creates a fresh root command instance for testing.
-// Unlike the production root, it does not set PersistentPreRun to avoid
-// races on output globals when tests run in parallel.
-func NewRootCmd() *RootCommand {
-	f := cmdutil.NewFactory()
-	cmd := buildRootCmd(f)
-	cmd.PersistentPreRun = nil
-	return cmd
-}
-
-// NewRootCmdWithFactory creates a fresh root command with a specific factory (for tests).
-func NewRootCmdWithFactory(f *cmdutil.Factory) *RootCommand {
+// NewCommand builds a root command for tests and doc generation.
+// Pass nil for f to get a fresh production factory. PersistentPreRun is
+// stripped so tests and doc walks don't spawn the update-check goroutine
+// or race on output globals. Aliases are not registered — callers that
+// need them invoke alias.RegisterAliases themselves.
+func NewCommand(f *cmdutil.Factory) *cobra.Command {
+	if f == nil {
+		f = cmdutil.NewFactory()
+	}
 	cmd := buildRootCmd(f)
 	cmd.PersistentPreRun = nil
 	return cmd

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -76,7 +76,8 @@ Report issues:  https://jb.gg/tc/issues`,
 	cmd.PersistentFlags().BoolVar(&f.Verbose, "debug", false, "Alias for --verbose")
 	cmd.PersistentFlags().BoolVar(&f.NoInput, "no-input", false, "Disable interactive prompts")
 
-	cmd.MarkFlagsMutuallyExclusive("quiet", "verbose", "debug")
+	cmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
+	cmd.MarkFlagsMutuallyExclusive("quiet", "debug")
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		f.InitOutput()

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -183,7 +184,7 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 				"Try --all, or verify the job ID with 'teamcity job list'",
 			)
 		}
-		runID = fmt.Sprintf("%d", runs.Builds[0].ID)
+		runID = strconv.Itoa(runs.Builds[0].ID)
 	} else if runID == "" {
 		return fmt.Errorf("run ID required (or use --job to get latest run)")
 	}

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -186,7 +187,7 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		}
 		runID = strconv.Itoa(runs.Builds[0].ID)
 	} else if runID == "" {
-		return fmt.Errorf("run ID required (or use --job to get latest run)")
+		return errors.New("run ID required (or use --job to get latest run)")
 	}
 
 	build, err := client.GetBuild(context.Background(), runID)

--- a/internal/cmd/run/artifacts.go
+++ b/internal/cmd/run/artifacts.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"strconv"
@@ -80,7 +81,7 @@ func runRunArtifacts(f *cmdutil.Factory, runID string, opts *runArtifactsOptions
 		runID = strconv.Itoa(runs.Builds[0].ID)
 		p.Info("Listing artifacts for run %s  #%s", runID, runs.Builds[0].Number)
 	} else if runID == "" {
-		return fmt.Errorf("run ID required (or use --job to get latest run)")
+		return errors.New("run ID required (or use --job to get latest run)")
 	}
 
 	artifacts, err := client.GetArtifacts(context.Background(), runID, opts.path)

--- a/internal/cmd/run/artifacts.go
+++ b/internal/cmd/run/artifacts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"strconv"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -76,7 +77,7 @@ func runRunArtifacts(f *cmdutil.Factory, runID string, opts *runArtifactsOptions
 				"Try --all, or verify the job ID with 'teamcity job list'",
 			)
 		}
-		runID = fmt.Sprintf("%d", runs.Builds[0].ID)
+		runID = strconv.Itoa(runs.Builds[0].ID)
 		p.Info("Listing artifacts for run %s  #%s", runID, runs.Builds[0].Number)
 	} else if runID == "" {
 		return fmt.Errorf("run ID required (or use --job to get latest run)")

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -35,8 +35,8 @@ in the TeamCity UI.`,
 
 	cmd.Flags().StringVar(&opts.comment, "comment", "", "Comment for cancellation")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
-	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "Deprecated: use --yes")
-	_ = cmd.Flags().MarkDeprecated("force", "use --yes instead")
+	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
+	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
 
 	return cmd
 }

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -295,7 +295,7 @@ func TestRunListWithAtMe(T *testing.T) {
 func TestInvalidStatusFilter(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 
-	rootCmd := cmd.NewRootCmdWithFactory(ts.Factory)
+	rootCmd := cmd.NewCommand(ts.Factory)
 	rootCmd.SetArgs([]string{"run", "list", "--status", "invalid"})
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
@@ -311,7 +311,7 @@ func TestValidStatusFilter(T *testing.T) {
 	validStatuses := []string{"success", "failure", "running", "queued", "canceled"}
 	for _, status := range validStatuses {
 		T.Run(status, func(t *testing.T) {
-			rootCmd := cmd.NewRootCmdWithFactory(ts.Factory)
+			rootCmd := cmd.NewCommand(ts.Factory)
 			rootCmd.SetArgs([]string{"run", "list", "--status", status, "--limit", "1"})
 			var out bytes.Buffer
 			rootCmd.SetOut(&out)
@@ -353,7 +353,7 @@ func TestStatusFilterLocator(T *testing.T) {
 				cmdtest.JSON(w, api.BuildList{Count: 0, Builds: []api.Build{}})
 			})
 
-			rootCmd := cmd.NewRootCmdWithFactory(ts.Factory)
+			rootCmd := cmd.NewCommand(ts.Factory)
 			rootCmd.SetArgs([]string{"run", "list", "--status", tt.status, "--limit", "1"})
 			var out bytes.Buffer
 			rootCmd.SetOut(&out)
@@ -389,7 +389,7 @@ func TestRunListFavoritesLocator(T *testing.T) {
 		cmdtest.JSON(w, api.BuildList{Count: 0, Builds: []api.Build{}})
 	})
 
-	rootCmd := cmd.NewRootCmdWithFactory(ts.Factory)
+	rootCmd := cmd.NewCommand(ts.Factory)
 	rootCmd.SetArgs([]string{"run", "list", "--favorites", "--limit", "1"})
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -183,9 +183,8 @@ func fetchBothBuilds(client api.ClientInterface, id1, id2 string, p *output.Prin
 	var d1, d2 buildData
 	var err1, err2 error
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() { defer wg.Done(); d1, err1 = fetchBuildData(client, id1, p) }()
-	go func() { defer wg.Done(); d2, err2 = fetchBuildData(client, id2, p) }()
+	wg.Go(func() { d1, err1 = fetchBuildData(client, id1, p) })
+	wg.Go(func() { d2, err2 = fetchBuildData(client, id2, p) })
 	wg.Wait()
 	if err1 != nil {
 		return d1, d2, err1

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -144,7 +145,7 @@ func resolveDiffBuildIDs(client api.ClientInterface, args []string) (string, str
 
 	for _, b := range builds.Builds {
 		if b.ID != build.ID {
-			return fmt.Sprintf("%d", b.ID), args[0], nil
+			return strconv.Itoa(b.ID), args[0], nil
 		}
 	}
 

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -218,7 +218,7 @@ func runLogDiff(f *cmdutil.Factory, client api.ClientInterface, id1, id2 string,
 
 	output.WithPager(p.Out, func(w io.Writer) {
 		hasDiff, err := output.UnifiedDiff(w, lines1, lines2,
-			fmt.Sprintf("Run #%s", b1.Number), fmt.Sprintf("Run #%s", b2.Number), contextLines)
+			"Run #"+b1.Number, "Run #"+b2.Number, contextLines)
 		if err != nil {
 			_, _ = fmt.Fprintf(w, "Error: %v\n", err)
 			return

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 
@@ -136,7 +137,7 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 		var status, runRef string
 		if opts.plain {
 			status = output.PlainStatusText(r.Status, r.State, r.StatusText)
-			runRef = fmt.Sprintf("%d", r.ID)
+			runRef = strconv.Itoa(r.ID)
 		} else {
 			status = fmt.Sprintf("%s %s", output.StatusIcon(r.Status, r.State, r.StatusText), output.StatusText(r.Status, r.State, r.StatusText))
 			runRef = fmt.Sprintf("%d  #%s", r.ID, r.Number)
@@ -402,15 +403,15 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 	}
 
 	if opts.JSON {
-		reused, _ := client.GetBuildUsedByOtherBuilds(fmt.Sprintf("%d", build.ID))
+		reused, _ := client.GetBuildUsedByOtherBuilds(strconv.Itoa(build.ID))
 		build.UsedByOtherBuilds = reused
 		return p.PrintJSON(build)
 	}
 
-	reused, _ := client.GetBuildUsedByOtherBuilds(fmt.Sprintf("%d", build.ID))
+	reused, _ := client.GetBuildUsedByOtherBuilds(strconv.Itoa(build.ID))
 	build.UsedByOtherBuilds = reused
 
-	pipelineRun, _ := client.GetBuildPipelineRun(fmt.Sprintf("%d", build.ID))
+	pipelineRun, _ := client.GetBuildPipelineRun(strconv.Itoa(build.ID))
 
 	icon := output.StatusIcon(build.Status, build.State, build.StatusText)
 	jobName := build.BuildTypeID

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -279,7 +280,7 @@ func resolveRunListBranch(opts *runListOptions) (string, error) {
 func resolveAutoBranch(required bool) (string, error) {
 	if !runListIsGitRepoFn() {
 		if required {
-			return "", fmt.Errorf("--branch @this requires a git repository")
+			return "", errors.New("--branch @this requires a git repository")
 		}
 		return "", nil
 	}
@@ -337,7 +338,7 @@ var runListResolveRevisionFn = resolveRevision
 func resolveRunListRevision(opts *runListOptions) (string, error) {
 	if strings.EqualFold(opts.revision, "@head") {
 		if !runListIsGitRepoFn() {
-			return "", fmt.Errorf("--revision @head requires a git repository")
+			return "", errors.New("--revision @head requires a git repository")
 		}
 		return runListHeadRevisionFn()
 	}

--- a/internal/cmd/run/local_changes.go
+++ b/internal/cmd/run/local_changes.go
@@ -66,7 +66,7 @@ func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, api.Validation(
-					fmt.Sprintf("diff file not found: %s", source),
+					"diff file not found: "+source,
 					"Check the file path and try again",
 				)
 			}
@@ -74,7 +74,7 @@ func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 		}
 		if len(patch) == 0 {
 			return nil, api.Validation(
-				fmt.Sprintf("diff file is empty: %s", source),
+				"diff file is empty: "+source,
 				"Provide a non-empty diff file",
 			)
 		}

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -219,7 +220,7 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 			f.Printer.Info("Showing log for #%s (%s)", runID, runs.Builds[0].Number)
 		}
 	} else if runID == "" {
-		return fmt.Errorf("run ID required (or use --job to get latest run)")
+		return errors.New("run ID required (or use --job to get latest run)")
 	}
 
 	if opts.web {

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -472,7 +472,7 @@ func waitForBuildStart(ctx context.Context, p *output.Printer, client api.Client
 			return nil
 		}
 		if !jsonOut && build.WaitReason != "" {
-			p.Infof("\r  %s", build.WaitReason)
+			p.Progress("\r  %s", build.WaitReason)
 		}
 	}
 }

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"time"
 
@@ -213,7 +214,7 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 				"Try --all, or verify the job ID with 'teamcity job list'",
 			)
 		}
-		runID = fmt.Sprintf("%d", runs.Builds[0].ID)
+		runID = strconv.Itoa(runs.Builds[0].ID)
 		if !opts.json {
 			f.Printer.Info("Showing log for #%s (%s)", runID, runs.Builds[0].Number)
 		}

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -266,17 +266,15 @@ func runLogFull(f *cmdutil.Factory, client api.ClientInterface, runID string, op
 		return nil
 	}
 
-	lines := strings.Split(log, "\n")
-
 	output.WithPager(f.Printer.Out, func(w io.Writer) {
 		if opts.raw {
 			_, _ = fmt.Fprintln(w, log)
-		} else {
-			for _, line := range lines {
-				formatted := formatLogLine(line)
-				if formatted != "" {
-					_, _ = fmt.Fprintln(w, formatted)
-				}
+			return
+		}
+		for line := range strings.SplitSeq(log, "\n") {
+			formatted := formatLogLine(line)
+			if formatted != "" {
+				_, _ = fmt.Fprintln(w, formatted)
 			}
 		}
 	})

--- a/internal/cmd/run/metadata.go
+++ b/internal/cmd/run/metadata.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -92,7 +93,7 @@ func runRunTag(f *cmdutil.Factory, runID string, tags []string) error {
 		}
 	}
 	if len(filtered) == 0 {
-		return fmt.Errorf("at least one non-empty tag is required")
+		return errors.New("at least one non-empty tag is required")
 	}
 	tags = filtered
 
@@ -131,11 +132,11 @@ func runRunUntag(f *cmdutil.Factory, runID string, tags []string) error {
 		return err
 	}
 
-	var errors []string
+	var failures []string
 	removed := 0
 	for _, tag := range tags {
 		if err := client.RemoveBuildTag(runID, tag); err != nil {
-			errors = append(errors, fmt.Sprintf("%s: %v", tag, err))
+			failures = append(failures, fmt.Sprintf("%s: %v", tag, err))
 		} else {
 			removed++
 		}
@@ -145,12 +146,12 @@ func runRunUntag(f *cmdutil.Factory, runID string, tags []string) error {
 		f.Printer.Success("Removed %d tag(s) from #%s", removed, runID)
 	}
 
-	if len(errors) > 0 {
-		for _, e := range errors {
+	if len(failures) > 0 {
+		for _, e := range failures {
 			f.Printer.Warn("  Failed: %s", e)
 		}
 		if removed == 0 {
-			return fmt.Errorf("failed to remove any tags")
+			return errors.New("failed to remove any tags")
 		}
 	}
 
@@ -233,7 +234,7 @@ func runRunComment(f *cmdutil.Factory, runID string, comment string, opts *runCo
 
 	p := f.Printer
 	if existingComment == "" {
-		p.Empty(fmt.Sprintf("No comment set on #%s", runID), output.TipNoCommentFor(runID))
+		p.Empty("No comment set on #"+runID, output.TipNoCommentFor(runID))
 	} else {
 		_, _ = fmt.Fprintln(p.Out, existingComment)
 	}

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -304,10 +304,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		}
 
 		p.Info("Uploading local changes...")
-		description := opts.comment
-		if description == "" {
-			description = "Personal build with local changes"
-		}
+		description := cmp.Or(opts.comment, "Personal build with local changes")
 
 		changeID, err := client.UploadDiffChanges(patch, description)
 		if err != nil {

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -107,7 +107,7 @@ func reuseDepRow(d reuseDep) (icon, summary string) {
 func printQueuedRun(p *output.Printer, build *api.Build, context string) {
 	ref := fmt.Sprintf("%d  #%s", build.ID, build.Number)
 	if build.Number == "" {
-		ref = fmt.Sprintf("%d", build.ID)
+		ref = strconv.Itoa(build.ID)
 	}
 	p.Success("Queued run %s for %s", ref, context)
 }
@@ -118,7 +118,7 @@ func afterQueue(f *cmdutil.Factory, build *api.Build, web bool, wf *watchFlags) 
 	}
 	if wf.watch {
 		_, _ = fmt.Fprintln(f.Printer.Out)
-		return doRunWatch(f, fmt.Sprintf("%d", build.ID), wf.watchOpts(true, false))
+		return doRunWatch(f, strconv.Itoa(build.ID), wf.watchOpts(true, false))
 	}
 	return nil
 }
@@ -342,14 +342,14 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 
 	if opts.json {
 		if opts.watch {
-			return doRunWatch(f, fmt.Sprintf("%d", build.ID), opts.watchOpts(false, true))
+			return doRunWatch(f, strconv.Itoa(build.ID), opts.watchOpts(false, true))
 		}
 		return p.PrintJSON(build)
 	}
 
 	reused := build.State == "finished"
 	if reused {
-		ref := fmt.Sprintf("%d", build.ID)
+		ref := strconv.Itoa(build.ID)
 		if build.Number != "" {
 			ref = fmt.Sprintf("%d  #%s", build.ID, build.Number)
 		}

--- a/internal/cmd/run/tree.go
+++ b/internal/cmd/run/tree.go
@@ -206,12 +206,10 @@ func buildRunTree(client api.ClientInterface, b api.Build, depth int, path map[s
 		childPath := make(map[string]bool, len(path)+1)
 		maps.Copy(childPath, path)
 		childPath[sid] = true
-		wg.Add(1)
-		go func(i int, dep api.Build, childPath map[string]bool) {
-			defer wg.Done()
+		wg.Go(func() {
 			child, err := buildRunTree(client, dep, next, childPath)
 			results[i] = result{idx: i, node: child, err: err}
-		}(i, dep, childPath)
+		})
 	}
 	wg.Wait()
 

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -191,7 +191,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 			if build.State == "queued" {
 				status = output.Faint("Queued")
 				if build.WaitReason != "" {
-					status = output.Faint(fmt.Sprintf("Queued · %s", build.WaitReason))
+					status = output.Faint("Queued · " + build.WaitReason)
 				}
 			}
 			progress := ""

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -1,6 +1,7 @@
 package skill
 
 import (
+	"errors"
 	"fmt"
 
 	teamcitycli "github.com/JetBrains/teamcity-cli"
@@ -256,7 +257,7 @@ func runSkillRemove(p *output.Printer, opts *skillOptions, args []string) error 
 
 func resolveSkillNames(all bool, args []string) ([]string, error) {
 	if all && len(args) > 0 {
-		return nil, fmt.Errorf("cannot specify both --all and skill names")
+		return nil, errors.New("cannot specify both --all and skill names")
 	}
 	if all {
 		skills := instill.ListSkills(teamcitycli.SkillsFS)

--- a/internal/cmd/update/update_test.go
+++ b/internal/cmd/update/update_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestUpdateCommandRegistered(t *testing.T) {
-	root := cmd.NewRootCmd()
+	root := cmd.NewCommand(nil)
 	child, _, err := root.Find([]string{"update"})
 	require.NoError(t, err)
 	assert.Equal(t, "update", child.Name())

--- a/internal/cmdtest/testutil.go
+++ b/internal/cmdtest/testutil.go
@@ -148,7 +148,7 @@ func ExtractID(path, prefix string) string {
 // RunCmd executes a CLI command using the default mock factory and asserts no error.
 func RunCmd(t *testing.T, args ...string) {
 	t.Helper()
-	rootCmd := cmd.NewRootCmd()
+	rootCmd := cmd.NewCommand(nil)
 	rootCmd.SetArgs(args)
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)
@@ -163,7 +163,7 @@ func CaptureOutput(t *testing.T, f *cmdutil.Factory, args ...string) string {
 	var buf bytes.Buffer
 	f.Printer = &output.Printer{Out: &buf, ErrOut: &buf}
 
-	rootCmd := cmd.NewRootCmdWithFactory(f)
+	rootCmd := cmd.NewCommand(f)
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
@@ -179,7 +179,7 @@ func CaptureErr(t *testing.T, f *cmdutil.Factory, args ...string) error {
 	var buf bytes.Buffer
 	f.Printer = &output.Printer{Out: &buf, ErrOut: &buf}
 
-	rootCmd := cmd.NewRootCmdWithFactory(f)
+	rootCmd := cmd.NewCommand(f)
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
@@ -198,7 +198,7 @@ func RunCmdWithFactory(t *testing.T, f *cmdutil.Factory, args ...string) {
 // RunCmdExpectErr executes a CLI command and asserts an error containing want.
 func RunCmdExpectErr(t *testing.T, want string, args ...string) {
 	t.Helper()
-	rootCmd := cmd.NewRootCmd()
+	rootCmd := cmd.NewCommand(nil)
 	rootCmd.SetArgs(args)
 	var out bytes.Buffer
 	rootCmd.SetOut(&out)

--- a/internal/cmdutil/experimental.go
+++ b/internal/cmdutil/experimental.go
@@ -20,16 +20,3 @@ func MarkExperimental(f *Factory, cmd *cobra.Command) {
 	}
 }
 
-// IsExperimental reports whether the command (or any of its parents) is marked experimental.
-func IsExperimental(cmd *cobra.Command) bool {
-	if cmd.Annotations["experimental"] == "true" {
-		return true
-	}
-	found := false
-	cmd.VisitParents(func(p *cobra.Command) {
-		if p.Annotations["experimental"] == "true" {
-			found = true
-		}
-	})
-	return found
-}

--- a/internal/cmdutil/experimental.go
+++ b/internal/cmdutil/experimental.go
@@ -19,4 +19,3 @@ func MarkExperimental(f *Factory, cmd *cobra.Command) {
 		return inner(cmd, args)
 	}
 }
-

--- a/internal/cmdutil/experimental_test.go
+++ b/internal/cmdutil/experimental_test.go
@@ -70,4 +70,3 @@ func TestMarkExperimental_Quiet(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 	assert.Empty(t, stderr.String())
 }
-

--- a/internal/cmdutil/experimental_test.go
+++ b/internal/cmdutil/experimental_test.go
@@ -35,7 +35,6 @@ func TestMarkExperimental(t *testing.T) {
 
 	assert.Equal(t, "[experimental] Do the thing", cmd.Short)
 	assert.Equal(t, "true", cmd.Annotations["experimental"])
-	assert.True(t, IsExperimental(cmd))
 
 	// Execute and verify the notice is printed
 	cmd.SetArgs([]string{})
@@ -72,13 +71,3 @@ func TestMarkExperimental_Quiet(t *testing.T) {
 	assert.Empty(t, stderr.String())
 }
 
-func TestIsExperimental_Parent(t *testing.T) {
-	t.Parallel()
-
-	parent := &cobra.Command{Use: "parent", Annotations: map[string]string{"experimental": "true"}}
-	child := &cobra.Command{Use: "child", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
-	parent.AddCommand(child)
-
-	assert.True(t, IsExperimental(child))
-	assert.False(t, IsExperimental(&cobra.Command{Use: "standalone"}))
-}

--- a/internal/cmdutil/failure.go
+++ b/internal/cmdutil/failure.go
@@ -3,6 +3,7 @@ package cmdutil
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -90,7 +91,7 @@ func BuildResultError(ctx context.Context, p *output.Printer, client api.ClientI
 		}
 		return nil
 	case "FAILURE":
-		PrintFailureSummary(ctx, p, client, fmt.Sprintf("%d", build.ID), build.Number, build.WebURL, build.StatusText)
+		PrintFailureSummary(ctx, p, client, strconv.Itoa(build.ID), build.Number, build.WebURL, build.StatusText)
 		return &ExitError{Code: ExitFailure}
 	default:
 		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s canceled\n", output.Yellow("○"), output.Cyan(jobName), build.ID, build.Number)

--- a/internal/cmdutil/list.go
+++ b/internal/cmdutil/list.go
@@ -1,6 +1,8 @@
 package cmdutil
 
 import (
+	"cmp"
+
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -84,11 +86,7 @@ func RunList(
 	}
 
 	if len(result.Table.Rows) == 0 {
-		msg := result.EmptyMsg
-		if msg == "" {
-			msg = "No items found"
-		}
-		f.Printer.Empty(msg, result.EmptyTip)
+		f.Printer.Empty(cmp.Or(result.EmptyMsg, "No items found"), result.EmptyTip)
 		return nil
 	}
 

--- a/internal/config/fields.go
+++ b/internal/config/fields.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -33,9 +35,9 @@ func GetField(key, serverURL string) (string, error) {
 	}
 	switch key {
 	case "guest":
-		return fmt.Sprintf("%t", sc.Guest), nil
+		return strconv.FormatBool(sc.Guest), nil
 	case "ro":
-		return fmt.Sprintf("%t", sc.RO), nil
+		return strconv.FormatBool(sc.RO), nil
 	case "token_expiry":
 		return sc.TokenExpiry, nil
 	}
@@ -48,7 +50,7 @@ func SetField(key, value, serverURL string) error {
 	}
 	if key == "default_server" {
 		if value == "" {
-			return fmt.Errorf("value cannot be empty")
+			return errors.New("value cannot be empty")
 		}
 		normalized := NormalizeURL(value)
 		if _, ok := cfg.Servers[normalized]; !ok {
@@ -91,7 +93,7 @@ func resolveServerForConfig(serverURL string) (string, error) {
 	}
 	c := Get()
 	if c.DefaultServer == "" {
-		return "", fmt.Errorf("no default server configured; use --server flag or run 'teamcity auth login'")
+		return "", errors.New("no default server configured; use --server flag or run 'teamcity auth login'")
 	}
 	return c.DefaultServer, nil
 }

--- a/internal/gallery/gallery_test.go
+++ b/internal/gallery/gallery_test.go
@@ -139,7 +139,7 @@ func capture(t *testing.T, ts *cmdtest.TestServer, args ...string) string {
 	f := ts.CloneFactory()
 	var buf bytes.Buffer
 	f.Printer = &output.Printer{Out: &buf, ErrOut: &buf}
-	rootCmd := cmd.NewRootCmdWithFactory(f)
+	rootCmd := cmd.NewCommand(f)
 	rootCmd.SetArgs(args)
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)

--- a/internal/output/color_test.go
+++ b/internal/output/color_test.go
@@ -14,7 +14,7 @@ func TestPrinterMethods(T *testing.T) {
 			p := &Printer{Out: &out, ErrOut: &errOut, Quiet: quiet}
 			p.Success("test %s", "message")
 			p.Info("test %s", "info")
-			p.Infof("test %s", "infof")
+			p.Progress("test %s", "progress")
 			p.Warn("test %s", "warn")
 			if quiet {
 				if out.Len() != 0 {

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -45,7 +45,7 @@ var (
 // NormalizeBuildLog strips per-run noise (header, ANSI, timestamps, temp paths, agent IDs, git progress).
 func NormalizeBuildLog(lines []string) []string {
 	start := 0
-	for i := 0; i < min(15, len(lines)); i++ {
+	for i := range min(15, len(lines)) {
 		if tcTimestampRe.MatchString(lines[i]) {
 			start = i
 			break

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -54,7 +54,8 @@ func (p *Printer) Tip(format string, args ...any) {
 	_, _ = fmt.Fprintln(p.Out, FormatTip(fmt.Sprintf(format, args...)))
 }
 
-func (p *Printer) Infof(format string, args ...any) {
+// Progress writes an inline progress line to stdout (no newline). Suppressed by --quiet.
+func (p *Printer) Progress(format string, args ...any) {
 	if !p.Quiet {
 		_, _ = fmt.Fprintf(p.Out, format, args...)
 	}

--- a/internal/output/printer_test.go
+++ b/internal/output/printer_test.go
@@ -50,10 +50,10 @@ func TestPrinterJSON(t *testing.T) {
 	assert.Contains(t, out.String(), `"count": 5`)
 }
 
-func TestPrinterInfof(t *testing.T) {
+func TestPrinterProgress(t *testing.T) {
 	var out bytes.Buffer
 	p := &Printer{Out: &out, ErrOut: &out}
-	p.Infof("hello %s", "world")
+	p.Progress("hello %s", "world")
 	assert.Equal(t, "hello world", out.String())
 }
 

--- a/internal/output/render_error.go
+++ b/internal/output/render_error.go
@@ -19,8 +19,7 @@ func RenderError(err error) error {
 
 // ClassifyError maps an error to a JSON error envelope (code + message + tip).
 func ClassifyError(err error) (JSONErrorCode, string, string) {
-	var ue api.UserError
-	if errors.As(err, &ue) {
+	if ue, ok := errors.AsType[api.UserError](err); ok {
 		return JSONErrorCode(ue.Category()), ue.Error(), tipFor(err)
 	}
 	if isInputError(err) {
@@ -31,19 +30,15 @@ func ClassifyError(err error) (JSONErrorCode, string, string) {
 
 // tipFor returns the next-step suggestion: explicit Suggestion() first, then category default.
 func tipFor(err error) string {
-	if h, ok := err.(interface{ Suggestion() string }); ok {
-		if s := h.Suggestion(); s != "" {
+	var hinter interface{ Suggestion() string }
+	if errors.As(err, &hinter) {
+		if s := hinter.Suggestion(); s != "" {
 			return s
 		}
 	}
-	var ue api.UserError
-	if !errors.As(err, &ue) {
+	ue, ok := errors.AsType[api.UserError](err)
+	if !ok {
 		return ""
-	}
-	if h, ok := ue.(interface{ Suggestion() string }); ok {
-		if s := h.Suggestion(); s != "" {
-			return s
-		}
 	}
 	switch ue.Category() {
 	case api.CatAuth:

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -2,7 +2,7 @@ package output
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"os"
 	"os/exec"
@@ -57,7 +57,7 @@ var pagerCmdFn = func() (*exec.Cmd, error) {
 	if pager := os.Getenv("PAGER"); pager != "" {
 		parts := strings.Fields(pager)
 		if len(parts) == 0 {
-			return nil, fmt.Errorf("PAGER is set but empty")
+			return nil, errors.New("PAGER is set but empty")
 		}
 		bin, err := exec.LookPath(parts[0])
 		if err != nil {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -67,7 +67,7 @@ func NewClient(baseURL, username, token string, debugf func(string, ...any)) *Cl
 func (c *Client) OpenSession(agentID int) (*Session, error) {
 	endpoint := fmt.Sprintf("%s/httpAuth/plugins/teamcity-agent-terminal/agentTerminal.html?id=%d", c.baseURL, agentID)
 
-	req, err := http.NewRequest("POST", endpoint, strings.NewReader(""))
+	req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(""))
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +93,7 @@ func (c *Client) OpenSession(agentID int) (*Session, error) {
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, api.Validation(
-			fmt.Sprintf("Failed to open terminal session: %s", strings.TrimSpace(string(body))),
+			"Failed to open terminal session: "+strings.TrimSpace(string(body)),
 			"Check if the agent-terminal plugin is installed on the server",
 		)
 	}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -74,11 +75,7 @@ func (c *Client) OpenSession(agentID int) (*Session, error) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	username := c.username
-	if username == "" {
-		username = "token"
-	}
-	req.SetBasicAuth(username, c.token)
+	req.SetBasicAuth(cmp.Or(c.username, "token"), c.token)
 
 	c.debugf("> POST %s", endpoint)
 

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -3,6 +3,7 @@ package update
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -102,7 +103,7 @@ func latestReleaseFromRedirect(ctx context.Context) (*ReleaseInfo, error) {
 
 	location := resp.Header.Get("Location")
 	if location == "" {
-		return nil, fmt.Errorf("GitHub releases page did not provide a redirect location")
+		return nil, errors.New("GitHub releases page did not provide a redirect location")
 	}
 
 	redirectURL, err := url.Parse(location)

--- a/scripts/generate-docs.go
+++ b/scripts/generate-docs.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"sort"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/spf13/cobra"

--- a/scripts/generate-docs.go
+++ b/scripts/generate-docs.go
@@ -5,10 +5,11 @@ package main
 
 import (
 	"bytes"
+	"cmp"
 	"fmt"
 	"os"
 	"regexp"
-	"sort"
+	"slices"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/spf13/cobra"
@@ -217,6 +218,6 @@ func pageLinkText(page string) string {
 
 func sortedCommands(c *cobra.Command) []*cobra.Command {
 	cmds := c.Commands()
-	sort.Slice(cmds, func(i, j int) bool { return cmds[i].Name() < cmds[j].Name() })
+	slices.SortFunc(cmds, func(a, b *cobra.Command) int { return cmp.Compare(a.Name(), b.Name()) })
 	return cmds
 }

--- a/scripts/generate-docs.go
+++ b/scripts/generate-docs.go
@@ -48,7 +48,7 @@ var sectionDescriptions = map[string]struct {
 const commandsDocPath = "docs/topics/teamcity-cli-commands.md"
 
 func main() {
-	rootCmd := cmd.GetRootCmd()
+	rootCmd := cmd.NewCommand(nil)
 
 	check := len(os.Args) > 1 && os.Args[1] == "--check"
 	ok := true


### PR DESCRIPTION
## Summary

Ten-commit hygiene pass: tighten lints, adopt modern Go idioms, delete dead code, collapse plumbing duplication, and fix a documented-but-never-enforced flag-group bug. No public API changes. No behaviour changes except one strict-improvement: `--verbose --debug` no longer errors (they're aliases for the same variable).

## Changes

**UX**
- Allow `--verbose` and `--debug` together. Cobra's single mutex group `("quiet", "verbose", "debug")` erroneously rejected the two aliases when passed jointly; split into two groups so `--quiet` still conflicts with each individually.
- Rename `Printer.Infof` → `Printer.Progress`. The old name read as "Info with format" but its only distinction from `Info` was no-auto-newline — inverted from `fmt.Printf` vs `fmt.Println` convention. Three call sites, all genuinely used it for inline progress output.

**Cleanup / plumbing**
- Collapse `GetRootCmd` + `NewRootCmd` + `NewRootCmdWithFactory` + `type RootCommand = cobra.Command` + `RegisterAliases` forwarder into a single `NewCommand(*Factory) *cobra.Command`. Inline `alias.RegisterAliases` in `Execute`.
- Extract `jsonOutputEnabled(cmd)` helper; collapse the duplicated JSON-flag detection in `PersistentPreRun` and `Execute`. Condition simplifies to `jsonFlag.Changed && jsonFlag.Value.String() != "false"` (handles bool `--json` and string `--json=fields`).
- Delete `cmdutil.IsExperimental` — unused outside its own test. Keep `MarkExperimental` (live via `run diff`) and its annotation write.

**Consistency**
- Migrate 7 hand-rolled `MarkDeprecated` sites to the existing `cmdutil.DeprecateFlag(cmd, old, new, "v1.0.0")`. Users now see a removal version in the deprecation notice.
- `fmt.Sprintf("%d", n)` → `strconv.Itoa(n)` across 17 sites plus 4 stragglers surfaced by `perfsprint`.
- Apply Go 1.22–1.26 idioms: `sync.WaitGroup.Go` (×2), `errors.AsType` (×3 prod, ×5 tests), `strings.SplitSeq`, `cmp.Or` (×4), `for i := range n`, `slices.SortFunc`. Collapse `tipFor`'s double `Suggestion()` probe.

**Lints**
- Enable `intrange`, `errorlint`, `perfsprint`, `usestdlibvars` in `.golangci.yml`.
- Fix all 94 violations surfaced by the new rules (81 `perfsprint`, 12 `usestdlibvars`, 1 `errorlint` in `pipeline/validate.go`). The bulk via `golangci-lint --fix`; one local `errors` variable renamed to `failures` to avoid shadowing the stdlib package after the `Errorf` → `errors.New` rewrite.

**Docs**
- Refresh `CONTRIBUTING.md`: drop nonexistent `Factory.SkipLinkLookup`, rename `teamcity.toml` → `config.yml`, update the standard-flags table (`--force`/`-f` → `--yes`/`-y`), and list the six currently deprecated flags instead of claiming none exist.

## Design Decisions

- **No `api.ClientInterface` changes.** Every diff is internal refactor; the public API is untouched.
- **Preserve current `--quiet` semantics.** `--quiet` still suppresses `Warn`. `TestPrinterQuiet` encodes this intent; deliberate design, not oversight.
- **`v1.0.0` as the deprecation removal version.** Matches CONTRIBUTING's example.
- **`Progress` over `Infoln`/`Info` flip.** Renaming the three `Infof` callers is one-file churn; flipping the `Info`/`Infoln` convention would touch ~40 call sites for the same end-state improvement.

## Test Plan

- [x] Unit tests pass (`just unit` via `go test ./...`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — not run locally; CI will cover
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, no new flags/commands
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A, `--json` detection refactored but output unchanged
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — only internal/behavioural refactors; no user-visible command/flag changes require doc sync. `CONTRIBUTING.md` drift corrected within this PR.