### PR TITLE
fix(output): handle pager early-quit without re-dumping the buffer

### DIFF
--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -83,11 +83,24 @@ func WithPager(out io.Writer, fn func(w io.Writer)) {
 		return
 	}
 
-	data := buf.Bytes()
-	pager.Stdin = bytes.NewReader(data)
+	stdin, err := pager.StdinPipe()
+	if err != nil {
+		_, _ = out.Write(buf.Bytes())
+		return
+	}
 	pager.Stdout = os.Stdout // must be a real terminal fd; using `out` here breaks pager rendering
 	pager.Stderr = os.Stderr
-	if err := pager.Run(); err != nil {
-		_, _ = out.Write(data)
+
+	if err := pager.Start(); err != nil {
+		_, _ = out.Write(buf.Bytes())
+		return
+	}
+
+	// Ignore copy errors: an early pager quit closes the pipe (EPIPE); Wait's exit code is authoritative.
+	_, _ = io.Copy(stdin, bytes.NewReader(buf.Bytes()))
+	_ = stdin.Close()
+	// Non-zero exit → misconfigured pager (bad flag, missing argv); fall back so the user isn't left with a blank terminal. `q` exits 0 on less/more/bat, so normal quits don't land here.
+	if err := pager.Wait(); err != nil {
+		_, _ = out.Write(buf.Bytes())
 	}
 }

--- a/internal/output/terminal_test.go
+++ b/internal/output/terminal_test.go
@@ -185,3 +185,30 @@ func TestWithPagerLessError(T *testing.T) {
 	assert.Contains(T, buf.String(), "line 0")
 	assert.Contains(T, buf.String(), "line 19")
 }
+
+// TestWithPagerEarlyQuit guards against re-dump when the pager exits 0 before draining stdin (e.g. user `q` in less → EPIPE on copy, Wait still nil).
+func TestWithPagerEarlyQuit(T *testing.T) {
+	overrideTerminal(T, true, 80, 5, nil)
+
+	oldPager := pagerCmdFn
+	T.Cleanup(func() { pagerCmdFn = oldPager })
+	pagerCmdFn = func() (*exec.Cmd, error) {
+		// head reads the first 10 bytes, exits 0, closes stdin — the remaining copy EPIPEs.
+		return exec.Command("head", "-c", "10"), nil
+	}
+
+	var lines []string
+	for i := range 200 {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	content := strings.Join(lines, "\n") + "\n"
+
+	var buf bytes.Buffer
+	captureStdout(T, func() {
+		WithPager(&buf, func(w io.Writer) {
+			fmt.Fprint(w, content)
+		})
+	})
+	// No fallback: buf stays empty because the pager exited 0.
+	assert.Empty(T, buf.String())
+}


### PR DESCRIPTION
## Summary

The old `WithPager` re-painted the entire buffer on top of the pager's released screen when the user quit the pager early (e.g. `q` in `less` before the buffer drained). `exec.Cmd.Run` surfaces the stdin-copy error (EPIPE) even when the process exited 0, and the fallback branch didn't distinguish "copy got EPIPE because pager quit" from "pager actually failed."

Rewrite the tail of `WithPager` to `StdinPipe` + explicit `Start` / `io.Copy` / `Wait`. Ignore copy errors and trust `Wait`'s exit code. A genuinely misconfigured pager (bad flag, missing argv, non-zero exit) still falls back to the writer so the user never ends up staring at a blank terminal.

## Changes

**output**

- `internal/output/terminal.go` — `WithPager` uses `StdinPipe` + `Start` + `io.Copy` + `Wait`. Copy errors are ignored; fallback fires only on pre-`Start` failure or non-zero `Wait`.

**tests**

- `internal/output/terminal_test.go` — `TestWithPagerEarlyQuit` guards the regression: pager (simulated with `head -c 10`) drains the first 10 bytes and exits 0 while the rest of the buffer EPIPEs on copy. The out-writer must stay empty (no re-dump).

## Design Decisions

- **No list-command paging.** Dropped from this PR. `run log` / `run diff` keep their existing auto-paging behavior (unchanged contract, unchanged env var handling via `PAGER`).
- **Fall back only on `Wait` non-zero.** `q` exits 0 on less/more/bat/most, so normal quits don't re-dump. A misconfigured pager exits non-zero before painting anything, and the fallback is what saves the user from a blank screen.
- **No new env vars or config keys.** `PAGER` still works for the existing long-form pager path; nothing else is needed.

## Example

Before this fix, pressing `q` in `less` while viewing a large `run log` could dump the entire log on top of the terminal after the pager exited. After the fix the screen stays clean.

```bash
teamcity run log 123456
# scroll a bit, then press q → terminal returns cleanly, no re-dump
```

## Test Plan

- [x] Unit tests pass (`just unit`) — green locally.
- [x] Linter passes (`just lint`) — `0 issues.`
- [ ] Acceptance tests pass (`just acceptance`) — not run locally; paging requires a TTY that `testscript` doesn't provide. No acceptance script touches this path.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A.
- [ ] If adding a data-producing command: includes `--json` support — N/A.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A.
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A (no user-visible behavior change; a pre-existing bug is fixed).