### PR TITLE
test(api): await agent release in cancelAndWait to deflake integration tests

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -89,20 +89,51 @@ func requireIdleAgent(t *testing.T) api.Agent {
 	return api.Agent{}
 }
 
-// cancelAndWait cancels a build and polls until it finishes.
+// cancelAndWait cancels a build, polls until it finishes, then waits for agents to release.
 func cancelAndWait(t *testing.T, buildID string) {
 	t.Helper()
 	_ = client.CancelBuild(buildID, "test cleanup")
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Until(deadline) > 0 {
 		b, err := client.GetBuild(t.Context(), buildID)
-		if err != nil || b.State == "finished" {
-			return
+		if err != nil {
+			break
+		}
+		if b.State == "finished" {
+			break
 		}
 		_ = client.CancelBuild(buildID, "test cleanup")
 		time.Sleep(time.Second)
 	}
-	t.Logf("cancelAndWait: build %s did not finish within 60s", buildID)
+	waitForAgentsReleased(t)
+}
+
+// waitForAgentsReleased blocks until every authorized+connected agent reports .Build == nil.
+func waitForAgentsReleased(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Until(deadline) > 0 {
+		agents, err := client.GetAgents(api.AgentsOptions{
+			Authorized: true, Connected: true, Enabled: true, Limit: 10,
+		})
+		if err != nil || len(agents.Agents) == 0 {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		busy := false
+		for _, a := range agents.Agents {
+			detail, err := client.GetAgent(a.ID)
+			if err != nil || detail.Build != nil {
+				busy = true
+				break
+			}
+		}
+		if !busy {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Logf("waitForAgentsReleased: agents did not release within 3m")
 }
 
 func TestMain(m *testing.M) {
@@ -811,18 +842,13 @@ teamcity auth status
 		require.NoError(T, err)
 	}
 
-	// Retry up to 3 times — the testcontainers agent can transiently reject builds
-	// with "Could not connect to build agent" or "Agent runs unknown build" when it's
-	// still cleaning up from a prior test.
+	// Retry on transient agent-handoff failures (surfacing as canceled-in-log or stuck queue).
 	var buildLog string
 	var build *api.Build
+	var waitErr error
 	for attempt := range 3 {
 		if attempt > 0 {
-			T.Logf("Retrying (attempt %d): rebooting agent and waiting for idle...", attempt+1)
-			agents, _ := client.GetAgents(api.AgentsOptions{Authorized: true, Connected: true, Limit: 1})
-			if len(agents.Agents) > 0 {
-				_ = client.RebootAgent(T.Context(), agents.Agents[0].ID, true)
-			}
+			T.Logf("Retrying (attempt %d)...", attempt+1)
 			requireIdleAgent(T)
 		}
 
@@ -833,9 +859,13 @@ teamcity auth status
 		T.Cleanup(func() { cancelAndWait(T, buildID) })
 
 		ctx, cancel := context.WithTimeout(T.Context(), 3*time.Minute)
-		build, err = client.WaitForBuild(ctx, buildID, api.WaitForBuildOptions{Interval: 3 * time.Second})
+		build, waitErr = client.WaitForBuild(ctx, buildID, api.WaitForBuildOptions{Interval: 3 * time.Second})
 		cancel()
-		require.NoError(T, err)
+		if waitErr != nil {
+			T.Logf("WaitForBuild: %v — will retry", waitErr)
+			_ = client.CancelBuild(buildID, "test retry")
+			continue
+		}
 
 		buildLog, err = client.GetBuildLog(T.Context(), buildID)
 		require.NoError(T, err)
@@ -849,6 +879,7 @@ teamcity auth status
 		}
 		break
 	}
+	require.NoError(T, waitErr)
 
 	assert.Contains(T, buildLog, "Build-level credentials", "CLI should use build-level auth")
 	assert.Equal(T, "SUCCESS", build.Status)


### PR DESCRIPTION
## Summary

Integration tests against testcontainers flake intermittently with three surface symptoms, all rooted in the test-to-test handoff on the single testcontainers agent:

- `no idle agent available within 2m` in tests that call `requireIdleAgent` (TestRemoveFromQueue, TestPoolOperations, TestBuildLevelAuth)
- `expected SUCCESS, actual UNKNOWN` in TestWaitForBuild_Integration (build canceled by server: re-queued after 60s agent non-response)
- `context deadline exceeded` in TestBuildLevelAuth (build stays queued for 3 min)

Root cause reproduced locally (1 fail + 1 near-miss in 10 random-shuffle runs): `cancelAndWait` returned as soon as `build.State == "finished"`, but the testcontainers agent's internal cleanup (temp dir, artifact publish, thread teardown) can linger for another 30–120 seconds. During that lag the agent reports `Connected: true, Build: nil` to the server — looks idle to `requireIdleAgent` — but is unresponsive to new build assignments, surfacing as `Could not connect to build agent` on the next queued build.

Validation: 14/14 runs clean post-fix (10 random shuffles + 4 CI-failing seeds replayed exactly).

## Changes

- `api/api_test.go` — `cancelAndWait` now ends by polling every authorized+connected agent until `.Build == nil` (new `waitForAgentsReleased` helper, 3-min budget). Moves the "agent is really idle" wait into the cleaning-up test instead of the next test's setup.
- `api/api_test.go` — `TestBuildLevelAuth` retry loop dropped the `RebootAgent(afterBuild=true)` call (ambiguous semantics, itself a flake source) and now also retries on `WaitForBuild` errors (including context deadline), not just build-log string patterns. Kept as a defensive backstop for the remaining server-side agent-stall case.
- `api/api_test.go` — Final `require.NoError(T, waitErr)` after the loop so a 3-attempt wash-out still fails loudly.

## Design Decisions

- The `.Build == nil` signal is imperfect — in ~1/14 runs the agent still stalls for ~60s on the next build assignment despite reporting idle. Two options considered: (a) force `RebootAgent` between every build test (adds ~60s to every run, deterministic), (b) rely on the existing TestBuildLevelAuth retry. Went with (b): retry path now works correctly, TestBuildLevelAuth occasionally takes ~170s but passes reliably, well inside the 15-min job budget.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint` — `go vet -tags=integration ./api/...` clean)
- [x] Integration tests: 10 random-shuffle runs, all pass (pre-fix: 1 fail + 1 near-miss in 10)
- [x] Integration tests: 4 CI-failing seeds replayed, all pass (pre-fix: all 4 failed with different symptoms)
- [ ] If adding a new command/flag: N/A — test-only change
- [ ] If adding a data-producing command: N/A
- [ ] If modifying \`--json\` output: N/A
- [ ] If changing docs-visible behavior: N/A