### PR TITLE
feat(ctx): honor Ctrl+C across all HTTP requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,15 @@ All output through `*output.Printer`. Never `fmt.Printf` in commands.
 
 Error strings: lowercase, no trailing punctuation. Wrap with `%w`, not bare `return err`.
 
+### Context
+
+Every HTTP request participates in the signal-cancel ctx wired up in `tc/main.go` so Ctrl+C aborts in-flight calls cleanly.
+
+- **`f.Context()`** everywhere in `internal/cmd/` and `internal/cmdutil/` — not `cmd.Context()`, not `context.Background()`.
+- `api/` methods without a `ctx` param use the Client's bound ctx (set by `f.Client()` via `.WithContext(f.Context())`) — nothing to thread at the call site.
+- New Client constructors in `api/` must chain `.WithContext(...)` before returning, or the caller loses cancellation.
+- `context.Background()` is reserved for `tc/main.go` (signal-handler parent) and lifecycle-bounded internals (HTTP server `Shutdown`, etc.). Tests use `t.Context()`.
+
 ### Comments
 
 One-line doc comments on funcs. No multi-line restate-the-code text. Inline comments only for non-obvious things (magic numbers, OS quirks, why-not-the-obvious-approach).

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -218,11 +219,12 @@ func runScripts(t *testing.T, dir, host, token, scriptFilter string) {
 // customCommands returns the custom testscript commands available in test scripts.
 func customCommands() map[string]func(ts *testscript.TestScript, neg bool, args []string) {
 	return map[string]func(ts *testscript.TestScript, neg bool, args []string){
-		"stdout2env":     cmdStdout2Env,
-		"env2upper":      cmdEnv2Upper,
-		"sleep":          cmdSleep,
-		"extract":        cmdExtract,
-		"wait_for_agent": cmdWaitForAgent,
+		"stdout2env":       cmdStdout2Env,
+		"env2upper":        cmdEnv2Upper,
+		"sleep":            cmdSleep,
+		"extract":          cmdExtract,
+		"wait_for_agent":   cmdWaitForAgent,
+		"start_hangserver": cmdStartHangServer,
 	}
 }
 
@@ -274,6 +276,22 @@ func cmdEnv2Upper(ts *testscript.TestScript, neg bool, args []string) {
 		ts.Fatalf("usage: env2upper <VAR_NAME>")
 	}
 	ts.Setenv(args[0], strings.ToUpper(ts.Getenv(args[0])))
+}
+
+// cmdStartHangServer starts an in-process HTTP server that never responds and exposes its URL as $HANG_URL; used to exercise client-side cancellation.
+// Usage: start_hangserver
+func cmdStartHangServer(ts *testscript.TestScript, neg bool, args []string) {
+	if neg {
+		ts.Fatalf("start_hangserver does not support negation")
+	}
+	if len(args) != 0 {
+		ts.Fatalf("usage: start_hangserver")
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	ts.Defer(srv.Close)
+	ts.Setenv("HANG_URL", srv.URL)
 }
 
 // cmdSleep pauses execution for the given duration.

--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -23,6 +23,7 @@
 package acceptance
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/hex"
@@ -32,9 +33,11 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -66,7 +69,9 @@ func teamcityMain() int {
 		fmt.Fprintf(os.Stderr, "Error initializing config: %v\n", err)
 		return 1
 	}
-	if err := cmd.Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	if err := cmd.Execute(ctx); err != nil {
 		if exitErr, ok := errors.AsType[*cmdutil.ExitError](err); ok {
 			return exitErr.Code
 		}

--- a/acceptance/testdata/api/api-signal-cancel.txtar
+++ b/acceptance/testdata/api/api-signal-cancel.txtar
@@ -1,0 +1,20 @@
+# Ctrl+C aborts in-flight HTTP requests and exits cleanly (no surfaced error).
+[windows] skip 'signal semantics differ on Windows'
+
+start_hangserver
+
+env TEAMCITY_URL=$HANG_URL
+env TEAMCITY_TOKEN=testtoken
+env TEAMCITY_GUEST=
+
+# Run a command that makes a single HTTP call; the hang server will block it.
+exec teamcity api /app/rest/server --no-input &cli&
+sleep 1s
+
+# Signal the CLI. Root-level context.Canceled suppression should produce exit 0.
+kill -INT cli
+wait cli
+
+# No error message should be surfaced to the user.
+! stderr 'Error:'
+! stdout 'context canceled'

--- a/api/agents.go
+++ b/api/agents.go
@@ -53,7 +53,7 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
 
 	agents, err := collectPages(c, path, opts.Limit, func(p string) ([]Agent, string, error) {
 		var page AgentList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Agents, page.NextHref, nil
@@ -72,7 +72,7 @@ func (c *Client) AuthorizeAgent(id int, authorized bool) error {
 	if authorized {
 		value = "true"
 	}
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(value), "text/plain")
+	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(value), "text/plain")
 }
 
 // agentDetailFields is the fields parameter used for agent detail requests
@@ -83,7 +83,7 @@ func (c *Client) GetAgent(id int) (*Agent, error) {
 	path := fmt.Sprintf("/app/rest/agents/id:%d?fields=%s", id, url.QueryEscape(agentDetailFields))
 
 	var result Agent
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -97,7 +97,7 @@ func (c *Client) GetAgentByName(name string) (*Agent, error) {
 	path := fmt.Sprintf("/app/rest/agents/name:%s?fields=%s", url.PathEscape(name), url.QueryEscape(agentDetailFields))
 
 	var result Agent
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -111,7 +111,7 @@ func (c *Client) EnableAgent(id int, enabled bool) error {
 	if enabled {
 		value = "true"
 	}
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(value), "text/plain")
+	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(value), "text/plain")
 }
 
 // GetAgentCompatibleBuildTypes returns build types compatible with an agent
@@ -120,7 +120,7 @@ func (c *Client) GetAgentCompatibleBuildTypes(id int) (*BuildTypeList, error) {
 	path := fmt.Sprintf("/app/rest/agents/id:%d/compatibleBuildTypes?fields=%s", id, url.QueryEscape(fields))
 
 	var result BuildTypeList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -133,7 +133,7 @@ func (c *Client) GetAgentIncompatibleBuildTypes(id int) (*CompatibilityList, err
 	path := fmt.Sprintf("/app/rest/agents/id:%d/incompatibleBuildTypes?fields=%s", id, url.QueryEscape(fields))
 
 	var result CompatibilityList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -148,7 +148,7 @@ func (c *Client) GetBuildCompatibleAgents(buildID int) (*AgentList, error) {
 	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(buildAgentsFields))
 
 	var result AgentList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -160,7 +160,7 @@ func (c *Client) GetBuildIncompatibleAgents(buildID int) (*AgentList, error) {
 	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(buildAgentsFields))
 
 	var result AgentList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -177,7 +177,7 @@ func (c *Client) GetAgentBuildTypeCompatibility(agentID int, buildTypeID string,
 		agentID, url.QueryEscape(locator), url.QueryEscape(fields))
 
 	var result CompatibilityList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	for i := range result.Compatibility {

--- a/api/builds.go
+++ b/api/builds.go
@@ -149,7 +149,7 @@ func (c *Client) GetBuildUsedByOtherBuilds(id string) (bool, error) {
 	var result struct {
 		UsedByOtherBuilds bool `json:"usedByOtherBuilds"`
 	}
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return false, err
 	}
 	return result.UsedByOtherBuilds, nil
@@ -357,7 +357,7 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 	}
 
 	var build Build
-	if err := c.post(context.Background(), "/app/rest/buildQueue", bytes.NewReader(body), &build); err != nil {
+	if err := c.post(c.ctx(), "/app/rest/buildQueue", bytes.NewReader(body), &build); err != nil {
 		return nil, err
 	}
 
@@ -366,12 +366,12 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 
 // CancelBuild cancels a running or queued build (accepts ID or #number)
 func (c *Client) CancelBuild(buildID string, comment string) error {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return err
 	}
 
-	build, err := c.GetBuild(context.Background(), id)
+	build, err := c.GetBuild(c.ctx(), id)
 	if err != nil {
 		return err
 	}
@@ -399,7 +399,7 @@ func (c *Client) CancelBuild(buildID string, comment string) error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	return c.doNoContent(context.Background(), "POST", path, bytes.NewReader(bodyBytes), "")
+	return c.doNoContent(c.ctx(), "POST", path, bytes.NewReader(bodyBytes), "")
 }
 
 // GetBuildSnapshotDependencies returns all immediate dependency builds in a snapshot dependency chain.
@@ -410,7 +410,7 @@ func (c *Client) GetBuildSnapshotDependencies(buildID string) (*BuildList, error
 
 	builds, err := collectPages(c, path, 0, func(p string) ([]Build, string, error) {
 		var page BuildList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Builds, page.NextHref, nil

--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -13,7 +13,7 @@ import (
 
 // PinBuild pins a build to prevent it from being cleaned up (accepts ID or #number)
 func (c *Client) PinBuild(buildID string, comment string) error {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return err
 	}
@@ -21,22 +21,22 @@ func (c *Client) PinBuild(buildID string, comment string) error {
 
 	body := cmp.Or(comment, "Pinned via teamcity CLI")
 
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(body), "text/plain")
+	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(body), "text/plain")
 }
 
 // UnpinBuild removes the pin from a build (accepts ID or #number)
 func (c *Client) UnpinBuild(buildID string) error {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return err
 	}
 	path := fmt.Sprintf("/app/rest/builds/id:%s/pin", id)
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 // AddBuildTags adds tags to a build (accepts ID or #number)
 func (c *Client) AddBuildTags(buildID string, tags []string) error {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (c *Client) AddBuildTags(buildID string, tags []string) error {
 		return fmt.Errorf("failed to marshal tags: %w", err)
 	}
 
-	resp, err := c.doRequest(context.Background(), "POST", path, bytes.NewReader(body))
+	resp, err := c.doRequest(c.ctx(), "POST", path, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -67,14 +67,14 @@ func (c *Client) AddBuildTags(buildID string, tags []string) error {
 
 // GetBuildTags returns the tags for a build (accepts ID or #number)
 func (c *Client) GetBuildTags(buildID string) (*TagList, error) {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return nil, err
 	}
 	path := fmt.Sprintf("/app/rest/builds/id:%s/tags", id)
 
 	var tags TagList
-	if err := c.get(context.Background(), path, &tags); err != nil {
+	if err := c.get(c.ctx(), path, &tags); err != nil {
 		return nil, err
 	}
 
@@ -83,7 +83,7 @@ func (c *Client) GetBuildTags(buildID string) (*TagList, error) {
 
 // RemoveBuildTag removes a specific tag from a build (accepts ID or #number)
 func (c *Client) RemoveBuildTag(buildID string, tag string) error {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return err
 	}
@@ -115,17 +115,17 @@ func (c *Client) RemoveBuildTag(buildID string, tag string) error {
 		return fmt.Errorf("failed to marshal tags: %w", err)
 	}
 
-	return c.doNoContent(context.Background(), "PUT", path, bytes.NewReader(body), "")
+	return c.doNoContent(c.ctx(), "PUT", path, bytes.NewReader(body), "")
 }
 
 // SetBuildComment sets or updates the comment on a build (accepts ID or #number)
 func (c *Client) SetBuildComment(buildID string, comment string) error {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return err
 	}
 	path := fmt.Sprintf("/app/rest/builds/id:%s/comment", id)
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(comment), "text/plain")
+	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(comment), "text/plain")
 }
 
 // buildWithComment is used to fetch just the comment from a build
@@ -135,14 +135,14 @@ type buildWithComment struct {
 
 // GetBuildComment returns the comment for a build (accepts ID or #number)
 func (c *Client) GetBuildComment(buildID string) (string, error) {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return "", err
 	}
 	path := fmt.Sprintf("/app/rest/builds/id:%s?fields=comment(text)", id)
 
 	var result buildWithComment
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return "", err
 	}
 
@@ -155,12 +155,12 @@ func (c *Client) GetBuildComment(buildID string) (string, error) {
 
 // DeleteBuildComment removes the comment from a build (accepts ID or #number)
 func (c *Client) DeleteBuildComment(buildID string) error {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return err
 	}
 	path := fmt.Sprintf("/app/rest/builds/id:%s/comment", id)
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 func (c *Client) GetBuildChanges(ctx context.Context, buildID string) (*ChangeList, error) {
@@ -184,7 +184,7 @@ func (c *Client) UploadDiffChanges(patch []byte, description string) (string, er
 	uploadURL := fmt.Sprintf("/uploadDiffChanges.html?description=%s&commitType=0",
 		url.QueryEscape(description))
 
-	resp, err := c.RawRequest(context.Background(), "POST", uploadURL, bytes.NewReader(patch), map[string]string{
+	resp, err := c.RawRequest(c.ctx(), "POST", uploadURL, bytes.NewReader(patch), map[string]string{
 		"Content-Type": "text/plain",
 		"Origin":       c.BaseURL,
 	})
@@ -238,7 +238,7 @@ func (c *Client) GetBuildTests(ctx context.Context, buildID string, failedOnly b
 }
 
 func (c *Client) GetBuildTestSummary(buildID string) (*TestOccurrences, error) {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return nil, err
 	}
@@ -248,14 +248,14 @@ func (c *Client) GetBuildTestSummary(buildID string) (*TestOccurrences, error) {
 	path := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(fields))
 
 	var summary TestOccurrences
-	if err := c.get(context.Background(), path, &summary); err != nil {
+	if err := c.get(c.ctx(), path, &summary); err != nil {
 		return nil, err
 	}
 	return &summary, nil
 }
 
 func (c *Client) GetBuildResultingProperties(buildID string) (*ParameterList, error) {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return nil, err
 	}
@@ -263,7 +263,7 @@ func (c *Client) GetBuildResultingProperties(buildID string) (*ParameterList, er
 	path := fmt.Sprintf("/app/rest/builds/id:%s/resulting-properties", id)
 
 	var params ParameterList
-	if err := c.get(context.Background(), path, &params); err != nil {
+	if err := c.get(c.ctx(), path, &params); err != nil {
 		return nil, err
 	}
 
@@ -271,7 +271,7 @@ func (c *Client) GetBuildResultingProperties(buildID string) (*ParameterList, er
 }
 
 func (c *Client) GetBuildProblems(buildID string) (*ProblemOccurrences, error) {
-	id, err := c.ResolveBuildID(context.Background(), buildID)
+	id, err := c.ResolveBuildID(c.ctx(), buildID)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func (c *Client) GetBuildProblems(buildID string) (*ProblemOccurrences, error) {
 	path := fmt.Sprintf("/app/rest/problemOccurrences?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(fields))
 
 	var problems ProblemOccurrences
-	if err := c.get(context.Background(), path, &problems); err != nil {
+	if err := c.get(c.ctx(), path, &problems); err != nil {
 		return nil, err
 	}
 

--- a/api/builds_queue.go
+++ b/api/builds_queue.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -36,7 +35,7 @@ func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
 
 	builds, err := collectPages(c, path, opts.Limit, func(p string) ([]QueuedBuild, string, error) {
 		var page BuildQueue
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Builds, page.NextHref, nil
@@ -50,13 +49,13 @@ func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
 // RemoveFromQueue removes a build from the queue
 func (c *Client) RemoveFromQueue(id string) error {
 	path := "/app/rest/buildQueue/id:" + id
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 // SetQueuedBuildPosition moves a queued build to a specific position in the queue
 func (c *Client) SetQueuedBuildPosition(buildID string, position int) error {
 	path := "/app/rest/buildQueue/order/" + buildID
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(strconv.Itoa(position)), "text/plain")
+	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(strconv.Itoa(position)), "text/plain")
 }
 
 // MoveQueuedBuildToTop moves a queued build to the top of the queue
@@ -67,7 +66,7 @@ func (c *Client) MoveQueuedBuildToTop(buildID string) error {
 // ApproveQueuedBuild approves a queued build that requires approval
 func (c *Client) ApproveQueuedBuild(buildID string) error {
 	path := fmt.Sprintf("/app/rest/buildQueue/id:%s/approval/status", buildID)
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(`"approved"`), "application/json")
+	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(`"approved"`), "application/json")
 }
 
 // GetQueuedBuildApprovalInfo returns approval information for a queued build
@@ -75,7 +74,7 @@ func (c *Client) GetQueuedBuildApprovalInfo(buildID string) (*ApprovalInfo, erro
 	path := fmt.Sprintf("/app/rest/buildQueue/id:%s/approval", buildID)
 
 	var info ApprovalInfo
-	if err := c.get(context.Background(), path, &info); err != nil {
+	if err := c.get(c.ctx(), path, &info); err != nil {
 		return nil, err
 	}
 

--- a/api/client.go
+++ b/api/client.go
@@ -53,10 +53,18 @@ type Client struct {
 	version     string // CLI version for request headers
 	commandName string // CLI command name for X-TeamCity-Client header
 
-	// Cached server info
-	serverInfo     *Server
-	serverInfoOnce sync.Once
-	serverInfoErr  error
+	// baseCtx is the default context for methods that don't take one; set via WithContext, nil falls back to Background.
+	baseCtx context.Context
+
+	// serverInfo is a pointer so WithContext copies share the cache instead of copying sync.Once.
+	serverInfo *serverInfoCache
+}
+
+// serverInfoCache memoizes the result of GetServer across copies of a Client.
+type serverInfoCache struct {
+	once sync.Once
+	info *Server
+	err  error
 }
 
 func (c *Client) debugLog(format string, args ...any) {
@@ -156,6 +164,7 @@ func NewClient(baseURL, token string, opts ...ClientOption) *Client {
 			Timeout:   30 * time.Second,
 			Transport: defaultTransport(),
 		},
+		serverInfo: &serverInfoCache{},
 	}
 
 	for _, opt := range opts {
@@ -177,6 +186,7 @@ func NewClientWithBasicAuth(baseURL, username, password string, opts ...ClientOp
 			Timeout:   30 * time.Second,
 			Transport: defaultTransport(),
 		},
+		serverInfo: &serverInfoCache{},
 	}
 
 	for _, opt := range opts {
@@ -197,6 +207,7 @@ func NewGuestClient(baseURL string, opts ...ClientOption) *Client {
 			Timeout:   30 * time.Second,
 			Transport: defaultTransport(),
 		},
+		serverInfo: &serverInfoCache{},
 	}
 
 	for _, opt := range opts {
@@ -241,6 +252,21 @@ func (c *Client) SetCommandName(name string) {
 	c.commandName = name
 }
 
+// WithContext returns a shallow copy of the client whose default context is ctx; mirrors http.Request.WithContext.
+func (c *Client) WithContext(ctx context.Context) *Client {
+	c2 := *c
+	c2.baseCtx = ctx
+	return &c2
+}
+
+// ctx returns the client's default context, falling back to context.Background() if unset.
+func (c *Client) ctx() context.Context {
+	if c.baseCtx == nil {
+		return context.Background()
+	}
+	return c.baseCtx
+}
+
 func (c *Client) setAuth(req *http.Request) {
 	if c.guestAuth {
 		return
@@ -254,10 +280,10 @@ func (c *Client) setAuth(req *http.Request) {
 
 // ServerVersion returns cached server version info
 func (c *Client) ServerVersion() (*Server, error) {
-	c.serverInfoOnce.Do(func() {
-		c.serverInfo, c.serverInfoErr = c.GetServer()
+	c.serverInfo.once.Do(func() {
+		c.serverInfo.info, c.serverInfo.err = c.GetServer()
 	})
-	return c.serverInfo, c.serverInfoErr
+	return c.serverInfo.info, c.serverInfo.err
 }
 
 // CheckVersion verifies the server meets minimum version requirements

--- a/api/cloud.go
+++ b/api/cloud.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -96,7 +95,7 @@ func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList,
 
 	profiles, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudProfile, string, error) {
 		var page CloudProfileList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Profiles, page.NextHref, nil
@@ -111,7 +110,7 @@ func (c *Client) GetCloudProfile(locator string) (*CloudProfile, error) {
 	path := "/app/rest/cloud/profiles/" + cloudLocator(locator, "id")
 
 	var result CloudProfile
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -134,7 +133,7 @@ func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error
 
 	images, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudImage, string, error) {
 		var page CloudImageList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Images, page.NextHref, nil
@@ -149,7 +148,7 @@ func (c *Client) GetCloudImage(locator string) (*CloudImage, error) {
 	path := "/app/rest/cloud/images/" + cloudLocator(locator, "name")
 
 	var result CloudImage
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -172,7 +171,7 @@ func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceLi
 
 	instances, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudInstance, string, error) {
 		var page CloudInstanceList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Instances, page.NextHref, nil
@@ -187,7 +186,7 @@ func (c *Client) GetCloudInstance(locator string) (*CloudInstance, error) {
 	path := "/app/rest/cloud/instances/" + cloudLocator(locator, "id")
 
 	var result CloudInstance
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -202,7 +201,7 @@ func (c *Client) StartCloudInstance(imageID string) (*CloudInstance, error) {
 	}
 
 	var result CloudInstance
-	if err := c.post(context.Background(), "/app/rest/cloud/instances", bytes.NewReader(body), &result); err != nil {
+	if err := c.post(c.ctx(), "/app/rest/cloud/instances", bytes.NewReader(body), &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -214,5 +213,5 @@ func (c *Client) StopCloudInstance(locator string, force bool) error {
 		action = "forceStop"
 	}
 	path := fmt.Sprintf("/app/rest/cloud/instances/%s/actions/%s", cloudLocator(locator, "id"), action)
-	return c.doNoContent(context.Background(), "POST", path, nil, "")
+	return c.doNoContent(c.ctx(), "POST", path, nil, "")
 }

--- a/api/connections.go
+++ b/api/connections.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"fmt"
 	"net/url"
 )
@@ -12,7 +11,7 @@ func (c *Client) GetProjectConnections(projectID string) (*ProjectFeatureList, e
 	path := fmt.Sprintf("/app/rest/projects/id:%s/projectFeatures?locator=type:OAuthProvider&fields=%s", projectID, fields)
 
 	var result ProjectFeatureList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -33,7 +32,7 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
 
 	buildTypes, err := collectPages(c, path, opts.Limit, func(p string) ([]BuildType, string, error) {
 		var page BuildTypeList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.BuildTypes, page.NextHref, nil
@@ -50,7 +49,7 @@ func (c *Client) GetBuildType(id string) (*BuildType, error) {
 	path := "/app/rest/buildTypes/id:" + id
 
 	var buildType BuildType
-	if err := c.get(context.Background(), path, &buildType); err != nil {
+	if err := c.get(c.ctx(), path, &buildType); err != nil {
 		return nil, err
 	}
 
@@ -61,7 +60,7 @@ func (c *Client) GetBuildType(id string) (*BuildType, error) {
 func (c *Client) SetBuildTypePaused(id string, paused bool) error {
 	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/paused", id)
 
-	resp, err := c.doRequestFull(context.Background(), "PUT", path, strings.NewReader(strconv.FormatBool(paused)), "text/plain", "text/plain")
+	resp, err := c.doRequestFull(c.ctx(), "PUT", path, strings.NewReader(strconv.FormatBool(paused)), "text/plain", "text/plain")
 	if err != nil {
 		return err
 	}
@@ -90,7 +89,7 @@ func (c *Client) CreateBuildType(projectID string, req CreateBuildTypeRequest) (
 	path := fmt.Sprintf("/app/rest/projects/id:%s/buildTypes", projectID)
 
 	var buildType BuildType
-	if err := c.post(context.Background(), path, bytes.NewReader(body), &buildType); err != nil {
+	if err := c.post(c.ctx(), path, bytes.NewReader(body), &buildType); err != nil {
 		return nil, err
 	}
 
@@ -119,7 +118,7 @@ func (c *Client) CreateBuildStep(buildTypeID string, step BuildStep) error {
 	}
 
 	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps", buildTypeID)
-	return c.doNoContent(context.Background(), "POST", path, bytes.NewReader(body), "")
+	return c.doNoContent(c.ctx(), "POST", path, bytes.NewReader(body), "")
 }
 
 // GetSnapshotDependencies returns the snapshot dependencies for a build configuration
@@ -127,7 +126,7 @@ func (c *Client) GetSnapshotDependencies(buildTypeID string) (*SnapshotDependenc
 	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/snapshot-dependencies?fields=count,snapshot-dependency(id,source-buildType(id,name,projectId))", buildTypeID)
 
 	var result SnapshotDependencyList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -139,7 +138,7 @@ func (c *Client) GetDependentBuildTypes(buildTypeID string) (*BuildTypeList, err
 	path := fmt.Sprintf("/app/rest/buildTypes?locator=snapshotDependency:(from:(id:%s),recursive:false)&fields=count,buildType(id,name,projectId)", buildTypeID)
 
 	var result BuildTypeList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -151,7 +150,7 @@ func (c *Client) GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error) 
 	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/vcs-root-entries", buildTypeID)
 
 	var result VcsRootEntries
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -161,5 +160,5 @@ func (c *Client) GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error) 
 // SetBuildTypeSetting sets a build configuration setting
 func (c *Client) SetBuildTypeSetting(buildTypeID, setting, value string) error {
 	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings/%s", buildTypeID, setting)
-	return c.doNoContent(context.Background(), "PUT", path, strings.NewReader(value), "text/plain")
+	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(value), "text/plain")
 }

--- a/api/paginate.go
+++ b/api/paginate.go
@@ -24,7 +24,7 @@ func collectPages[T any](c *Client, path string, limit int, fetch func(string) (
 }
 
 // normalizePaginationPath converts a TeamCity NextHref value into a path
-// suitable for c.get(context.Background(), ). It strips the scheme/host, context path, guestAuth
+// suitable for c.get. It strips the scheme/host, context path, guestAuth
 // prefix, and API version so that apiPath() can re-apply them consistently.
 func (c *Client) normalizePaginationPath(href string) string {
 	if href == "" {

--- a/api/params.go
+++ b/api/params.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -31,7 +30,7 @@ func (c *Client) getParameters(basePath string) (*ParameterList, error) {
 	path := basePath + "/parameters"
 
 	var params ParameterList
-	if err := c.get(context.Background(), path, &params); err != nil {
+	if err := c.get(c.ctx(), path, &params); err != nil {
 		return nil, err
 	}
 
@@ -42,7 +41,7 @@ func (c *Client) getParameter(basePath, name string) (*Parameter, error) {
 	path := fmt.Sprintf("%s/parameters/%s", basePath, name)
 
 	var param Parameter
-	if err := c.get(context.Background(), path, &param); err != nil {
+	if err := c.get(c.ctx(), path, &param); err != nil {
 		return nil, err
 	}
 
@@ -66,12 +65,12 @@ func (c *Client) setParameter(basePath, name, value string, secure bool) error {
 		return fmt.Errorf("failed to marshal parameter: %w", err)
 	}
 
-	return c.doNoContent(context.Background(), "PUT", path, bytes.NewReader(body), "")
+	return c.doNoContent(c.ctx(), "PUT", path, bytes.NewReader(body), "")
 }
 
 func (c *Client) deleteParameter(basePath, name string) error {
 	path := fmt.Sprintf("%s/parameters/%s", basePath, name)
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 // GetProjectParameters returns parameters for a project
@@ -116,7 +115,7 @@ func (c *Client) DeleteBuildTypeParameter(buildTypeID, name string) error {
 
 // GetParameterValue returns just the raw value of a parameter
 func (c *Client) GetParameterValue(path string) (string, error) {
-	resp, err := c.doRequestWithAccept(context.Background(), "GET", path, nil, "text/plain")
+	resp, err := c.doRequestWithAccept(c.ctx(), "GET", path, nil, "text/plain")
 	if err != nil {
 		return "", err
 	}

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -30,7 +29,7 @@ func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, error) {
 
 	pipelines, err := collectPages(c, path, opts.Limit, func(p string) ([]Pipeline, string, error) {
 		var page PipelineList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Pipelines, page.NextHref, nil
@@ -47,7 +46,7 @@ func (c *Client) GetPipeline(id string) (*Pipeline, error) {
 	path := fmt.Sprintf("/app/rest/pipelines/id:%s?fields=%s", id, url.QueryEscape(fields))
 
 	var result Pipeline
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -58,7 +57,7 @@ func (c *Client) GetPipeline(id string) (*Pipeline, error) {
 func (c *Client) getPipelineRaw(id string) (map[string]any, error) {
 	path := "/app/pipeline/" + id
 	var raw map[string]any
-	if err := c.get(context.Background(), path, &raw); err != nil {
+	if err := c.get(c.ctx(), path, &raw); err != nil {
 		return nil, err
 	}
 	return raw, nil
@@ -98,7 +97,7 @@ func (c *Client) CreatePipeline(parentProjectID, name, yaml, vcsRootID string) (
 
 	path := "/app/pipeline?parentProjectExtId=" + url.QueryEscape(parentProjectID)
 	var result Pipeline
-	if err := c.post(context.Background(), path, bytes.NewReader(body), &result); err != nil {
+	if err := c.post(c.ctx(), path, bytes.NewReader(body), &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -134,7 +133,7 @@ func (c *Client) UpdatePipelineYAML(id string, yamlContent string) error {
 
 	path := "/app/pipeline/" + id
 	var result json.RawMessage
-	return c.post(context.Background(), path, bytes.NewReader(body), &result)
+	return c.post(c.ctx(), path, bytes.NewReader(body), &result)
 }
 
 // GetBuildPipelineRun fetches pipeline run metadata for a build.
@@ -146,7 +145,7 @@ func (c *Client) GetBuildPipelineRun(buildID string) (*PipelineRun, error) {
 	var result struct {
 		PipelineRun *PipelineRun `json:"pipelineRun,omitempty"`
 	}
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return result.PipelineRun, nil
@@ -154,12 +153,12 @@ func (c *Client) GetBuildPipelineRun(buildID string) (*PipelineRun, error) {
 
 // DeletePipeline deletes a pipeline by removing its project.
 func (c *Client) DeletePipeline(id string) error {
-	return c.doNoContent(context.Background(), "DELETE", "/app/rest/projects/id:"+id, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", "/app/rest/projects/id:"+id, nil, "")
 }
 
 // GetPipelineSchema fetches the pipeline JSON schema from the server.
 func (c *Client) GetPipelineSchema() ([]byte, error) {
-	resp, err := c.doRequest(context.Background(), "POST", "/app/pipeline/schema/generate", nil)
+	resp, err := c.doRequest(c.ctx(), "POST", "/app/pipeline/schema/generate", nil)
 	if err != nil {
 		return nil, &NetworkError{URL: c.BaseURL, Cause: err}
 	}

--- a/api/pools.go
+++ b/api/pools.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -19,7 +18,7 @@ func (c *Client) GetAgentPools(requestedFields []string) (*PoolList, error) {
 
 	pools, err := collectPages(c, path, 0, func(p string) ([]Pool, string, error) {
 		var page PoolList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Pools, page.NextHref, nil
@@ -37,7 +36,7 @@ func (c *Client) GetAgentPool(id int) (*Pool, error) {
 	path := fmt.Sprintf("/app/rest/agentPools/id:%d?fields=%s", id, url.QueryEscape(fields))
 
 	var result Pool
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 
@@ -51,13 +50,13 @@ func (c *Client) AddProjectToPool(poolID int, projectID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
-	return c.doNoContent(context.Background(), "POST", path, bytes.NewReader(body), "")
+	return c.doNoContent(c.ctx(), "POST", path, bytes.NewReader(body), "")
 }
 
 // RemoveProjectFromPool removes a project from an agent pool
 func (c *Client) RemoveProjectFromPool(poolID int, projectID string) error {
 	path := fmt.Sprintf("/app/rest/agentPools/id:%d/projects/id:%s", poolID, projectID)
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 // SetAgentPool moves an agent to a different pool
@@ -67,5 +66,5 @@ func (c *Client) SetAgentPool(agentID int, poolID int) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
-	return c.doNoContent(context.Background(), "PUT", path, bytes.NewReader(body), "")
+	return c.doNoContent(c.ctx(), "PUT", path, bytes.NewReader(body), "")
 }

--- a/api/projects.go
+++ b/api/projects.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -33,7 +32,7 @@ func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
 
 	projects, err := collectPages(c, path, opts.Limit, func(p string) ([]Project, string, error) {
 		var page ProjectList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.Projects, page.NextHref, nil
@@ -50,7 +49,7 @@ func (c *Client) GetProject(id string) (*Project, error) {
 	path := "/app/rest/projects/id:" + id
 
 	var project Project
-	if err := c.get(context.Background(), path, &project); err != nil {
+	if err := c.get(c.ctx(), path, &project); err != nil {
 		return nil, err
 	}
 
@@ -72,7 +71,7 @@ func (c *Client) CreateProject(req CreateProjectRequest) (*Project, error) {
 	}
 
 	var project Project
-	if err := c.post(context.Background(), "/app/rest/projects", bytes.NewReader(body), &project); err != nil {
+	if err := c.post(c.ctx(), "/app/rest/projects", bytes.NewReader(body), &project); err != nil {
 		return nil, err
 	}
 
@@ -91,7 +90,7 @@ func (c *Client) ProjectExists(id string) bool {
 func (c *Client) CreateSecureToken(projectID, value string) (string, error) {
 	path := fmt.Sprintf("/app/rest/projects/%s/secure/tokens", projectID)
 
-	resp, err := c.doRequestFull(context.Background(), "POST", path, strings.NewReader(value), "text/plain", "text/plain")
+	resp, err := c.doRequestFull(c.ctx(), "POST", path, strings.NewReader(value), "text/plain", "text/plain")
 	if err != nil {
 		return "", err
 	}
@@ -114,7 +113,7 @@ func (c *Client) CreateSecureToken(projectID, value string) (string, error) {
 func (c *Client) GetSecureValue(projectID, token string) (string, error) {
 	path := fmt.Sprintf("/app/rest/projects/%s/secure/values/%s", projectID, token)
 
-	resp, err := c.doRequestWithAccept(context.Background(), "GET", path, nil, "text/plain")
+	resp, err := c.doRequestWithAccept(c.ctx(), "GET", path, nil, "text/plain")
 	if err != nil {
 		return "", err
 	}
@@ -137,7 +136,7 @@ func (c *Client) GetVersionedSettingsStatus(projectID string) (*VersionedSetting
 	path := fmt.Sprintf("/app/rest/projects/%s/versionedSettings/status", projectID)
 
 	var status VersionedSettingsStatus
-	if err := c.get(context.Background(), path, &status); err != nil {
+	if err := c.get(c.ctx(), path, &status); err != nil {
 		return nil, err
 	}
 
@@ -149,7 +148,7 @@ func (c *Client) GetVersionedSettingsConfig(projectID string) (*VersionedSetting
 	path := fmt.Sprintf("/app/rest/projects/%s/versionedSettings/config", projectID)
 
 	var config VersionedSettingsConfig
-	if err := c.get(context.Background(), path, &config); err != nil {
+	if err := c.get(c.ctx(), path, &config); err != nil {
 		return nil, err
 	}
 
@@ -162,7 +161,7 @@ func (c *Client) ExportProjectSettings(projectID, format string, useRelativeIds 
 	path := fmt.Sprintf("/admin/versionedSettingsActions.html?projectId=%s&action=generate&format=%s&version=latest&useRelativeIds=%t",
 		url.QueryEscape(projectID), url.QueryEscape(format), useRelativeIds)
 
-	resp, err := c.doRequestWithAccept(context.Background(), "GET", path, nil, "application/zip")
+	resp, err := c.doRequestWithAccept(c.ctx(), "GET", path, nil, "application/zip")
 	if err != nil {
 		return nil, err
 	}

--- a/api/ssh_keys.go
+++ b/api/ssh_keys.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"net/url"
 )
@@ -12,7 +11,7 @@ func (c *Client) GetSSHKeys(projectID string) (*SSHKeyList, error) {
 	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys", projectID)
 
 	var result SSHKeyList
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -21,7 +20,7 @@ func (c *Client) GetSSHKeys(projectID string) (*SSHKeyList, error) {
 // UploadSSHKey uploads a private SSH key to a project
 func (c *Client) UploadSSHKey(projectID, name string, privateKey []byte) error {
 	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/?fileName=%s", projectID, url.QueryEscape(name))
-	return c.doNoContent(context.Background(), "POST", path, bytes.NewReader(privateKey), "text/plain")
+	return c.doNoContent(c.ctx(), "POST", path, bytes.NewReader(privateKey), "text/plain")
 }
 
 // GenerateSSHKey generates an SSH key pair in a project and returns the key with public key
@@ -29,7 +28,7 @@ func (c *Client) GenerateSSHKey(projectID, name, keyType string) (*SSHKey, error
 	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/generated?keyName=%s&keyType=%s", projectID, url.QueryEscape(name), url.QueryEscape(keyType))
 
 	var result SSHKey
-	if err := c.post(context.Background(), path, nil, &result); err != nil {
+	if err := c.post(c.ctx(), path, nil, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -38,5 +37,5 @@ func (c *Client) GenerateSSHKey(projectID, name, keyType string) (*SSHKey, error
 // DeleteSSHKey deletes an SSH key from a project
 func (c *Client) DeleteSSHKey(projectID, name string) error {
 	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/%s", projectID, url.PathEscape(name))
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }

--- a/api/users.go
+++ b/api/users.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -10,7 +9,7 @@ import (
 // GetCurrentUser returns the authenticated user
 func (c *Client) GetCurrentUser() (*User, error) {
 	var user User
-	if err := c.get(context.Background(), "/app/rest/users/current?fields=username,name", &user); err != nil {
+	if err := c.get(c.ctx(), "/app/rest/users/current?fields=username,name", &user); err != nil {
 		return nil, err
 	}
 	return &user, nil
@@ -21,7 +20,7 @@ func (c *Client) GetUser(username string) (*User, error) {
 	path := "/app/rest/users/username:" + username
 
 	var user User
-	if err := c.get(context.Background(), path, &user); err != nil {
+	if err := c.get(c.ctx(), path, &user); err != nil {
 		return nil, err
 	}
 	return &user, nil
@@ -61,7 +60,7 @@ func (c *Client) CreateUser(req CreateUserRequest) (*User, error) {
 	}
 
 	var user User
-	if err := c.post(context.Background(), "/app/rest/users", bytes.NewReader(body), &user); err != nil {
+	if err := c.post(c.ctx(), "/app/rest/users", bytes.NewReader(body), &user); err != nil {
 		return nil, err
 	}
 
@@ -79,7 +78,7 @@ func (c *Client) CreateAPIToken(name string) (*Token, error) {
 	path := "/app/rest/users/current/tokens/" + name
 
 	var token Token
-	if err := c.post(context.Background(), path, nil, &token); err != nil {
+	if err := c.post(c.ctx(), path, nil, &token); err != nil {
 		return nil, err
 	}
 
@@ -89,13 +88,13 @@ func (c *Client) CreateAPIToken(name string) (*Token, error) {
 // DeleteAPIToken deletes an API token for the current user
 func (c *Client) DeleteAPIToken(name string) error {
 	path := "/app/rest/users/current/tokens/" + name
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 // GetServer returns server information
 func (c *Client) GetServer() (*Server, error) {
 	var server Server
-	if err := c.get(context.Background(), "/app/rest/server", &server); err != nil {
+	if err := c.get(c.ctx(), "/app/rest/server", &server); err != nil {
 		return nil, err
 	}
 	return &server, nil

--- a/api/vcs_roots.go
+++ b/api/vcs_roots.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,7 +24,7 @@ func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
 
 	roots, err := collectPages(c, path, opts.Limit, func(p string) ([]VcsRoot, string, error) {
 		var page VcsRootList
-		if err := c.get(context.Background(), p, &page); err != nil {
+		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
 		}
 		return page.VcsRoot, page.NextHref, nil
@@ -41,7 +40,7 @@ func (c *Client) GetVcsRoot(id string) (*VcsRoot, error) {
 	path := "/app/rest/vcs-roots/id:" + id
 
 	var result VcsRoot
-	if err := c.get(context.Background(), path, &result); err != nil {
+	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -50,7 +49,7 @@ func (c *Client) GetVcsRoot(id string) (*VcsRoot, error) {
 // DeleteVcsRoot deletes a VCS root by ID
 func (c *Client) DeleteVcsRoot(id string) error {
 	path := "/app/rest/vcs-roots/id:" + id
-	return c.doNoContent(context.Background(), "DELETE", path, nil, "")
+	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 // CreateVcsRoot creates a new VCS root
@@ -61,7 +60,7 @@ func (c *Client) CreateVcsRoot(root VcsRoot) (*VcsRoot, error) {
 	}
 
 	var result VcsRoot
-	if err := c.post(context.Background(), "/app/rest/vcs-roots", bytes.NewReader(body), &result); err != nil {
+	if err := c.post(c.ctx(), "/app/rest/vcs-roots", bytes.NewReader(body), &result); err != nil {
 		return nil, err
 	}
 	return &result, nil
@@ -76,7 +75,7 @@ func (c *Client) TestVcsConnection(req TestConnectionRequest, projectID string) 
 	}
 
 	path := "/app/pipeline/repository/testConnection?parentProjectExtId=" + projectID
-	resp, err := c.doRequest(context.Background(), "POST", path, bytes.NewReader(body))
+	resp, err := c.doRequest(c.ctx(), "POST", path, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/agent/agent_reboot.go
+++ b/internal/cmd/agent/agent_reboot.go
@@ -70,7 +70,7 @@ Note: Local agents (running on the same machine as the server) cannot be reboote
   teamcity agent reboot Agent-Linux-01 --graceful
   teamcity agent reboot Agent-Linux-01 --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runAgentReboot(f, cmd.Context(), args[0], opts)
+			return runAgentReboot(f, f.Context(), args[0], opts)
 		},
 	}
 

--- a/internal/cmd/agent/terminal.go
+++ b/internal/cmd/agent/terminal.go
@@ -29,11 +29,11 @@ or the connection drops.`,
 		Example: `  teamcity agent term 1
   teamcity agent term Agent-Linux-01`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			conn, err := connectToAgent(f, cmd.Context(), args[0], true)
+			conn, err := connectToAgent(f, f.Context(), args[0], true)
 			if err != nil {
 				return err
 			}
-			return conn.RunInteractive(cmd.Context())
+			return conn.RunInteractive(f.Context())
 		},
 	}
 }
@@ -54,11 +54,11 @@ agent-side commands from teamcity flags.`,
   teamcity agent exec Agent-Linux-01 "cat /etc/os-release"
   teamcity agent exec Agent-Linux-01 --timeout 10m -- long-running-script.sh`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			conn, err := connectToAgent(f, cmd.Context(), args[0], false)
+			conn, err := connectToAgent(f, f.Context(), args[0], false)
 			if err != nil {
 				return err
 			}
-			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+			ctx, cancel := context.WithTimeout(f.Context(), timeout)
 			defer cancel()
 
 			return conn.Exec(ctx, strings.Join(args[1:], " "))
@@ -73,7 +73,7 @@ func connectToAgent(f *cmdutil.Factory, ctx context.Context, nameOrID string, sh
 	serverURL := config.GetServerURL()
 	token, _, keyringErr := config.GetTokenWithSource()
 	if serverURL == "" || token == "" {
-		return nil, cmdutil.NotAuthenticatedError(serverURL, keyringErr)
+		return nil, cmdutil.NotAuthenticatedError(ctx, serverURL, keyringErr)
 	}
 
 	client, err := f.Client()

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -159,10 +159,10 @@ func runAPI(f *cmdutil.Factory, endpoint string, opts *apiOptions) error {
 	}
 
 	if opts.paginate {
-		return runAPIPaginated(f.Printer, client, endpoint, headers, opts)
+		return runAPIPaginated(f.Context(), f.Printer, client, endpoint, headers, opts)
 	}
 
-	resp, err := client.RawRequest(context.Background(), opts.method, endpoint, body, headers)
+	resp, err := client.RawRequest(f.Context(), opts.method, endpoint, body, headers)
 	if err != nil {
 		return err
 	}
@@ -170,8 +170,8 @@ func runAPI(f *cmdutil.Factory, endpoint string, opts *apiOptions) error {
 	return outputAPIResponse(f.Printer, resp.Body, resp.StatusCode, resp.Headers, opts)
 }
 
-func runAPIPaginated(p *output.Printer, client api.ClientInterface, endpoint string, headers map[string]string, opts *apiOptions) error {
-	pages, err := fetchAllPages(client, endpoint, headers)
+func runAPIPaginated(ctx context.Context, p *output.Printer, client api.ClientInterface, endpoint string, headers map[string]string, opts *apiOptions) error {
+	pages, err := fetchAllPages(ctx, client, endpoint, headers)
 	if err != nil {
 		return err
 	}
@@ -255,12 +255,12 @@ func outputAPIResponse(p *output.Printer, body []byte, statusCode int, respHeade
 	return nil
 }
 
-func fetchAllPages(client api.ClientInterface, endpoint string, headers map[string]string) ([][]byte, error) {
+func fetchAllPages(ctx context.Context, client api.ClientInterface, endpoint string, headers map[string]string) ([][]byte, error) {
 	var pages [][]byte
 	currentEndpoint := endpoint
 
 	for range maxPaginationPages {
-		resp, err := client.RawRequest(context.Background(), "GET", currentEndpoint, nil, headers)
+		resp, err := client.RawRequest(ctx, "GET", currentEndpoint, nil, headers)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -640,7 +640,7 @@ func TestFetchAllPages(T *testing.T) {
 
 	client := api.NewClient(server.URL, "test-token")
 
-	pages, err := fetchAllPages(client, "/app/rest/builds", nil)
+	pages, err := fetchAllPages(T.Context(), client, "/app/rest/builds", nil)
 	require.NoError(T, err)
 	assert.Len(T, pages, 3, "fetchAllPages() page count")
 
@@ -673,7 +673,7 @@ func TestFetchAllPagesSinglePage(T *testing.T) {
 
 	client := api.NewClient(server.URL, "test-token")
 
-	pages, err := fetchAllPages(client, "/app/rest/builds", nil)
+	pages, err := fetchAllPages(T.Context(), client, "/app/rest/builds", nil)
 	require.NoError(T, err)
 	assert.Len(T, pages, 1, "fetchAllPages() page count")
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -111,12 +111,12 @@ func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage b
 	pkceChecked := false
 	if token == "" && !noBrowser && isInteractive {
 		pkceChecked = true
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(f.Context(), 10*time.Second)
 		enabled, _ := api.IsPkceEnabled(ctx, serverURL)
 		cancel()
 		if enabled {
 			p.Info("Secure browser login available on this server")
-			if tokenResp, err := runPkceLogin(p, serverURL); err != nil {
+			if tokenResp, err := runPkceLogin(f.Context(), p, serverURL); err != nil {
 				p.Warn("Browser auth failed: %v", err)
 				p.Info("Falling back to manual token entry...")
 			} else {
@@ -171,7 +171,7 @@ func runAuthLogin(f *cmdutil.Factory, serverURL, token string, insecureStorage b
 	f.WarnInsecureHTTP(serverURL, "authentication token")
 	p.Progress("Validating... ")
 
-	client := api.NewClient(serverURL, token, api.WithDebugFunc(p.Debug), api.WithVersion(version.String()))
+	client := api.NewClient(serverURL, token, api.WithDebugFunc(p.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	user, err := client.GetCurrentUser()
 	if err != nil {
 		p.Info("%s", output.Red("✗"))
@@ -230,7 +230,7 @@ func runAuthLoginGuest(f *cmdutil.Factory, serverURL, token string) error {
 	f.WarnInsecureHTTP(serverURL, "guest access")
 	p.Progress("Validating guest access... ")
 
-	client := api.NewGuestClient(serverURL, api.WithDebugFunc(p.Debug), api.WithVersion(version.String()))
+	client := api.NewGuestClient(serverURL, api.WithDebugFunc(p.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	server, err := client.GetServer()
 	if err != nil {
 		p.Info("%s", output.Red("✗"))
@@ -252,7 +252,7 @@ func runAuthLoginGuest(f *cmdutil.Factory, serverURL, token string) error {
 	return nil
 }
 
-func runPkceLogin(p *output.Printer, serverURL string) (*api.TokenResponse, error) {
+func runPkceLogin(parent context.Context, p *output.Printer, serverURL string) (*api.TokenResponse, error) {
 	verifier, err := api.GenerateCodeVerifier()
 	if err != nil {
 		return nil, fmt.Errorf("generate code verifier: %w", err)
@@ -292,11 +292,14 @@ func runPkceLogin(p *output.Printer, serverURL string) (*api.TokenResponse, erro
 		}
 		_, _ = fmt.Fprintln(p.Out)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 		defer cancel()
 		return api.ExchangeCodeForToken(ctx, serverURL, result.Code, verifier, redirectURI)
 
 	case <-time.After(authCodeLifetime):
 		return nil, fmt.Errorf("timeout waiting for callback (exceeded %v)", authCodeLifetime)
+
+	case <-parent.Done():
+		return nil, parent.Err()
 	}
 }

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"cmp"
+	"context"
 	"errors"
 	"fmt"
 	"maps"
@@ -131,7 +132,7 @@ func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerC
 
 func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "guest", IsDefault: isDefault}
-	client := api.NewGuestClient(serverURL, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String()))
+	client := api.NewGuestClient(serverURL, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	server, err := client.GetServer()
 	if err != nil {
 		s.Status = "error"
@@ -148,7 +149,7 @@ func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) au
 
 func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "token", TokenSource: tokenSource, IsDefault: isDefault}
-	client := api.NewClient(serverURL, token, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String()))
+	client := api.NewClient(serverURL, token, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	user, err := client.GetCurrentUser()
 	if err != nil {
 		s.Status = "error"
@@ -184,7 +185,7 @@ func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string
 
 func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth) authStatus {
 	s := authStatus{Server: buildAuth.ServerURL, AuthMethod: "build"}
-	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String()))
+	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	server, err := client.GetServer()
 	if err != nil {
 		s.Status = "error"
@@ -207,7 +208,7 @@ func renderAuthStatusHuman(f *cmdutil.Factory, results []authStatus) error {
 		if config.IsBuildEnvironment() {
 			_, _ = fmt.Fprintln(p.Out, "\n"+output.Yellow("!")+" Build environment detected but credentials not found in properties file")
 		}
-		renderDSLTip(p, results)
+		renderDSLTip(f.Context(), p, results)
 		return nil
 	}
 
@@ -223,7 +224,7 @@ func renderAuthStatusHuman(f *cmdutil.Factory, results []authStatus) error {
 		p.Tip("To switch the default server, run %s", output.Cyan("teamcity config set default_server <url>"))
 	}
 
-	renderDSLTip(p, results)
+	renderDSLTip(f.Context(), p, results)
 	return nil
 }
 
@@ -260,7 +261,7 @@ func renderOneStatus(f *cmdutil.Factory, p *output.Printer, s authStatus) {
 
 	case s.Status == "error" && s.AuthMethod == "":
 		_, _ = fmt.Fprintf(p.Out, "%s %s%s\n", output.Red("✗"), s.Server, suffix)
-		renderCredentialsDiagnostic(p, s)
+		renderCredentialsDiagnostic(f.Context(), p, s)
 
 	case s.Status == "error":
 		_, _ = fmt.Fprintf(p.Out, "%s Server: %s%s\n", output.Red("✗"), s.Server, suffix)
@@ -303,7 +304,7 @@ func renderTokenExpiry(p *output.Printer, expiry string) {
 	}
 }
 
-func renderCredentialsDiagnostic(p *output.Printer, s authStatus) {
+func renderCredentialsDiagnostic(ctx context.Context, p *output.Printer, s authStatus) {
 	if s.configUser != "" {
 		if s.keyringErr != nil {
 			_, _ = fmt.Fprintf(p.Out, "  Token is in the system keyring but could not be retrieved: %v\n", s.keyringErr)
@@ -319,12 +320,12 @@ func renderCredentialsDiagnostic(p *output.Printer, s authStatus) {
 		output.Cyan("TEAMCITY_URL"), output.Cyan("TEAMCITY_TOKEN"))
 	_, _ = fmt.Fprintf(p.Out, "    • Or run %s\n",
 		output.Cyan("teamcity auth login --server "+s.Server+" --insecure-storage"))
-	if cmdutil.ProbeGuestAccess(s.Server) {
+	if cmdutil.ProbeGuestAccess(ctx, s.Server) {
 		_, _ = fmt.Fprintf(p.Out, "    • Or set %s for read-only guest access\n", output.Cyan("TEAMCITY_GUEST=1"))
 	}
 }
 
-func renderDSLTip(p *output.Printer, results []authStatus) {
+func renderDSLTip(ctx context.Context, p *output.Printer, results []authStatus) {
 	dslURL := config.DetectServerFromDSL()
 	if dslURL == "" {
 		return
@@ -338,7 +339,7 @@ func renderDSLTip(p *output.Printer, results []authStatus) {
 	_, _ = fmt.Fprintf(p.Out, "%s Commands in this directory target %s (from DSL settings)\n",
 		output.Yellow("!"), output.Cyan(dslURL))
 	loginCmd := output.Cyan("teamcity auth login --server " + dslURL)
-	if cmdutil.ProbeGuestAccess(dslURL) {
+	if cmdutil.ProbeGuestAccess(ctx, dslURL) {
 		_, _ = fmt.Fprintf(p.Out, "  Run %s, or set %s for guest access\n", loginCmd, output.Cyan("TEAMCITY_GUEST=1"))
 	} else {
 		_, _ = fmt.Fprintf(p.Out, "  Run %s to authenticate\n", loginCmd)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"time"
@@ -85,7 +86,7 @@ Report issues:  https://jb.gg/tc/issues`,
 			f.JSONOutput = true
 		}
 		if cmd.Name() != "update" && f.UpdateNotice == nil {
-			f.UpdateNotice = update.CheckInBackground(f.Printer.ErrOut, f.Quiet)
+			f.UpdateNotice = update.CheckInBackground(f.Context(), f.Printer.ErrOut, f.Quiet)
 		}
 	}
 
@@ -106,9 +107,11 @@ Report issues:  https://jb.gg/tc/issues`,
 	return cmd
 }
 
-func Execute() error {
+func Execute(ctx context.Context) error {
 	f := cmdutil.NewFactory()
+	f.SetContext(ctx)
 	rootCmd := buildRootCmd(f)
+	rootCmd.SetContext(ctx)
 
 	alias.RegisterAliases(rootCmd, f)
 	rootCmd.SilenceErrors = true
@@ -116,6 +119,9 @@ func Execute() error {
 	executedCmd, err := rootCmd.ExecuteC()
 	if f.UpdateNotice != nil {
 		f.UpdateNotice()
+	}
+	if err != nil && ctx.Err() != nil && errors.Is(err, context.Canceled) {
+		return nil
 	}
 	if !f.JSONOutput && executedCmd != nil && jsonOutputEnabled(executedCmd) {
 		f.JSONOutput = true

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -120,7 +120,7 @@ func Execute(ctx context.Context) error {
 	if f.UpdateNotice != nil {
 		f.UpdateNotice()
 	}
-	if err != nil && ctx.Err() != nil && errors.Is(err, context.Canceled) {
+	if err != nil && ctx.Err() != nil {
 		return nil
 	}
 	if !f.JSONOutput && executedCmd != nil && jsonOutputEnabled(executedCmd) {

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"strconv"
@@ -47,7 +46,7 @@ func runRunChanges(f *cmdutil.Factory, runID string, opts *runChangesOptions) er
 		return err
 	}
 
-	changes, err := client.GetBuildChanges(context.Background(), runID)
+	changes, err := client.GetBuildChanges(f.Context(), runID)
 	if err != nil {
 		return fmt.Errorf("failed to get changes: %w", err)
 	}
@@ -172,7 +171,7 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	}
 
 	if opts.job != "" {
-		runs, err := client.GetBuilds(context.Background(), api.BuildsOptions{
+		runs, err := client.GetBuilds(f.Context(), api.BuildsOptions{
 			BuildTypeID: opts.job,
 			Limit:       1,
 		})
@@ -190,12 +189,12 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		return errors.New("run ID required (or use --job to get latest run)")
 	}
 
-	build, err := client.GetBuild(context.Background(), runID)
+	build, err := client.GetBuild(f.Context(), runID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
 
-	tests, err := client.GetBuildTests(context.Background(), runID, opts.failed, opts.limit)
+	tests, err := client.GetBuildTests(f.Context(), runID, opts.failed, opts.limit)
 	if err != nil {
 		return fmt.Errorf("failed to get tests: %w", err)
 	}

--- a/internal/cmd/run/artifacts.go
+++ b/internal/cmd/run/artifacts.go
@@ -64,7 +64,7 @@ func runRunArtifacts(f *cmdutil.Factory, runID string, opts *runArtifactsOptions
 	}
 
 	if opts.job != "" {
-		runs, err := client.GetBuilds(context.Background(), api.BuildsOptions{
+		runs, err := client.GetBuilds(f.Context(), api.BuildsOptions{
 			BuildTypeID: opts.job,
 			State:       "finished",
 			Limit:       1,
@@ -84,7 +84,7 @@ func runRunArtifacts(f *cmdutil.Factory, runID string, opts *runArtifactsOptions
 		return errors.New("run ID required (or use --job to get latest run)")
 	}
 
-	artifacts, err := client.GetArtifacts(context.Background(), runID, opts.path)
+	artifacts, err := client.GetArtifacts(f.Context(), runID, opts.path)
 	if err != nil {
 		return fmt.Errorf("failed to get artifacts: %w", err)
 	}

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -87,14 +87,14 @@ func runRunDiff(f *cmdutil.Factory, args []string, opts *runDiffOptions) error {
 		return err
 	}
 
-	id1, id2, err := resolveDiffBuildIDs(client, args)
+	id1, id2, err := resolveDiffBuildIDs(f.Context(), client, args)
 	if err != nil {
 		return err
 	}
 
 	if opts.web {
-		b1, err1 := client.GetBuild(context.Background(), id1)
-		b2, err2 := client.GetBuild(context.Background(), id2)
+		b1, err1 := client.GetBuild(f.Context(), id1)
+		b2, err2 := client.GetBuild(f.Context(), id2)
 		if err1 != nil {
 			return fmt.Errorf("resolving #%s: %w", id1, err1)
 		}
@@ -110,7 +110,7 @@ func runRunDiff(f *cmdutil.Factory, args []string, opts *runDiffOptions) error {
 		return runLogDiff(f, client, id1, id2, opts.context)
 	}
 
-	d1, d2, err := fetchBothBuilds(client, id1, id2, p)
+	d1, d2, err := fetchBothBuilds(f.Context(), client, id1, id2, p)
 	if err != nil {
 		return err
 	}
@@ -123,17 +123,17 @@ func runRunDiff(f *cmdutil.Factory, args []string, opts *runDiffOptions) error {
 	return nil
 }
 
-func resolveDiffBuildIDs(client api.ClientInterface, args []string) (string, string, error) {
+func resolveDiffBuildIDs(ctx context.Context, client api.ClientInterface, args []string) (string, string, error) {
 	if len(args) == 2 {
 		return args[0], args[1], nil
 	}
 
-	build, err := client.GetBuild(context.Background(), args[0])
+	build, err := client.GetBuild(ctx, args[0])
 	if err != nil {
 		return "", "", fmt.Errorf("could not resolve: %w", err)
 	}
 
-	builds, err := client.GetBuilds(context.Background(), api.BuildsOptions{
+	builds, err := client.GetBuilds(ctx, api.BuildsOptions{
 		BuildTypeID: build.BuildTypeID,
 		Limit:       1,
 		State:       "finished",
@@ -155,19 +155,19 @@ func resolveDiffBuildIDs(client api.ClientInterface, args []string) (string, str
 	)
 }
 
-func fetchBuildData(client api.ClientInterface, id string, p *output.Printer) (buildData, error) {
-	b, err := client.GetBuild(context.Background(), id)
+func fetchBuildData(ctx context.Context, client api.ClientInterface, id string, p *output.Printer) (buildData, error) {
+	b, err := client.GetBuild(ctx, id)
 	if err != nil {
 		return buildData{}, fmt.Errorf("#%s: %w", id, err)
 	}
 	d := buildData{build: b}
-	if d.tests, err = client.GetBuildTests(context.Background(), id, true, 0); err != nil {
+	if d.tests, err = client.GetBuildTests(ctx, id, true, 0); err != nil {
 		p.Warn("Could not fetch tests for #%s: %v", id, err)
 	}
 	if d.testSummary, err = client.GetBuildTestSummary(id); err != nil {
 		p.Warn("Could not fetch test summary for #%s: %v", id, err)
 	}
-	if d.changes, err = client.GetBuildChanges(context.Background(), id); err != nil {
+	if d.changes, err = client.GetBuildChanges(ctx, id); err != nil {
 		p.Warn("Could not fetch changes for #%s: %v", id, err)
 	}
 	if d.problems, err = client.GetBuildProblems(id); err != nil {
@@ -179,12 +179,12 @@ func fetchBuildData(client api.ClientInterface, id string, p *output.Printer) (b
 	return d, nil
 }
 
-func fetchBothBuilds(client api.ClientInterface, id1, id2 string, p *output.Printer) (buildData, buildData, error) {
+func fetchBothBuilds(ctx context.Context, client api.ClientInterface, id1, id2 string, p *output.Printer) (buildData, buildData, error) {
 	var d1, d2 buildData
 	var err1, err2 error
 	var wg sync.WaitGroup
-	wg.Go(func() { d1, err1 = fetchBuildData(client, id1, p) })
-	wg.Go(func() { d2, err2 = fetchBuildData(client, id2, p) })
+	wg.Go(func() { d1, err1 = fetchBuildData(ctx, client, id1, p) })
+	wg.Go(func() { d2, err2 = fetchBuildData(ctx, client, id2, p) })
 	wg.Wait()
 	if err1 != nil {
 		return d1, d2, err1
@@ -194,21 +194,22 @@ func fetchBothBuilds(client api.ClientInterface, id1, id2 string, p *output.Prin
 
 func runLogDiff(f *cmdutil.Factory, client api.ClientInterface, id1, id2 string, contextLines int) error {
 	p := f.Printer
+	ctx := f.Context()
 
-	b1, err := client.GetBuild(context.Background(), id1)
+	b1, err := client.GetBuild(ctx, id1)
 	if err != nil {
 		return err
 	}
-	b2, err := client.GetBuild(context.Background(), id2)
+	b2, err := client.GetBuild(ctx, id2)
 	if err != nil {
 		return err
 	}
 
-	log1, err := client.GetBuildLog(context.Background(), id1)
+	log1, err := client.GetBuildLog(ctx, id1)
 	if err != nil {
 		return fmt.Errorf("log for #%s: %w", id1, err)
 	}
-	log2, err := client.GetBuildLog(context.Background(), id2)
+	log2, err := client.GetBuildLog(ctx, id2)
 	if err != nil {
 		return fmt.Errorf("log for #%s: %w", id2, err)
 	}

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -70,7 +70,7 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), opts.timeout)
+	ctx, cancel := context.WithTimeout(f.Context(), opts.timeout)
 	defer cancel()
 
 	flatList, totalSize, err := fetchAllArtifacts(ctx, client, runID, opts.path)

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -112,7 +111,7 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 		return browser.OpenURL(url)
 	}
 
-	runs, err := client.GetBuilds(context.Background(), request.builds)
+	runs, err := client.GetBuilds(f.Context(), request.builds)
 	if err != nil {
 		return err
 	}
@@ -394,7 +393,7 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 		return err
 	}
 
-	build, err := client.GetBuild(context.Background(), runID)
+	build, err := client.GetBuild(f.Context(), runID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"os/signal"
 	"strconv"
 	"strings"
 	"time"
@@ -201,7 +199,7 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 		if opts.follow {
 			state = "any"
 		}
-		runs, err := client.GetBuilds(context.Background(), api.BuildsOptions{
+		runs, err := client.GetBuilds(f.Context(), api.BuildsOptions{
 			BuildTypeID: opts.job,
 			State:       state,
 			Limit:       1,
@@ -224,7 +222,7 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 	}
 
 	if opts.web {
-		build, err := client.GetBuild(context.Background(), runID)
+		build, err := client.GetBuild(f.Context(), runID)
 		if err != nil {
 			return err
 		}
@@ -250,7 +248,7 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 }
 
 func runLogFull(f *cmdutil.Factory, client api.ClientInterface, runID string, opts *runLogOptions) error {
-	log, err := client.GetBuildLog(context.Background(), runID)
+	log, err := client.GetBuildLog(f.Context(), runID)
 	if err != nil {
 		return fmt.Errorf("failed to get run log: %w", err)
 	}
@@ -283,7 +281,7 @@ func runLogFull(f *cmdutil.Factory, client api.ClientInterface, runID string, op
 }
 
 func runLogTail(f *cmdutil.Factory, client api.ClientInterface, runID string, opts *runLogOptions) error {
-	resp, err := client.GetBuildMessages(context.Background(), runID, api.BuildMessagesOptions{
+	resp, err := client.GetBuildMessages(f.Context(), runID, api.BuildMessagesOptions{
 		Count:     -opts.tail,
 		Tail:      true,
 		ExpandAll: true,
@@ -318,27 +316,20 @@ func printMessages(f *cmdutil.Factory, runID string, messages []api.BuildMessage
 	return nil
 }
 
-func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, opts *runLogOptions) error {
+func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, opts *runLogOptions) (resErr error) {
 	p := f.Printer
+	ctx := f.Context()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-	defer signal.Stop(sigCh)
-	go func() {
-		select {
-		case <-sigCh:
-			_, _ = fmt.Fprintln(p.Out)
-			if !opts.json {
-				_, _ = fmt.Fprintln(p.Out, output.Faint("Interrupted. Run continues in background."))
-				p.Tip("Resume: teamcity run log -f %s", runID)
-			}
-			cancel()
-		case <-ctx.Done():
+	defer func() {
+		if ctx.Err() == nil {
 			return
 		}
+		if !opts.json {
+			_, _ = fmt.Fprintln(p.Out)
+			_, _ = fmt.Fprintln(p.Out, output.Faint("Interrupted. Run continues in background."))
+			p.Tip("Resume: teamcity run log -f %s", runID)
+		}
+		resErr = nil
 	}()
 
 	initialTail := defaultFollowTail
@@ -350,7 +341,7 @@ func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 		return err
 	}
 
-	resp, err := client.GetBuildMessages(context.Background(), runID, api.BuildMessagesOptions{
+	resp, err := client.GetBuildMessages(ctx, runID, api.BuildMessagesOptions{
 		Count:     -initialTail,
 		Tail:      true,
 		ExpandAll: true,
@@ -369,12 +360,12 @@ func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 		printFollowMessage(p.Out, msg, showVerbose, opts.raw, opts.json)
 	}
 
-	build, err := client.GetBuild(context.Background(), runID)
+	build, err := client.GetBuild(ctx, runID)
 	if err != nil {
 		return err
 	}
 	if build.State == "finished" {
-		return buildFinishedResult(p, client, build, opts.json)
+		return buildFinishedResult(ctx, p, client, build, opts.json)
 	}
 
 	for {
@@ -384,14 +375,14 @@ func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 		case <-time.After(followPollInterval):
 		}
 
-		resp, err := client.GetBuildMessages(context.Background(), runID, api.BuildMessagesOptions{
+		resp, err := client.GetBuildMessages(ctx, runID, api.BuildMessagesOptions{
 			Count:     -followFetchWindow,
 			Tail:      true,
 			ExpandAll: true,
 		})
 		if err != nil {
-			if build, err := client.GetBuild(context.Background(), runID); err == nil && build.State == "finished" {
-				return buildFinishedResult(p, client, build, opts.json)
+			if build, err := client.GetBuild(ctx, runID); err == nil && build.State == "finished" {
+				return buildFinishedResult(ctx, p, client, build, opts.json)
 			}
 			continue
 		}
@@ -417,12 +408,12 @@ func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 			printFollowMessage(p.Out, msg, showVerbose, opts.raw, opts.json)
 		}
 
-		build, err := client.GetBuild(context.Background(), runID)
+		build, err := client.GetBuild(ctx, runID)
 		if err != nil {
 			continue
 		}
 		if build.State == "finished" {
-			finalResp, err := client.GetBuildMessages(context.Background(), runID, api.BuildMessagesOptions{
+			finalResp, err := client.GetBuildMessages(ctx, runID, api.BuildMessagesOptions{
 				Count:     -followFetchWindow,
 				Tail:      true,
 				ExpandAll: true,
@@ -435,13 +426,13 @@ func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 					printFollowMessage(p.Out, msg, showVerbose, opts.raw, opts.json)
 				}
 			}
-			return buildFinishedResult(p, client, build, opts.json)
+			return buildFinishedResult(ctx, p, client, build, opts.json)
 		}
 	}
 }
 
 func waitForBuildStart(ctx context.Context, p *output.Printer, client api.ClientInterface, runID string, jsonOut bool) error {
-	build, err := client.GetBuild(context.Background(), runID)
+	build, err := client.GetBuild(ctx, runID)
 	if err != nil {
 		return err
 	}
@@ -460,7 +451,7 @@ func waitForBuildStart(ctx context.Context, p *output.Printer, client api.Client
 		case <-time.After(followPollInterval):
 		}
 
-		build, err = client.GetBuild(context.Background(), runID)
+		build, err = client.GetBuild(ctx, runID)
 		if err != nil {
 			return err
 		}
@@ -491,7 +482,7 @@ func printFollowMessage(w io.Writer, msg api.BuildMessage, showVerbose, raw, jso
 	}
 }
 
-func buildFinishedResult(p *output.Printer, client api.ClientInterface, build *api.Build, jsonOut bool) error {
+func buildFinishedResult(ctx context.Context, p *output.Printer, client api.ClientInterface, build *api.Build, jsonOut bool) error {
 	if jsonOut {
 		switch build.Status {
 		case "SUCCESS":
@@ -503,7 +494,7 @@ func buildFinishedResult(p *output.Printer, client api.ClientInterface, build *a
 		}
 	}
 	_, _ = fmt.Fprintln(p.Out)
-	return cmdutil.BuildResultError(context.Background(), p, client, build, true)
+	return cmdutil.BuildResultError(ctx, p, client, build, true)
 }
 
 func messageToJSON(msg api.BuildMessage) string {
@@ -515,7 +506,7 @@ func messageToJSON(msg api.BuildMessage) string {
 }
 
 func runLogFailed(f *cmdutil.Factory, client api.ClientInterface, runID string, jsonOut bool) error {
-	build, err := client.GetBuild(context.Background(), runID)
+	build, err := client.GetBuild(f.Context(), runID)
 	if err != nil {
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
@@ -533,7 +524,7 @@ func runLogFailed(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 			summary.Problems = problems.ProblemOccurrence
 		}
 		if build.Status != "SUCCESS" {
-			if tests, err := client.GetBuildTests(context.Background(), runID, true, 0); err == nil {
+			if tests, err := client.GetBuildTests(f.Context(), runID, true, 0); err == nil {
 				summary.Tests = tests
 			}
 		}
@@ -544,6 +535,6 @@ func runLogFailed(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 		f.Printer.Success("Build %d  #%s succeeded", build.ID, build.Number)
 		return nil
 	}
-	cmdutil.PrintFailureSummary(context.Background(), f.Printer, client, runID, build.Number, build.WebURL, build.StatusText)
+	cmdutil.PrintFailureSummary(f.Context(), f.Printer, client, runID, build.Number, build.WebURL, build.StatusText)
 	return nil
 }

--- a/internal/cmd/run/restart.go
+++ b/internal/cmd/run/restart.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -48,7 +47,7 @@ func runRunRestart(f *cmdutil.Factory, runID string, opts *runRestartOptions) er
 		return err
 	}
 
-	originalBuild, err := client.GetBuild(context.Background(), runID)
+	originalBuild, err := client.GetBuild(f.Context(), runID)
 	if err != nil {
 		return fmt.Errorf("failed to get run: %w", err)
 	}

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -53,12 +53,12 @@ type reuseDep struct {
 	err   error
 }
 
-func fetchReuseDeps(client api.ClientInterface, ids []int) []reuseDep {
+func fetchReuseDeps(ctx context.Context, client api.ClientInterface, ids []int) []reuseDep {
 	out := make([]reuseDep, len(ids))
 	var wg sync.WaitGroup
 	for i, id := range ids {
 		wg.Go(func() {
-			b, err := client.GetBuild(context.Background(), strconv.Itoa(id))
+			b, err := client.GetBuild(ctx, strconv.Itoa(id))
 			out[i] = reuseDep{id: id, build: b, err: err}
 		})
 	}
@@ -255,7 +255,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 			_, _ = fmt.Fprintln(p.Out, "  Rebuild dependencies: yes")
 		}
 		if len(opts.reuseDeps) > 0 {
-			printReuseDeps(p, fetchReuseDeps(client, opts.reuseDeps))
+			printReuseDeps(p, fetchReuseDeps(f.Context(), client, opts.reuseDeps))
 		}
 		if opts.queueAtTop {
 			_, _ = fmt.Fprintln(p.Out, "  Queue at top: yes")
@@ -365,7 +365,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		p.Info("  Tags: %s", strings.Join(opts.tags, ", "))
 	}
 	if len(opts.reuseDeps) > 0 {
-		printReuseDeps(p, fetchReuseDeps(client, opts.reuseDeps))
+		printReuseDeps(p, fetchReuseDeps(f.Context(), client, opts.reuseDeps))
 	}
 	p.Info("  URL: %s", build.WebURL)
 	if opts.agent > 0 {

--- a/internal/cmd/run/tree.go
+++ b/internal/cmd/run/tree.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"context"
 	"fmt"
 	"maps"
 	"strconv"
@@ -66,7 +65,7 @@ func runRunTree(f *cmdutil.Factory, runID string, depth int, jsonOut bool) error
 		return err
 	}
 
-	build, err := client.GetBuild(context.Background(), runID)
+	build, err := client.GetBuild(f.Context(), runID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/signal"
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmd/run/tui"
@@ -60,7 +58,7 @@ For a simpler, pipe-friendly log stream, use "teamcity run log --follow" instead
 	return cmd
 }
 
-func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
+func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) (resErr error) {
 	p := f.Printer
 	if f.Quiet {
 		opts.quiet = true
@@ -74,9 +72,8 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 		return err
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+	topCtx := f.Context()
+	ctx := topCtx
 	if opts.timeout > 0 {
 		var timeoutCancel context.CancelFunc
 		ctx, timeoutCancel = context.WithTimeout(ctx, opts.timeout)
@@ -90,24 +87,19 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) error {
 		p.Warn("--logs requires a TTY; falling back to standard watch mode")
 	}
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, os.Interrupt)
-	defer signal.Stop(sigCh)
-	go func() {
-		select {
-		case <-sigCh:
-			if !opts.json {
-				_, _ = fmt.Fprintln(p.Out)
-			}
-			if !opts.quiet && !opts.json {
-				_, _ = fmt.Fprintln(p.Out)
-				_, _ = fmt.Fprintln(p.Out, output.Faint("Interrupted. Run continues in background."))
-				p.Tip("Resume watching: teamcity run watch %s", runID)
-			}
-			cancel()
-		case <-ctx.Done():
+	defer func() {
+		if topCtx.Err() == nil {
 			return
 		}
+		if !opts.json {
+			_, _ = fmt.Fprintln(p.Out)
+		}
+		if !opts.quiet && !opts.json {
+			_, _ = fmt.Fprintln(p.Out)
+			_, _ = fmt.Fprintln(p.Out, output.Faint("Interrupted. Run continues in background."))
+			p.Tip("Resume watching: teamcity run watch %s", runID)
+		}
+		resErr = nil
 	}()
 
 	build, err := client.GetBuild(ctx, runID)

--- a/internal/cmd/update/update.go
+++ b/internal/cmd/update/update.go
@@ -1,7 +1,6 @@
 package update
 
 import (
-	"context"
 	"fmt"
 	"time"
 
@@ -35,7 +34,7 @@ func runUpdate(f *cmdutil.Factory) error {
 
 	p.Info("Checking for updates...")
 
-	release, err := update.LatestRelease(context.Background())
+	release, err := update.LatestRelease(f.Context())
 	if err != nil {
 		return fmt.Errorf("failed to check for updates: %w", err)
 	}

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -26,12 +27,12 @@ func (f *Factory) defaultGetClient() (api.ClientInterface, error) {
 			)
 		}
 		f.Printer.Debug("Using guest authentication")
-		return api.NewGuestClient(serverURL, opts...), nil
+		return api.NewGuestClient(serverURL, opts...).WithContext(f.Context()), nil
 	}
 
 	if serverURL != "" && token != "" {
 		f.WarnInsecureHTTP(serverURL, "authentication token")
-		return api.NewClient(serverURL, token, opts...), nil
+		return api.NewClient(serverURL, token, opts...).WithContext(f.Context()), nil
 	}
 
 	if buildAuth, ok := config.GetBuildAuth(); ok {
@@ -40,32 +41,31 @@ func (f *Factory) defaultGetClient() (api.ClientInterface, error) {
 		}
 		f.Printer.Debug("Using build-level authentication")
 		f.WarnInsecureHTTP(serverURL, "credentials")
-		return api.NewClientWithBasicAuth(serverURL, buildAuth.Username, buildAuth.Password, opts...), nil
+		return api.NewClientWithBasicAuth(serverURL, buildAuth.Username, buildAuth.Password, opts...).WithContext(f.Context()), nil
 	}
 
-	return nil, NotAuthenticatedError(serverURL, keyringErr)
+	return nil, NotAuthenticatedError(f.Context(), serverURL, keyringErr)
 }
 
-// ProbeGuestAccess checks whether the server at serverURL supports guest access.
-func ProbeGuestAccess(serverURL string) bool {
+// ProbeGuestAccess checks whether the server at serverURL supports guest access; honors ctx for cancellation.
+func ProbeGuestAccess(ctx context.Context, serverURL string) bool {
 	if serverURL == "" {
 		return false
 	}
-	guest := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
+	guest := api.NewGuestClient(serverURL, api.WithVersion(version.String())).WithContext(ctx)
 	_, err := guest.GetServer()
 	return err == nil
 }
 
-// NotAuthenticatedError returns a not-authenticated error with a hint that covers
-// all authentication methods: environment variables, interactive login, and guest access.
-func NotAuthenticatedError(serverURL string, keyringErr error) *api.ValidationError {
+// NotAuthenticatedError returns a not-authenticated error with a hint that covers all authentication methods.
+func NotAuthenticatedError(ctx context.Context, serverURL string, keyringErr error) *api.ValidationError {
 	msg := "Not authenticated"
 	if keyringErr != nil {
 		msg = fmt.Sprintf("Not authenticated (could not access system keyring: %v)", keyringErr)
 	}
 
 	suggestion := "If you use environment overrides, set both TEAMCITY_URL and TEAMCITY_TOKEN; TEAMCITY_URL alone bypasses stored credentials. Otherwise unset TEAMCITY_URL to use stored auth, or run 'teamcity auth login --insecure-storage'"
-	if ProbeGuestAccess(serverURL) {
+	if ProbeGuestAccess(ctx, serverURL) {
 		suggestion += ", or set TEAMCITY_GUEST=1 for guest access"
 	}
 

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"context"
 	"io"
 	"os"
 
@@ -46,6 +47,9 @@ type Factory struct {
 
 	// UpdateNotice is called after command execution to print update notices.
 	UpdateNotice func()
+
+	// ctx is the signal-aware root context set by cmd.Execute; read via Context(), unset falls back to Background.
+	ctx context.Context
 }
 
 // NewFactory creates a Factory with production defaults.
@@ -84,4 +88,17 @@ func (f *Factory) InitOutput() {
 // IsInteractive returns true if the CLI can prompt the user.
 func (f *Factory) IsInteractive() bool {
 	return !f.NoInput && output.IsStdinTerminal()
+}
+
+// Context returns the Factory's root context; use this everywhere in our code rather than cmd.Context().
+func (f *Factory) Context() context.Context {
+	if f.ctx == nil {
+		return context.Background()
+	}
+	return f.ctx
+}
+
+// SetContext installs the signal-cancel root context; cmd.Execute keeps rootCmd's Cobra context in sync as a safety net.
+func (f *Factory) SetContext(ctx context.Context) {
+	f.ctx = ctx
 }

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -116,18 +116,15 @@ func Check(ctx context.Context) *ReleaseInfo {
 
 const noticeWait = 500 * time.Millisecond
 
-// CheckInBackground starts an update check in a goroutine and returns a
-// function that, when called, waits briefly for the result and prints a
-// one-line notice if a new version is available. The wait is bounded so
-// slow networks don't delay command exit.
-func CheckInBackground(w io.Writer, quiet bool) func() {
+// CheckInBackground starts an update check in a goroutine and returns a function that waits briefly for the result and prints a one-line notice if a new version is available.
+func CheckInBackground(ctx context.Context, w io.Writer, quiet bool) func() {
 	if IsDisabled() || quiet {
 		return func() {}
 	}
 
 	done := make(chan *ReleaseInfo, 1)
 	go func() {
-		done <- Check(context.Background())
+		done <- Check(ctx)
 	}()
 
 	return func() {
@@ -137,7 +134,7 @@ func CheckInBackground(w io.Writer, quiet bool) func() {
 				PrintNotice(w, version.Version, release)
 			}
 		case <-time.After(noticeWait):
-			// Don't delay exit — the check will be cached next time.
+		case <-ctx.Done():
 		}
 	}
 }

--- a/tc/main.go
+++ b/tc/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
+	"os/signal"
 	"runtime/debug"
+	"syscall"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -29,7 +32,10 @@ func run() (exitCode int) {
 		return 1
 	}
 
-	if err := cmd.Execute(); err != nil {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if err := cmd.Execute(ctx); err != nil {
 		if exitErr, ok := errors.AsType[*cmdutil.ExitError](err); ok {
 			return exitErr.Code
 		}


### PR DESCRIPTION
## Summary

Wires `signal.NotifyContext` from `main.go` through the Cobra root into every HTTP request so SIGINT/SIGTERM aborts in-flight work cleanly. User-visible: Ctrl+C now actually cancels long requests (log follow, watch, artifact download, multi-server `auth status`, long paginated lists) instead of hanging until the per-request HTTP timeout.

## Changes

**Core plumbing**
- `tc/main.go`: `signal.NotifyContext(ctx, SIGINT, SIGTERM)` + `cmd.Execute(ctx)`.
- `internal/cmd/root.go`: `Execute` now takes `ctx`; sets it on both `*cmdutil.Factory` (via `f.SetContext`) and `rootCmd` (via `SetContext`, as a Cobra-ecosystem safety net); root-level `context.Canceled` suppression so Ctrl+C exits cleanly across every command (no more ugly `Error: … context canceled` lines).
- `internal/cmdutil/factory.go`: new `Context()` / `SetContext(ctx)` pair; godoc documents `f.Context()` as the single source of truth for our code.
- `internal/cmdutil/client.go`: `defaultGetClient` binds `f.Context()` onto every constructed Client via `.WithContext(...)`.

**`api/` (no public signature break)**
- `api.Client` gains unexported `baseCtx` + `WithContext(ctx) *Client` (shallow copy, mirrors `http.Request.WithContext`) + `ctx()` helper.
- 105 `context.Background()` calls in non-ctx-taking `*Client` methods → `c.ctx()`.
- Moved `sync.Once`-based server-version cache behind a `*serverInfoCache` pointer so `WithContext` copies share the cache and don't trip `go vet` on copied `sync.Once`.

**Long-running commands**
- `run log --follow` and `run watch`: dropped the bespoke `signal.Notify` goroutines (redundant with `NotifyContext`); replaced with named-return + `defer` that prints "Interrupted. Run continues in background." when `f.Context()` is done, swallowing the cancel as a clean exit.
- `runPkceLogin`: `select` gains `<-parent.Done()` case so Ctrl+C during browser auth returns immediately instead of waiting out `authCodeLifetime`.
- `update.CheckInBackground(ctx, ...)`: the up-to-500ms wait for the notice now returns immediately on cancel.

**Call-site fixes**
- 46 `context.Background()` sites in `internal/cmd/` → `f.Context()` or threaded `ctx` param (added ctx param to 8 helpers that lacked one: `fetchReuseDeps`, `fetchAllPages`, `runAPIPaginated`, `resolveDiffBuildIDs`, `fetchBuildData`, `fetchBothBuilds`, `runPkceLogin`, `buildFinishedResult`).
- `auth/status.go`: the S1 fan-out's 3 Client constructors (`collectGuestStatus`, `collectTokenStatus`, `collectBuildStatus`) now `.WithContext(f.Context())` — previously a slow server would hang `teamcity auth status` uncancellably.
- `auth/login.go`: the 2 validation Client constructors bind ctx.
- `ProbeGuestAccess` + `NotAuthenticatedError`: take `ctx` param; threaded from all 4 callers (`defaultGetClient`, `connectToAgent`, `renderCredentialsDiagnostic`, `renderDSLTip`).
- Pre-existing `cmd.Context()` calls in `agent/` converted to `f.Context()` for consistency.

**Docs**
- `CONTRIBUTING.md` gains a 4-bullet "Context" subsection under Go conventions encoding the rule: `f.Context()` everywhere, `api/` new Client constructors must chain `.WithContext`, `context.Background()` is reserved for `main.go` and lifecycle-bounded internals.

## Design Decisions

**Why not break `api/` public signatures?** The canonical Go answer is to add `ctx context.Context` as the first parameter to all 102 `*Client` methods. I considered and rejected that because (a) zero user-visible benefit beyond what the Client-holds-ctx pattern already delivers, (b) would require updating every `ClientInterface` consumer and every test mock, (c) pre-v1.0 framing only helps for `api/` (the public surface), but the breaking change costs the same post-v1.0 if we ever want it.

**Why `f.Context()` instead of threading `ctx` as an explicit helper param?** Similar reasoning — the consolidation (~150-250 LoC of mechanical churn across ~50 files, adding `ctx` to every `runX(f, ...)` and `f.Client()` call) has no behavioral benefit. The Factory is already a bag of contextual deps (`f.Printer`, `f.Client`, etc.); adding `ctx` to that bag fits the surrounding style. Documented rule in `CONTRIBUTING.md` makes the convention explicit.

**Why keep `rootCmd.SetContext(ctx)` if we never call `cmd.Context()`?** Safety net. If a future contributor writes idiomatic Cobra (`ctx := cmd.Context()` in a RunE) and passes that into a ctx-taking method like `client.GetBuild(ctx, ...)`, the method uses the caller's ctx and bypasses the Client's bound `baseCtx`. Without the sync, they'd silently lose signal cancellation. One line to prevent a sharp edge.

**Why a `*serverInfoCache` pointer instead of embedding?** `go vet` correctly flagged that the `WithContext` shallow copy would copy a `sync.Once`. Putting the cache behind a pointer means copies share it (which is what we want anyway — avoid re-fetching on per-call ctx overrides).

**Root-level `context.Canceled` suppression vs. per-function defer pattern.** Both exist and are complementary. The defer in `runLogFollow`/`doRunWatch` prints the command-specific "Run continues in background." tip and clears the error *before* it propagates. The root-level check at `cmd.Execute` is a backstop for every other command — on Ctrl+C, `err` wraps `context.Canceled` and `ctx.Err() != nil`, so we return nil (clean exit, code 0). `errors.Is(err, context.Canceled)` doesn't match `*cmdutil.ExitError`, so exit codes for genuine build failures are preserved.

## Example

Before — `teamcity auth status` with one unresponsive server, user hits Ctrl+C: process hangs up to 30 s per server (HTTP default timeout), then prints partial results.

After — Ctrl+C aborts all in-flight probes in parallel and exits cleanly with no error output.

Same story for `run log --follow`, `run watch`, `run download`, `run diff`, `run list` on a slow paginated response, and any `teamcity api …` call.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — 0 issues
- [ ] Acceptance tests pass (`just acceptance`) — not run locally, CI will cover
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, no new surface
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A, no JSON changes
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — added a "Context" subsection to `CONTRIBUTING.md`; no user-facing docs affected since command surface is unchanged