### PR TITLE
fix(run): consistent @this/@head sigils across run list and run start

### DIFF
--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -320,6 +320,9 @@ teamcity run start MyProject_Build
 # Build a specific branch
 teamcity run start MyProject_Build --branch feature/login
 
+# Build the branch you are currently on
+teamcity run start MyProject_Build --branch @this
+
 # Pin to a specific Git commit
 teamcity run start MyProject_Build --branch main --revision abc123def
 ```
@@ -432,7 +435,7 @@ Description
 </td>
 <td>
 
-Branch to build
+Branch to build. Use `@this` to resolve the current git branch.
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -325,6 +325,9 @@ teamcity run start MyProject_Build --branch @this
 
 # Pin to a specific Git commit
 teamcity run start MyProject_Build --branch main --revision abc123def
+
+# Pin to the current HEAD
+teamcity run start MyProject_Build --branch @this --revision @head
 ```
 
 ### Build parameters
@@ -447,7 +450,7 @@ Branch to build. Use `@this` to resolve the current git branch.
 </td>
 <td>
 
-Pin build to a specific Git commit SHA
+Pin build to a specific Git commit SHA. Use `@head` to resolve the current HEAD; short SHAs are expanded from the local repo.
 
 </td>
 </tr>

--- a/internal/cmd/run/cancel.go
+++ b/internal/cmd/run/cancel.go
@@ -33,7 +33,7 @@ in the TeamCity UI.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.comment, "comment", "", "Comment for cancellation")
+	cmd.Flags().StringVarP(&opts.comment, "comment", "m", "", "Comment for cancellation")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
 	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")

--- a/internal/cmd/run/git.go
+++ b/internal/cmd/run/git.go
@@ -1,11 +1,45 @@
 package run
 
 import (
+	"errors"
 	"os/exec"
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
 )
