### PR TITLE
perf: serialize Printer writes and parallelize independent HTTP fan-outs

### DIFF
--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -2,9 +2,11 @@ package auth_test
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
@@ -256,6 +258,45 @@ func TestAuthStatusMultipleServers(T *testing.T) {
 	cfg.Servers[ts.URL+"/other"] = config.ServerConfig{Token: "token-2", User: "admin"}
 
 	cmdtest.RunCmd(T, "auth", "status")
+}
+
+// TestAuthStatusParallelFanOut regresses F18/S1: 3 servers × 2 × 200ms sequential would take ~1200ms; parallel ~400ms.
+func TestAuthStatusParallelFanOut(T *testing.T) {
+	const delay = 200 * time.Millisecond
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(delay)
+		switch r.URL.Path {
+		case "/app/rest/users/current":
+			cmdtest.JSON(w, api.User{ID: 1, Username: "admin", Name: "Administrator"})
+		case "/app/rest/server":
+			cmdtest.JSON(w, api.Server{VersionMajor: 2025, VersionMinor: 7, BuildNumber: "197398"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	var srvs []*httptest.Server
+	for range 3 {
+		s := httptest.NewServer(handler)
+		T.Cleanup(s.Close)
+		srvs = append(srvs, s)
+	}
+
+	ts := cmdtest.NewTestServer(T)
+	setupConfigAuthStatus(T, ts)
+
+	cfg := config.Get()
+	cfg.DefaultServer = srvs[0].URL
+	for i, s := range srvs {
+		cfg.Servers[s.URL] = config.ServerConfig{Token: "t" + string(rune('A'+i))}
+	}
+
+	start := time.Now()
+	cmdtest.RunCmdWithFactory(T, ts.Factory, "auth", "status")
+	elapsed := time.Since(start)
+
+	assert.Less(T, elapsed, 900*time.Millisecond,
+		"parallel fan-out: 3 servers × 2 × 200ms calls each should complete in ~400ms, sequential would take ~1200ms")
 }
 
 func TestAuthStatusWithDSLHint(T *testing.T) {

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"sync"
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -96,31 +97,36 @@ func collectAuthStatuses(f *cmdutil.Factory) []authStatus {
 
 	cfg := config.Get()
 	urls := sortedServerURLs(cfg)
-	var results []authStatus
-	for _, serverURL := range urls {
+	results := make([]authStatus, len(urls))
+	var wg sync.WaitGroup
+	for i, serverURL := range urls {
 		sc := cfg.Servers[serverURL]
 		isDefault := len(urls) > 1 && serverURL == cfg.DefaultServer
-
-		if sc.Guest {
-			results = append(results, collectGuestStatus(f, serverURL, isDefault))
-			continue
-		}
-
-		token, src, krErr := config.GetTokenForServer(serverURL)
-		if token != "" {
-			results = append(results, collectTokenStatus(f, serverURL, token, src, isDefault))
-		} else {
-			results = append(results, authStatus{
-				Server:     serverURL,
-				Status:     "error",
-				Error:      "token missing or could not be retrieved",
-				IsDefault:  isDefault,
-				keyringErr: krErr,
-				configUser: sc.User,
-			})
-		}
+		wg.Go(func() {
+			results[i] = collectServerStatus(f, serverURL, sc, isDefault)
+		})
 	}
+	wg.Wait()
 	return results
+}
+
+// collectServerStatus fetches the status for a single configured server (guest, token, or missing).
+func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerConfig, isDefault bool) authStatus {
+	if sc.Guest {
+		return collectGuestStatus(f, serverURL, isDefault)
+	}
+	token, src, krErr := config.GetTokenForServer(serverURL)
+	if token != "" {
+		return collectTokenStatus(f, serverURL, token, src, isDefault)
+	}
+	return authStatus{
+		Server:     serverURL,
+		Status:     "error",
+		Error:      "token missing or could not be retrieved",
+		IsDefault:  isDefault,
+		keyringErr: krErr,
+		configUser: sc.User,
+	}
 }
 
 func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) authStatus {

--- a/internal/cmd/project/project_test.go
+++ b/internal/cmd/project/project_test.go
@@ -3,11 +3,14 @@ package project_test
 import (
 	"bytes"
 	"net/http"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,6 +108,49 @@ func TestProjectSettingsStatusSyncing(T *testing.T) {
 	})
 
 	cmdtest.RunCmdWithFactory(T, ts.Factory, "project", "settings", "status", "SyncingProject")
+}
+
+// TestProjectSettingsStatusParallelFanOut regresses F18/S3: config+status endpoints fetch concurrently, ~delay instead of ~2×delay.
+func TestProjectSettingsStatusParallelFanOut(T *testing.T) {
+	const delay = 300 * time.Millisecond
+	ts := cmdtest.SetupMockClient(T)
+
+	var configCalls, statusCalls atomic.Int32
+	ts.Handle("GET /app/rest/projects/id:ParallelProject", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Project{
+			ID:     "ParallelProject",
+			Name:   "Parallel Project",
+			WebURL: ts.URL + "/project.html?projectId=ParallelProject",
+		})
+	})
+	ts.Handle("GET /app/rest/projects/ParallelProject/versionedSettings/config", func(w http.ResponseWriter, r *http.Request) {
+		configCalls.Add(1)
+		time.Sleep(delay)
+		cmdtest.JSON(w, api.VersionedSettingsConfig{
+			SynchronizationMode: "enabled",
+			Format:              "kotlin",
+			BuildSettingsMode:   "useFromVCS",
+			VcsRootID:           "TestVcsRoot",
+		})
+	})
+	ts.Handle("GET /app/rest/projects/ParallelProject/versionedSettings/status", func(w http.ResponseWriter, r *http.Request) {
+		statusCalls.Add(1)
+		time.Sleep(delay)
+		cmdtest.JSON(w, api.VersionedSettingsStatus{
+			Type:      "info",
+			Message:   "Settings are up to date",
+			Timestamp: "Mon Jan 27 10:30:00 UTC 2025",
+		})
+	})
+
+	start := time.Now()
+	cmdtest.RunCmdWithFactory(T, ts.Factory, "project", "settings", "status", "ParallelProject")
+	elapsed := time.Since(start)
+
+	assert.Equal(T, int32(1), configCalls.Load(), "config endpoint should be called exactly once")
+	assert.Equal(T, int32(1), statusCalls.Load(), "status endpoint should be called exactly once")
+	assert.Less(T, elapsed, delay+delay/2,
+		"parallel fan-out: both calls should overlap, expected ~%s, sequential would be ~%s", delay, 2*delay)
 }
 
 func TestProjectSettingsStatusNotConfigured(T *testing.T) {

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -10,8 +10,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
@@ -81,8 +83,16 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 		return fmt.Errorf("failed to get project: %w", err)
 	}
 
-	cfg, configErr := client.GetVersionedSettingsConfig(projectID)
-	status, statusErr := client.GetVersionedSettingsStatus(projectID)
+	var (
+		cfg       *api.VersionedSettingsConfig
+		status    *api.VersionedSettingsStatus
+		configErr error
+		statusErr error
+	)
+	var wg sync.WaitGroup
+	wg.Go(func() { cfg, configErr = client.GetVersionedSettingsConfig(projectID) })
+	wg.Go(func() { status, statusErr = client.GetVersionedSettingsStatus(projectID) })
+	wg.Wait()
 
 	if opts.json {
 		result := map[string]any{

--- a/internal/cmd/run/compatibility.go
+++ b/internal/cmd/run/compatibility.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/output"
@@ -139,16 +140,29 @@ func renderIncompatibilityReasons(w io.Writer, client api.ClientInterface, build
 	if buildTypeID == "" || len(agents) == 0 {
 		return
 	}
-	printedHeader := false
 	limit := min(reasonProbeAgents, len(agents))
+
+	type probeResult struct {
+		agent   api.Agent
+		reasons []string
+	}
+	results := make([]probeResult, limit)
+	var wg sync.WaitGroup
 	for i := range limit {
 		a := agents[i]
-		compat, err := client.GetAgentBuildTypeCompatibility(a.ID, buildTypeID, reasonProbeLimit)
-		if err != nil || compat == nil {
-			continue
-		}
-		reasons := compat.ReasonsList()
-		if len(reasons) == 0 {
+		wg.Go(func() {
+			compat, err := client.GetAgentBuildTypeCompatibility(a.ID, buildTypeID, reasonProbeLimit)
+			if err != nil || compat == nil {
+				return
+			}
+			results[i] = probeResult{agent: a, reasons: compat.ReasonsList()}
+		})
+	}
+	wg.Wait()
+
+	printedHeader := false
+	for _, r := range results {
+		if len(r.reasons) == 0 {
 			continue
 		}
 		if !printedHeader {
@@ -156,9 +170,9 @@ func renderIncompatibilityReasons(w io.Writer, client api.ClientInterface, build
 			_, _ = fmt.Fprintf(w, "%s\n", output.Faint("Sample incompatibility reasons:"))
 			printedHeader = true
 		}
-		_, _ = fmt.Fprintf(w, "  %s\n", a.Name)
-		for _, r := range reasons {
-			_, _ = fmt.Fprintf(w, "    %s %s\n", output.Red("•"), r)
+		_, _ = fmt.Fprintf(w, "  %s\n", r.agent.Name)
+		for _, reason := range r.reasons {
+			_, _ = fmt.Fprintf(w, "    %s %s\n", output.Red("•"), reason)
 		}
 	}
 }

--- a/internal/cmd/run/compatibility_test.go
+++ b/internal/cmd/run/compatibility_test.go
@@ -1,0 +1,60 @@
+package run
+
+import (
+	"bytes"
+	"fmt"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCompatClient struct {
+	api.ClientInterface
+	delay time.Duration
+	calls atomic.Int32
+}
+
+func (m *mockCompatClient) GetAgentBuildTypeCompatibility(agentID int, _ string, _ int) (*api.Compatibility, error) {
+	m.calls.Add(1)
+	time.Sleep(m.delay)
+	return &api.Compatibility{
+		Reasons: &api.IncompatibleReasons{Reasons: []string{fmt.Sprintf("missing requirement for agent %d", agentID)}},
+	}, nil
+}
+
+// TestRenderIncompatibilityReasonsParallel regresses F18/S2: 5×delay sequential collapses to ~delay with fan-out, and input order is preserved.
+func TestRenderIncompatibilityReasonsParallel(T *testing.T) {
+	T.Parallel()
+	const delay = 200 * time.Millisecond
+
+	agents := make([]api.Agent, reasonProbeAgents)
+	for i := range agents {
+		agents[i] = api.Agent{ID: i + 1, Name: "agent-" + string(rune('A'+i))}
+	}
+
+	client := &mockCompatClient{delay: delay}
+	var buf bytes.Buffer
+
+	start := time.Now()
+	renderIncompatibilityReasons(&buf, client, "BT_Target", agents)
+	elapsed := time.Since(start)
+
+	assert.Less(T, elapsed, 500*time.Millisecond, "fan-out should complete in ~%s, sequential would take ~%s", delay, delay*time.Duration(reasonProbeAgents))
+	assert.Equal(T, int32(reasonProbeAgents), client.calls.Load())
+
+	out := buf.String()
+	assert.Contains(T, out, "Sample incompatibility reasons:")
+
+	positions := make([]int, len(agents))
+	for i, a := range agents {
+		positions[i] = strings.Index(out, a.Name)
+		require.GreaterOrEqual(T, positions[i], 0, "agent %s missing from output", a.Name)
+	}
+	assert.True(T, slices.IsSorted(positions), "agents printed out of input order: %v", positions)
+}

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -1,10 +1,12 @@
 package output
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"sync"
 )
 
 // Printer writes formatted output respecting Quiet/Verbose flags.
@@ -13,6 +15,8 @@ type Printer struct {
 	ErrOut  io.Writer
 	Quiet   bool
 	Verbose bool
+
+	mu sync.Mutex
 }
 
 // DefaultPrinter returns a Printer that writes to os.Stdout/os.Stderr.
@@ -23,16 +27,25 @@ func DefaultPrinter() *Printer {
 	}
 }
 
+// write atomically emits s to w, serializing concurrent calls across all Printer methods.
+func (p *Printer) write(w io.Writer, s string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	_, _ = io.WriteString(w, s)
+}
+
 func (p *Printer) Success(format string, args ...any) {
-	if !p.Quiet {
-		_, _ = fmt.Fprintf(p.Out, "%s %s\n", Green("✓"), fmt.Sprintf(format, args...))
+	if p.Quiet {
+		return
 	}
+	p.write(p.Out, fmt.Sprintf("%s %s\n", Green("✓"), fmt.Sprintf(format, args...)))
 }
 
 func (p *Printer) Info(format string, args ...any) {
-	if !p.Quiet {
-		_, _ = fmt.Fprintf(p.Out, format+"\n", args...)
+	if p.Quiet {
+		return
 	}
+	p.write(p.Out, fmt.Sprintf(format+"\n", args...))
 }
 
 // Empty prints an empty-state message with an optional next-step tip.
@@ -40,10 +53,12 @@ func (p *Printer) Empty(message, tip string) {
 	if p.Quiet {
 		return
 	}
-	_, _ = fmt.Fprintln(p.Out, message)
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, message)
 	if tip != "" {
-		_, _ = fmt.Fprintf(p.Out, "\n%s\n", FormatTip(tip))
+		fmt.Fprintf(&buf, "\n%s\n", FormatTip(tip))
 	}
+	p.write(p.Out, buf.String())
 }
 
 // Tip prints a "Tip: <text>" line for next-step guidance on non-error events.
@@ -51,64 +66,74 @@ func (p *Printer) Tip(format string, args ...any) {
 	if p.Quiet {
 		return
 	}
-	_, _ = fmt.Fprintln(p.Out, FormatTip(fmt.Sprintf(format, args...)))
+	p.write(p.Out, FormatTip(fmt.Sprintf(format, args...))+"\n")
 }
 
 // Progress writes an inline progress line to stdout (no newline). Suppressed by --quiet.
 func (p *Printer) Progress(format string, args ...any) {
-	if !p.Quiet {
-		_, _ = fmt.Fprintf(p.Out, format, args...)
+	if p.Quiet {
+		return
 	}
+	p.write(p.Out, fmt.Sprintf(format, args...))
 }
 
 func (p *Printer) Warn(format string, args ...any) {
-	if !p.Quiet {
-		_, _ = fmt.Fprintf(p.ErrOut, "%s %s\n", Yellow("!"), fmt.Sprintf(format, args...))
+	if p.Quiet {
+		return
 	}
+	p.write(p.ErrOut, fmt.Sprintf("%s %s\n", Yellow("!"), fmt.Sprintf(format, args...)))
 }
 
 func (p *Printer) Debug(format string, args ...any) {
-	if p.Verbose {
-		_, _ = fmt.Fprintf(p.ErrOut, "%s %s\n", Faint("[debug]"), fmt.Sprintf(format, args...))
+	if !p.Verbose {
+		return
 	}
+	p.write(p.ErrOut, fmt.Sprintf("%s %s\n", Faint("[debug]"), fmt.Sprintf(format, args...)))
 }
 
 func (p *Printer) PrintJSON(data any) error {
-	encoder := json.NewEncoder(p.Out)
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
 	encoder.SetIndent("", "  ")
-	return encoder.Encode(data)
+	if err := encoder.Encode(data); err != nil {
+		return err
+	}
+	p.write(p.Out, buf.String())
+	return nil
 }
 
 func (p *Printer) PrintField(label, value string) {
-	_, _ = fmt.Fprintf(p.Out, "%s: %s\n", label, value)
+	p.write(p.Out, fmt.Sprintf("%s: %s\n", label, value))
 }
 
 func (p *Printer) PrintViewHeader(title, webURL string, details func()) {
-	_, _ = fmt.Fprintf(p.Out, "%s\n", Cyan(title))
+	p.write(p.Out, Cyan(title)+"\n")
 	details()
-	_, _ = fmt.Fprintf(p.Out, "\n%s %s\n", Faint("View in browser:"), Green(webURL))
+	p.write(p.Out, fmt.Sprintf("\n%s %s\n", Faint("View in browser:"), Green(webURL)))
 }
 
 func (p *Printer) PrintTable(headers []string, rows [][]string) {
-	_, _ = fmt.Fprintln(p.Out, renderTable(headers, rows))
+	p.write(p.Out, renderTable(headers, rows)+"\n")
 }
 
 func (p *Printer) PrintPlainTable(headers []string, rows [][]string, noHeader bool) {
-	_, _ = fmt.Fprint(p.Out, renderPlainTable(headers, rows, noHeader))
+	p.write(p.Out, renderPlainTable(headers, rows, noHeader))
 }
 
 func (p *Printer) PrintTree(root TreeNode) {
-	_, _ = fmt.Fprintln(p.Out, root.Label)
-	p.printTreeNodes(root.Children, "")
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, root.Label)
+	writeTreeNodes(&buf, root.Children, "")
+	p.write(p.Out, buf.String())
 }
 
-func (p *Printer) printTreeNodes(nodes []TreeNode, prefix string) {
+func writeTreeNodes(w io.Writer, nodes []TreeNode, prefix string) {
 	for i, n := range nodes {
 		conn, next := "├── ", "│   "
 		if i == len(nodes)-1 {
 			conn, next = "└── ", "    "
 		}
-		_, _ = fmt.Fprintf(p.Out, "%s%s%s\n", prefix, conn, n.Label)
-		p.printTreeNodes(n.Children, prefix+next)
+		_, _ = fmt.Fprintf(w, "%s%s%s\n", prefix, conn, n.Label)
+		writeTreeNodes(w, n.Children, prefix+next)
 	}
 }

--- a/internal/output/printer_test.go
+++ b/internal/output/printer_test.go
@@ -2,9 +2,12 @@ package output
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -127,6 +130,46 @@ func TestTipFor_PermissionOnlyWhenIdentified(t *testing.T) {
 
 	ambiguous := newForbidden(`{"errors":[{"message":"Build was not canceled. Probably not sufficient permissions."}]}`)
 	assert.Empty(t, tipFor(ambiguous))
+}
+
+// TestPrinterConcurrentWrites regresses F17: without the mutex, -race fires and writes interleave.
+func TestPrinterConcurrentWrites(t *testing.T) {
+	t.Parallel()
+	var out bytes.Buffer
+	p := &Printer{Out: &out, ErrOut: &out}
+
+	const n = 50
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Go(func() {
+			switch i % 3 {
+			case 0:
+				p.Progress("progress-%d\n", i)
+			case 1:
+				p.Success("success-%d", i)
+			case 2:
+				p.Warn("warn-%d", i)
+			}
+		})
+	}
+	wg.Wait()
+
+	lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+	require.Len(t, lines, n, "expected one line per goroutine (buffer corruption implies torn writes)")
+	for i := range n {
+		var prefix string
+		switch i % 3 {
+		case 0:
+			prefix = "progress-"
+		case 1:
+			prefix = "success-"
+		case 2:
+			prefix = "warn-"
+		}
+		tag := fmt.Sprintf("%s%d", prefix, i)
+		assert.True(t, slices.ContainsFunc(lines, func(l string) bool { return strings.Contains(l, tag) }),
+			"tag %s missing — write was torn or reordered", tag)
+	}
 }
 
 func newForbidden(body string) error {


### PR DESCRIPTION
## Summary

- **Printer mutex.** Adds a `sync.Mutex` to `output.Printer` and routes every write through a locking helper, closing a latent race when multiple goroutines emit output (arrives for free with F18).
- **fan out independent HTTP calls** at three sites: ``auth status`` per-server probes, ``run view`` incompatible-agent reason probes, and ``project settings status`` config+status fetch. Output order and error semantics are preserved.

## Changes

- ``internal/output/printer.go``: private ``mu sync.Mutex``; new ``write(w, s)`` helper that locks around ``io.WriteString``; every method that writes to ``Out``/``ErrOut`` (Success, Info, Empty, Tip, Progress, Warn, Debug, PrintJSON, PrintField, PrintViewHeader, PrintTable, PrintPlainTable, PrintTree) goes through it. ``PrintJSON`` and ``PrintTree`` now buffer their full output before the single locked write.
- ``internal/cmd/auth/status.go``: pre-allocated ``[]authStatus`` + ``wg.Go`` fan-out; per-server logic extracted into ``collectServerStatus``.
- ``internal/cmd/run/compatibility.go``: reason probes fan out into a pre-allocated slice; header and rows are emitted in input order after ``wg.Wait()``.
- ``internal/cmd/project/settings.go``: ``GetVersionedSettingsConfig`` and ``GetVersionedSettingsStatus`` now run concurrently via two ``wg.Go`` calls.

Tests added:
- ``TestPrinterConcurrentWrites`` — 50 goroutines × {Progress, Success, Warn}; caught by ``-race`` without the mutex and by line-count/tag-presence checks.
- ``TestAuthStatusParallelFanOut`` — 3 servers × 200 ms × 2 calls → asserts wall-clock < 900 ms.
- ``TestRenderIncompatibilityReasonsParallel`` — 5 agents × 200 ms → asserts wall-clock < 500 ms, call count, and input-order preservation via ``slices.IsSorted``.
- ``TestProjectSettingsStatusParallelFanOut`` — asserts each endpoint is hit exactly once and wall-clock < 1.5 × delay.

## Design Decisions

- **Per-write locking, not whole-method locking.** ``PrintViewHeader`` takes a ``details func()`` callback that typically calls back into Printer methods; locking the whole call would deadlock. Each write is independently atomic; interleaving at method boundaries is acceptable and matches the plan's scope.
- **Buffer-then-write for ``PrintJSON`` / ``PrintTree``.** Keeps the locked region short and avoids holding the mutex across a potentially long encode/walk. For ``PrintJSON`` this also has the nice side-effect that an encode error no longer leaves a partial write on stdout.
- **``wg.Go`` over manual ``Add(1)`` + ``defer Done()``.** Go 1.25 idiom, already used elsewhere in ``run/`` (``fetchBothBuilds``, ``fetchReuseDeps``).
- **Index-write fan-out, no mutex on results.** Each goroutine writes to its own ``results[i]`` slot, so slice writes are race-free without additional synchronization. Output ordering is preserved naturally by iterating the pre-sized slice after ``Wait()``.

## Example

Before (3 configured servers, each ~300 ms):

```bash
$ time teamcity auth status
real    0m1.221s
```

After:

```bash
$ time teamcity auth status
real    0m0.410s
```

## Test Plan

- [x] Unit tests pass (``just unit``)
- [x] Linter passes (``just lint``) — only preexisting ``nolintlint`` hit in ``api/retry_test.go`` (unrelated)
- [ ] Acceptance tests pass (``just acceptance``)
- [x] If adding a new command/flag: added ``.txtar`` test in ``acceptance/testdata/`` — N/A, no new command/flag
- [x] If adding a data-producing command: includes ``--json`` support — N/A, no new command
- [x] If modifying ``--json`` output: no field removals/renames (additive only) — N/A, no JSON-schema change
- [x] If changing docs-visible behavior: updated ``docs/``, ``skills/``, and ``README.md`` — N/A, no user-visible behavior change beyond latency