### PR TITLE
fix(config): remove DSL-based server detection for improved security …

### DIFF
--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -220,7 +220,6 @@ func renderAuthStatusHuman(f *cmdutil.Factory, results []authStatus) error {
 		if config.IsBuildEnvironment() {
 			_, _ = fmt.Fprintln(p.Out, "\n"+output.Yellow("!")+" Build environment detected but credentials not found in properties file")
 		}
-		renderDSLTip(f.Context(), p, results)
 		return nil
 	}
 
@@ -236,7 +235,6 @@ func renderAuthStatusHuman(f *cmdutil.Factory, results []authStatus) error {
 		p.Tip("%s", output.TipSwitchDefaultServer())
 	}
 
-	renderDSLTip(f.Context(), p, results)
 	return nil
 }
 
@@ -334,27 +332,6 @@ func renderCredentialsDiagnostic(ctx context.Context, p *output.Printer, s authS
 		output.Cyan("teamcity auth login --server "+s.Server+" --insecure-storage"))
 	if cmdutil.ProbeGuestAccess(ctx, s.Server) {
 		_, _ = fmt.Fprintf(p.Out, "    • Or set %s for read-only guest access\n", output.Cyan("TEAMCITY_GUEST=1"))
-	}
-}
-
-func renderDSLTip(ctx context.Context, p *output.Printer, results []authStatus) {
-	dslURL := config.DetectServerFromDSL()
-	if dslURL == "" {
-		return
-	}
-	for _, s := range results {
-		if s.Server == dslURL {
-			return
-		}
-	}
-	_, _ = fmt.Fprintln(p.Out)
-	_, _ = fmt.Fprintf(p.Out, "%s Commands in this directory target %s (from DSL settings)\n",
-		output.Yellow("!"), output.Cyan(dslURL))
-	loginCmd := output.Cyan("teamcity auth login --server " + dslURL)
-	if cmdutil.ProbeGuestAccess(ctx, dslURL) {
-		_, _ = fmt.Fprintf(p.Out, "  Run %s, or set %s for guest access\n", loginCmd, output.Cyan("TEAMCITY_GUEST=1"))
-	} else {
-		_, _ = fmt.Fprintf(p.Out, "  Run %s to authenticate\n", loginCmd)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,15 +146,11 @@ func keyringService(serverURL string) string {
 	return "tc:" + serverURL
 }
 
+// GetServerURL resolves the target server from TEAMCITY_URL, then the configured default; never from DSL (avoids routing a stored token to an untrusted repo's .teamcity/pom.xml — opt in via `auth login`).
 func GetServerURL() string {
 	if url := os.Getenv(EnvServerURL); url != "" {
 		return NormalizeURL(url)
 	}
-
-	if url := DetectServerFromDSL(); url != "" {
-		return url
-	}
-
 	return cfg.DefaultServer
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -464,7 +464,7 @@ func TestGetServerURLPriority(T *testing.T) {
     </repositories>
 </project>`
 
-	T.Run("env > DSL > config", func(t *testing.T) {
+	T.Run("env > config, DSL never influences routing", func(t *testing.T) {
 		ResetDSLCache()
 		tmpDir := t.TempDir()
 		dslDir := filepath.Join(tmpDir, DefaultDSLDirTeamCity)
@@ -474,19 +474,20 @@ func TestGetServerURLPriority(T *testing.T) {
 		withWorkingDir(t, tmpDir)
 		cfg = &Config{DefaultServer: "https://config.example.com"}
 
-		// Env var takes priority
 		t.Setenv(EnvDSLDir, "")
 		t.Setenv(EnvServerURL, "https://env.example.com")
 		assert.Equal(t, "https://env.example.com", GetServerURL())
 
-		// DSL takes priority over config
+		// Security: a DSL pom.xml in the working tree must NOT hijack the target
+		// server. Without TEAMCITY_URL set, the configured default wins — not the
+		// value scraped from .teamcity/pom.xml.
 		t.Setenv(EnvServerURL, "")
-		ResetDSLCache() // reset cache to re-detect
-		assert.Equal(t, "https://dsl-server.example.com", GetServerURL())
+		ResetDSLCache()
+		assert.Equal(t, "https://config.example.com", GetServerURL(),
+			"DSL pom.xml must not override the configured default server")
 
-		// Falls back to config
 		require.NoError(t, os.RemoveAll(dslDir))
-		ResetDSLCache() // reset cache to re-detect
+		ResetDSLCache()
 		assert.Equal(t, "https://config.example.com", GetServerURL())
 	})
 }

--- a/internal/output/diff.go
+++ b/internal/output/diff.go
@@ -6,7 +6,7 @@ import (
 	"regexp"
 	"strings"
 
-	udiff "github.com/aymanbagabas/go-udiff"
+	"github.com/aymanbagabas/go-udiff"
 )
 
 // UnifiedDiff writes a colored unified diff between two line slices, returns true if they differ.


### PR DESCRIPTION
## Summary

Removes the silent DSL-based server URL fallback in `GetServerURL()`. A `.teamcity/pom.xml` in any untrusted repo under cwd could steer commands (and leak `TEAMCITY_TOKEN`) to an attacker-controlled host. Proper replacement — explicit per-repo binding via `teamcity.toml` — lands in #273.

## Changes

- `internal/config/config.go` — `GetServerURL()` resolves from `TEAMCITY_URL` env → configured default only. No DSL inference.
- `internal/cmd/auth/status.go` — dropped `renderDSLTip`; it also fired a `ProbeGuestAccess` HTTP request to the DSL URL, the same ambient-URL → network-egress pattern.
- `internal/config/config_test.go` — `TestGetServerURLPriority` rewritten as a regression test asserting a DSL `pom.xml` cannot override the configured default.

DSL detection is preserved where the user's intent is explicit:
- `auth login` — prefilled suggestion the user can edit/confirm.
- `project settings validate` — validation output about the DSL itself.

## Design Decisions

Stopgap, not the final shape. #273 replaces DSL-derived routing with an explicit committed `teamcity.toml`, which is the proper fix; this PR just closes the ambient-URL hole in the meantime.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — no new command/flag behavior, existing suite covers this
- [ ] If adding a new command/flag: added \`.txtar\` test — N/A
- [ ] If adding a data-producing command: includes \`--json\` support — N/A
- [ ] If modifying \`--json\` output: no field removals/renames — N/A
- [ ] If changing docs-visible behavior: updated \`docs/\`, \`skills/\`, and \`README.md\` — N/A