### PR TITLE
test(api): fall back to broad agent-release wait in testcontainers mode

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -89,10 +89,11 @@ func requireIdleAgent(t *testing.T) api.Agent {
 	return api.Agent{}
 }
 
-// cancelAndWait cancels a build, polls until it finishes, then waits for agents to release.
+// cancelAndWait cancels a build, polls until it finishes, then waits for its agent to release.
 func cancelAndWait(t *testing.T, buildID string) {
 	t.Helper()
 	_ = client.CancelBuild(buildID, "test cleanup")
+	var finished *api.Build
 	deadline := time.Now().Add(60 * time.Second)
 	for time.Until(deadline) > 0 {
 		b, err := client.GetBuild(t.Context(), buildID)
@@ -100,16 +101,35 @@ func cancelAndWait(t *testing.T, buildID string) {
 			break
 		}
 		if b.State == "finished" {
+			finished = b
 			break
 		}
 		_ = client.CancelBuild(buildID, "test cleanup")
 		time.Sleep(time.Second)
 	}
-	waitForAgentsReleased(t)
+	if finished != nil && finished.Agent != nil {
+		waitForAgentReleased(t, finished.Agent.ID)
+	} else if testEnvRef != nil && testEnvRef.ownsContainers {
+		waitForOwnedAgentsReleased(t)
+	}
 }
 
-// waitForAgentsReleased blocks until every authorized+connected agent reports .Build == nil.
-func waitForAgentsReleased(t *testing.T) {
+// waitForAgentReleased blocks until the given agent reports .Build == nil.
+func waitForAgentReleased(t *testing.T, agentID int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Until(deadline) > 0 {
+		detail, err := client.GetAgent(agentID)
+		if err == nil && detail.Build == nil {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Logf("waitForAgentReleased: agent %d did not release within 3m", agentID)
+}
+
+// waitForOwnedAgentsReleased blocks until every agent reports .Build == nil; testcontainers-only.
+func waitForOwnedAgentsReleased(t *testing.T) {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Minute)
 	for time.Until(deadline) > 0 {
@@ -133,7 +153,7 @@ func waitForAgentsReleased(t *testing.T) {
 		}
 		time.Sleep(2 * time.Second)
 	}
-	t.Logf("waitForAgentsReleased: agents did not release within 3m")
+	t.Logf("waitForOwnedAgentsReleased: agents did not release within 3m")
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Summary

Follow-up to #269. The scoped `waitForAgentReleased(finished.Agent.ID)` introduced there was correct for builds that actually got assigned to an agent, but a build canceled *while still queued* has `finished.Agent == nil` — in that case we skipped the wait entirely, letting the cleanup tail from an earlier build bleed into the next test.

Observed: 2 flakes in 8 runs (TestQueueOperations `no idle agent within 2m`; TestWaitForBuild_Integration `status=UNKNOWN` after the build ran to 100%) introduced by the scope change.

## Changes

- `api/api_test.go` — In `cancelAndWait`, when the cleaned-up build never got an agent (`finished.Agent == nil`) and we own the testcontainers (`testEnvRef.ownsContainers == true`), fall back to `waitForOwnedAgentsReleased`, which polls every authorized+connected agent until `.Build == nil` or the 3-minute deadline hits.
- External-shared-server mode (non-owned agents) still skips the broad wait — honors the original concern that we shouldn't block on unrelated workloads on a shared TeamCity.

## Design Decisions

- Split by `testEnvRef.ownsContainers` rather than unconditional broad wait: on a shared TC (e.g., `TEAMCITY_URL`/`TEAMCITY_TOKEN` pointed at cli.teamcity.com), iterating every connected agent would stall cleanup on unrelated running builds. In testcontainers the agents are all ours, so broad wait is safe and matches the behavior that was validated 10/10 before the scope refactor.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`go vet -tags=integration ./api/...` clean)
- [x] Integration tests: 10 random-shuffle runs, 10/10 pass (previous scope-only version: 2 failures in 8 runs)
- [ ] If adding a new command/flag: N/A — test-only change
- [ ] If adding a data-producing command: N/A
- [ ] If modifying \`--json\` output: N/A
- [ ] If changing docs-visible behavior: N/A