+
+var (
+	isGitRepoFn       = isGitRepo
+	currentBranchFn   = getCurrentBranch
+	headRevisionFn    = getHeadRevision
+	resolveRevisionFn = resolveRevision
+)
+
+// resolveBranchFlag turns "@this" into the current git branch. Other values pass through.
+func resolveBranchFlag(branch string) (string, error) {
+	if !strings.EqualFold(branch, "@this") {
+		return branch, nil
+	}
+	if !isGitRepoFn() {
+		return "", errors.New("--branch @this requires a git repository")
+	}
+	return currentBranchFn()
+}
+
+// resolveRevisionFlag turns "@head" into the current HEAD SHA and expands short SHAs to full ones.
+// Values of 40+ chars pass through unchanged, as do empty strings or values when not in a git repo.
+func resolveRevisionFlag(revision string) (string, error) {
+	if strings.EqualFold(revision, "@head") {
+		if !isGitRepoFn() {
+			return "", errors.New("--revision @head requires a git repository")
+		}
+		return headRevisionFn()
+	}
+	if revision != "" && len(revision) < 40 && isGitRepoFn() {
+		return resolveRevisionFn(revision)
+	}
+	return revision, nil
+}
 
 func isGitRepo() bool {
 	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")

--- a/internal/cmd/run/git.go
+++ b/internal/cmd/run/git.go
@@ -26,8 +26,7 @@ func resolveBranchFlag(branch string) (string, error) {
 	return currentBranchFn()
 }
 
-// resolveRevisionFlag turns "@head" into the current HEAD SHA and expands short SHAs to full ones.
-// Values of 40+ chars pass through unchanged, as do empty strings or values when not in a git repo.
+// resolveRevisionFlag resolves "@head" to the current HEAD SHA and expands short SHAs from the local repo.
 func resolveRevisionFlag(revision string) (string, error) {
 	if strings.EqualFold(revision, "@head") {
 		if !isGitRepoFn() {

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -17,10 +16,7 @@ import (
 )
 
 var runListConfigCurrentUserFn = config.GetCurrentUser
-var runListAPICurrentUserFn = func(client api.ClientInterface) (*api.User, error) { return client.GetCurrentUser() }
-var runListIsGitRepoFn = isGitRepo
-var runListCurrentBranchFn = getCurrentBranch
-var runListHeadRevisionFn = getHeadRevision // used in tests
+var runListAPICurrentUserFn = func(client api.ClientInterface) (*api.User, error) { return client.GetCurrentUser() } // used in tests
 
 type runListOptions struct {
 	job        string
@@ -207,7 +203,7 @@ func resolveRunListRequest(client api.ClientInterface, opts *runListOptions, fie
 		return nil, err
 	}
 
-	branch, err := resolveRunListBranch(opts)
+	branch, err := resolveBranchFlag(opts.branch)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +218,7 @@ func resolveRunListRequest(client api.ClientInterface, opts *runListOptions, fie
 		return nil, err
 	}
 
-	revision, err := resolveRunListRevision(opts)
+	revision, err := resolveRevisionFlag(opts.revision)
 	if err != nil {
 		return nil, err
 	}
@@ -269,23 +265,6 @@ func resolveCurrentAuthenticatedUser(client api.ClientInterface, source string) 
 	return u.Username, nil
 }
 
-func resolveRunListBranch(opts *runListOptions) (string, error) {
-	if strings.EqualFold(opts.branch, "@this") {
-		return resolveAutoBranch(true)
-	}
-	return opts.branch, nil
-}
-
-func resolveAutoBranch(required bool) (string, error) {
-	if !runListIsGitRepoFn() {
-		if required {
-			return "", errors.New("--branch @this requires a git repository")
-		}
-		return "", nil
-	}
-	return runListCurrentBranchFn()
-}
-
 func resolveRunListStatus(status string) (statusFilter, stateFilter string, err error) {
 	if status == "" {
 		return "", "", nil
@@ -330,21 +309,6 @@ func resolveRunListDateRange(opts *runListOptions) (sinceDate, untilDate string,
 	}
 
 	return sinceDate, untilDate, nil
-}
-
-var runListResolveRevisionFn = resolveRevision
-
-func resolveRunListRevision(opts *runListOptions) (string, error) {
-	if strings.EqualFold(opts.revision, "@head") {
-		if !runListIsGitRepoFn() {
-			return "", errors.New("--revision @head requires a git repository")
-		}
-		return runListHeadRevisionFn()
-	}
-	if opts.revision != "" && len(opts.revision) < 40 && runListIsGitRepoFn() {
-		return runListResolveRevisionFn(opts.revision)
-	}
-	return opts.revision, nil
 }
 
 func resolveRunListWebPath(opts *runListOptions) string {

--- a/internal/cmd/run/list_test.go
+++ b/internal/cmd/run/list_test.go
@@ -61,10 +61,10 @@ func TestResolveRunListRequestAtMeFallsBackToAPIUser(T *testing.T) {
 }
 
 func TestResolveRunListRequestBranchThisRequiresGitRepo(T *testing.T) {
-	oldIsGitRepo := runListIsGitRepoFn
-	T.Cleanup(func() { runListIsGitRepoFn = oldIsGitRepo })
+	oldIsGitRepo := isGitRepoFn
+	T.Cleanup(func() { isGitRepoFn = oldIsGitRepo })
 
-	runListIsGitRepoFn = func() bool { return false }
+	isGitRepoFn = func() bool { return false }
 
 	_, err := resolveRunListRequest(nil, &runListOptions{
 		branch: "@this",
@@ -75,15 +75,15 @@ func TestResolveRunListRequestBranchThisRequiresGitRepo(T *testing.T) {
 }
 
 func TestResolveRunListRequestRevisionAtHead(T *testing.T) {
-	oldIsGitRepo := runListIsGitRepoFn
-	oldHeadRevision := runListHeadRevisionFn
+	oldIsGitRepo := isGitRepoFn
+	oldHeadRevision := headRevisionFn
 	T.Cleanup(func() {
-		runListIsGitRepoFn = oldIsGitRepo
-		runListHeadRevisionFn = oldHeadRevision
+		isGitRepoFn = oldIsGitRepo
+		headRevisionFn = oldHeadRevision
 	})
 
-	runListIsGitRepoFn = func() bool { return true }
-	runListHeadRevisionFn = func() (string, error) { return "deadbeef12345678", nil }
+	isGitRepoFn = func() bool { return true }
+	headRevisionFn = func() (string, error) { return "deadbeef12345678", nil }
 
 	req, err := resolveRunListRequest(nil, &runListOptions{
 		revision: "@head",
@@ -94,10 +94,10 @@ func TestResolveRunListRequestRevisionAtHead(T *testing.T) {
 }
 
 func TestResolveRunListRequestRevisionAtHeadRequiresGitRepo(T *testing.T) {
-	oldIsGitRepo := runListIsGitRepoFn
-	T.Cleanup(func() { runListIsGitRepoFn = oldIsGitRepo })
+	oldIsGitRepo := isGitRepoFn
+	T.Cleanup(func() { isGitRepoFn = oldIsGitRepo })
 
-	runListIsGitRepoFn = func() bool { return false }
+	isGitRepoFn = func() bool { return false }
 
 	_, err := resolveRunListRequest(nil, &runListOptions{
 		revision: "@head",

--- a/internal/cmd/run/local_changes.go
+++ b/internal/cmd/run/local_changes.go
@@ -32,7 +32,7 @@ func (v *localChangesValue) Type() string {
 func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 	switch source {
 	case "git":
-		if !isGitRepo() {
+		if !isGitRepoFn() {
 			return nil, api.Validation(
 				"not a git repository",
 				"Run this command from within a git repository, or use --local-changes <path> to specify a diff file",

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -159,6 +159,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		Example: `  teamcity run start Falcon_Build
   teamcity run start Falcon_Build --branch feature/test
+  teamcity run start Falcon_Build --branch @this
   teamcity run start Falcon_Build -P version=1.0 -S build.number=123 -E CI=true
   teamcity run start Falcon_Build --comment "Release build" --tag release --tag v1.0
   teamcity run start Falcon_Build --clean --rebuild-deps --top
@@ -172,7 +173,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch to build")
+	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch to build (or '@this' for current git branch)")
 	cmd.Flags().StringVar(&opts.revision, "revision", "", "Pin to a specific Git commit SHA")
 	cmd.Flags().StringToStringVarP(&opts.params, "param", "P", nil, "Parameters (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.systemProps, "system", "S", nil, "System properties (key=value)")
@@ -200,6 +201,11 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error {
 	p := f.Printer
 	opts.resolve()
+	branch, err := resolveBranchFlag(opts.branch)
+	if err != nil {
+		return err
+	}
+	opts.branch = branch
 	if opts.dryRun {
 		client, err := f.Client()
 		if err != nil {

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -167,6 +167,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run start Falcon_Build --local-changes # personal build with uncommitted Git changes
   teamcity run start Falcon_Build --local-changes changes.patch  # from file
   teamcity run start Falcon_Build --revision abc123def --branch main
+  teamcity run start Falcon_Build --revision @head --branch @this
   teamcity run start Falcon_Build --dry-run`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunStart(f, args[0], opts)
@@ -174,7 +175,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch to build (or '@this' for current git branch)")
-	cmd.Flags().StringVar(&opts.revision, "revision", "", "Pin to a specific Git commit SHA")
+	cmd.Flags().StringVar(&opts.revision, "revision", "", "Pin to a specific Git commit SHA (or '@head' for current HEAD)")
 	cmd.Flags().StringToStringVarP(&opts.params, "param", "P", nil, "Parameters (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.systemProps, "system", "S", nil, "System properties (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.envVars, "env", "E", nil, "Environment variables (key=value)")
@@ -206,6 +207,11 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		return err
 	}
 	opts.branch = branch
+	revision, err := resolveRevisionFlag(opts.revision)
+	if err != nil {
+		return err
+	}
+	opts.revision = revision
 	if opts.dryRun {
 		client, err := f.Client()
 		if err != nil {

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -279,13 +279,13 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 	}
 
 	if opts.localChanges != "" && opts.branch == "" {
-		if !isGitRepo() {
+		if !isGitRepoFn() {
 			return api.Validation(
 				"not a git repository",
 				"Run this command from within a git repository, or specify --branch explicitly",
 			)
 		}
-		branch, err := getCurrentBranch()
+		branch, err := currentBranchFn()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

`run list --branch @this` and `run list --revision @head` worked, but the same sigils on `run start` did not

## Changes

- **`run start --branch @this`** — resolves to the current git branch, matching `run list`.
- **`run start --revision @head`** — resolves to the current HEAD SHA.
- **`run start --revision <short-sha>`** — expanded to the full SHA via `git rev-parse`, matching `run list`.
- **`run cancel --comment` gets `-m` short flag** — matches `run start` and `run pin`, which already mapped `-m` to `--comment`.
- **Shared plumbing** — sigil resolvers (`resolveBranchFlag`, `resolveRevisionFlag`) and their overridable git helpers (`isGitRepoFn`, `currentBranchFn`, `headRevisionFn`, `resolveRevisionFn`) moved from `list.go` to `git.go` so any command in the `run` package can reuse them. Removed the list-only wrappers (`resolveRunListBranch`, `resolveAutoBranch`, `resolveRunListRevision`).
- **Testability** — `run start`'s local-changes branch auto-detect and `loadLocalChanges` now go through the overridable mock vars instead of calling `isGitRepo` / `getCurrentBranch` directly.
- **Docs** — `docs/topics/teamcity-cli-managing-runs.md` updated with `@this` / `@head` mentions and a live example for `run start`.

## Design Decisions

Kept two callsite shapes (`run list` returns the resolved value for its request struct; `run start` writes back to `opts`) rather than forcing one unified wrapper. The shared core is a single pair of functions in `git.go`; the two-line dispatch at each callsite is clearer than an abstraction built to paper over the signature mismatch.

## Example

```bash
# Trigger a run on the branch you're currently on
teamcity run start MyProject_Build --branch @this

# Pin to the current HEAD
teamcity run start MyProject_Build --branch @this --revision @head

# Short-SHA expansion (previously silently ignored, now expanded locally)
teamcity run start MyProject_Build --revision abc1234

# -m now works here too
teamcity run cancel 12345 -m "wrong branch"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A (no new flags, only behavior and help text changes to existing flags)
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — `docs/topics/teamcity-cli-managing-runs.md` updated; `skills/` and `README.md` have no `@this` / `@head` / `-m` references to sync