### PR TITLE
feat(config): add extra HTTP headers support for proxied servers

### DIFF
--- a/acceptance/testdata/config/extra-headers.txtar
+++ b/acceptance/testdata/config/extra-headers.txtar
@@ -1,0 +1,9 @@
+# Test --header flag and extra_headers config behaviour.
+
+# Invalid header format (missing colon) is rejected before any network request.
+! exec teamcity --header 'CF-Access-Client-Id' run list --no-input
+stderr 'invalid header'
+
+# Valid --header flag is accepted and the command succeeds (server ignores unknown headers).
+exec teamcity --header 'X-Test-Header: test-value' run list --limit 1 --no-input
+! stderr 'invalid header'

--- a/acceptance/testdata/help/help.txtar
+++ b/acceptance/testdata/help/help.txtar
@@ -18,6 +18,7 @@ stdout '--no-color'
 stdout '--quiet'
 stdout '--verbose'
 stdout '--no-input'
+stdout '--header'
 stdout '--version'
 ! stderr .
 

--- a/api/client.go
+++ b/api/client.go
@@ -56,6 +56,9 @@ type Client struct {
 	version     string // CLI version for request headers
 	commandName string // CLI command name for X-TeamCity-Client header
 
+	// extraHeaders are added to every request; set via WithExtraHeaders.
+	extraHeaders map[string]string
+
 	// baseCtx is the default context for methods that don't take one; set via WithContext, nil falls back to Background.
 	baseCtx context.Context
 
@@ -101,7 +104,8 @@ func (c *Client) debugLogHeaders(prefix string, headers http.Header) {
 
 	for _, name := range names {
 		values := headers[name]
-		if sensitiveHeaders[name] {
+		_, isExtra := c.extraHeaders[name]
+		if sensitiveHeaders[name] || isExtra {
 			c.debugLog("%s %s: [REDACTED]", prefix, name)
 		} else {
 			for _, value := range values {
@@ -153,6 +157,22 @@ func WithVersion(v string) ClientOption {
 func WithCommandName(name string) ClientOption {
 	return func(c *Client) {
 		c.commandName = name
+	}
+}
+
+// WithExtraHeaders adds headers to every request made by the client.
+// CLI flag values take precedence over config file values — callers should
+// pass only one source.
+func WithExtraHeaders(headers map[string]string) ClientOption {
+	return func(c *Client) {
+		if len(headers) == 0 {
+			return
+		}
+		canonical := make(map[string]string, len(headers))
+		for k, v := range headers {
+			canonical[http.CanonicalHeaderKey(k)] = v
+		}
+		c.extraHeaders = canonical
 	}
 }
 
@@ -270,6 +290,18 @@ func (c *Client) ctx() context.Context {
 	return c.baseCtx
 }
 
+// applyExtraHeaders extracts extra headers from opts and sets them on req.
+// Used by standalone probes that build raw http.Requests rather than going through Client.
+func applyExtraHeaders(req *http.Request, opts []ClientOption) {
+	tmp := &Client{}
+	for _, opt := range opts {
+		opt(tmp)
+	}
+	for k, v := range tmp.extraHeaders {
+		req.Header.Set(k, v)
+	}
+}
+
 func (c *Client) setAuth(req *http.Request) {
 	if c.guestAuth {
 		return
@@ -355,6 +387,9 @@ func (c *Client) doRequestFull(ctx context.Context, method, path string, body io
 	req.Header.Set("X-TeamCity-Client", c.teamCityClientHeader())
 	if body != nil {
 		req.Header.Set("Content-Type", contentType)
+	}
+	for k, v := range c.extraHeaders {
+		req.Header.Set(k, v)
 	}
 
 	c.debugLogRequest(req)
@@ -540,6 +575,9 @@ func (c *Client) doRawRequest(ctx context.Context, method, path string, body io.
 	req.Header.Set("X-TeamCity-Client", c.teamCityClientHeader())
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
+	}
+	for k, v := range c.extraHeaders {
+		req.Header.Set(k, v)
 	}
 
 	for k, v := range headers {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -988,3 +988,103 @@ func TestReadOnlyMode(T *testing.T) {
 		assert.True(t, client.ReadOnly)
 	})
 }
+
+func TestExtraHeaders(T *testing.T) {
+	T.Parallel()
+
+	T.Run("WithExtraHeaders sends headers on every typed request", func(t *testing.T) {
+		t.Parallel()
+
+		var got http.Header
+		client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(Server{VersionMajor: 2024, VersionMinor: 12})
+		})
+		client = NewClient(client.BaseURL, "token", WithExtraHeaders(map[string]string{
+			"CF-Access-Client-Id":     "team.access",
+			"CF-Access-Client-Secret": "secret123",
+		}))
+
+		_, err := client.GetServer()
+		require.NoError(t, err)
+		assert.Equal(t, "team.access", got.Get("CF-Access-Client-Id"))
+		assert.Equal(t, "secret123", got.Get("CF-Access-Client-Secret"))
+	})
+
+	T.Run("WithExtraHeaders sends headers on RawRequest", func(t *testing.T) {
+		t.Parallel()
+
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		client := NewClient(server.URL, "token", WithExtraHeaders(map[string]string{
+			"X-Custom-Header": "custom-value",
+		}))
+
+		_, err := client.RawRequest(T.Context(), "GET", "/app/rest/server", nil, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "custom-value", got.Get("X-Custom-Header"))
+	})
+
+	T.Run("per-request headers in RawRequest override extra headers", func(t *testing.T) {
+		t.Parallel()
+
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		client := NewClient(server.URL, "token", WithExtraHeaders(map[string]string{
+			"X-Custom-Header": "from-extra",
+		}))
+
+		_, err := client.RawRequest(T.Context(), "GET", "/app/rest/server", nil, map[string]string{
+			"X-Custom-Header": "from-per-request",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "from-per-request", got.Get("X-Custom-Header"))
+	})
+
+	T.Run("nil extra headers cause no error", func(t *testing.T) {
+		t.Parallel()
+
+		client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(Server{VersionMajor: 2024, VersionMinor: 12})
+		})
+		client = NewClient(client.BaseURL, "token", WithExtraHeaders(nil))
+
+		_, err := client.GetServer()
+		assert.NoError(t, err)
+	})
+
+	T.Run("extra header values are redacted in debug output", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		client := NewClient(server.URL, "token",
+			WithExtraHeaders(map[string]string{"Cf-Access-Token": "secret-proxy-token"}),
+			WithDebugFunc(func(format string, args ...any) {
+				fmt.Fprintf(&buf, format+"\n", args...)
+			}),
+		)
+
+		_, _ = client.RawRequest(T.Context(), "GET", "/app/rest/server", nil, nil)
+
+		captured := buf.String()
+		assert.Contains(t, captured, "> Cf-Access-Token: [REDACTED]")
+		assert.NotContains(t, captured, "secret-proxy-token")
+	})
+}

--- a/api/pkce.go
+++ b/api/pkce.go
@@ -119,11 +119,12 @@ func FindAvailableListener() (net.Listener, error) {
 	return l, nil
 }
 
-func IsPkceEnabled(ctx context.Context, serverURL string) (bool, error) {
+func IsPkceEnabled(ctx context.Context, serverURL string, opts ...ClientOption) (bool, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(serverURL, "/")+PkceIsEnabledPath, nil)
 	if err != nil {
 		return false, err
 	}
+	applyExtraHeaders(req, opts)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return false, fmt.Errorf("check PKCE status: %w", err)
@@ -179,7 +180,7 @@ func DefaultScopes() []string {
 	return slices.Clone(fallbackScopes)
 }
 
-func ExchangeCodeForToken(ctx context.Context, serverURL, code, verifier, redirectURI string) (*TokenResponse, error) {
+func ExchangeCodeForToken(ctx context.Context, serverURL, code, verifier, redirectURI string, opts ...ClientOption) (*TokenResponse, error) {
 	data := url.Values{}
 	data.Set("grant_type", "authorization_code")
 	data.Set("client_id", PkceClientID)
@@ -192,6 +193,7 @@ func ExchangeCodeForToken(ctx context.Context, serverURL, code, verifier, redire
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	applyExtraHeaders(req, opts)
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/api/probe.go
+++ b/api/probe.go
@@ -15,7 +15,8 @@ const probeTimeout = 10 * time.Second
 var ErrLoginGatewayDetected = errors.New("login gateway detected — VPN may be required")
 
 // ProbeTeamCity checks whether serverURL points to a reachable TeamCity server without sending credentials.
-func ProbeTeamCity(ctx context.Context, serverURL string) error {
+// Pass ClientOption values (e.g. WithExtraHeaders) to include additional headers in the probe request.
+func ProbeTeamCity(ctx context.Context, serverURL string, opts ...ClientOption) error {
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
 	u := strings.TrimSuffix(serverURL, "/") + "/app/rest/server/version"
@@ -23,6 +24,7 @@ func ProbeTeamCity(ctx context.Context, serverURL string) error {
 	if err != nil {
 		return err
 	}
+	applyExtraHeaders(req, opts)
 	client := &http.Client{Transport: defaultTransport()}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/docs/topics/teamcity-cli-configuration.md
+++ b/docs/topics/teamcity-cli-configuration.md
@@ -144,6 +144,10 @@ servers:
   https://teamcity-prod.example.com:
     user: alice
     ro: true
+  https://teamcity-internal.example.com:
+    user: alice
+    extra_headers:
+      cf-access-token: $CF_ACCESS_TOKEN
 aliases:
   rl: 'run list'
   rw: 'run view $1 --web'
@@ -185,7 +189,7 @@ The server URL used when no `TEAMCITY_URL` environment variable is set. Updated 
 </td>
 <td>
 
-A map of server URLs to their settings. Each entry stores the `user` field (username on that server) and optionally `guest: true` for guest access, `ro: true` for read-only mode. Tokens are stored in the system keyring, not in this file, unless `--insecure-storage` was used during login.
+A map of server URLs to their settings. Each entry stores the `user` field (username on that server) and optionally `guest: true` for guest access, `ro: true` for read-only mode, and `extra_headers` (a map of header names to values) for headers that must be added to every request — useful when the server sits behind an authenticating proxy. Header values support `$VAR` and `${VAR}` environment variable expansion; use `$$` to include a literal `$`. Tokens are stored in the system keyring, not in this file, unless `--insecure-storage` was used during login.
 
 </td>
 </tr>
@@ -436,6 +440,18 @@ Show detailed output, including debug information. Mutually exclusive with `--qu
 <td>
 
 Disable interactive prompts. The CLI uses sensible defaults when a prompt would otherwise appear.
+
+</td>
+</tr>
+<tr>
+<td>
+
+`--header`
+
+</td>
+<td>
+
+Add an extra HTTP header to every request (format: `Name: Value`). May be repeated for multiple headers. When supplied, overrides any `extra_headers` configured in the config file.
 
 </td>
 </tr>

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -68,6 +68,11 @@ func runAuthLogin(f *cmdutil.Factory, opts *loginOpts) error {
 		)
 	}
 
+	headerOpts, err := f.ExtraHeaderOpts()
+	if err != nil {
+		return err
+	}
+
 	p := f.Printer
 	ctx := f.Context()
 	interactive := f.IsInteractive()
@@ -77,7 +82,7 @@ func runAuthLogin(f *cmdutil.Factory, opts *loginOpts) error {
 		_, _ = fmt.Fprintln(p.Out)
 	}
 
-	serverURL, err := resolveServerURL(ctx, p, opts.serverURL, interactive)
+	serverURL, err := resolveServerURL(ctx, p, opts.serverURL, interactive, headerOpts)
 	if err != nil {
 		return err
 	}
@@ -89,13 +94,13 @@ func runAuthLogin(f *cmdutil.Factory, opts *loginOpts) error {
 	f.WarnInsecureHTTP(serverURL, reason)
 
 	if opts.guest {
-		return finishGuestLogin(ctx, f, serverURL)
+		return finishGuestLogin(ctx, f, serverURL, headerOpts)
 	}
-	return finishTokenLogin(ctx, f, serverURL, opts, interactive)
+	return finishTokenLogin(ctx, f, serverURL, opts, interactive, headerOpts)
 }
 
 // resolveServerURL prompts and probes in a loop until a reachable TeamCity server is found or the user cancels.
-func resolveServerURL(ctx context.Context, p *output.Printer, initial string, interactive bool) (string, error) {
+func resolveServerURL(ctx context.Context, p *output.Printer, initial string, interactive bool, headerOpts []api.ClientOption) (string, error) {
 	serverURL := initial
 	detected := ""
 	savedDefault := ""
@@ -136,7 +141,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 		serverURL = config.NormalizeURL(serverURL)
 
 		p.Progress("Checking %s... ", output.Cyan(serverURL))
-		if err := api.ProbeTeamCity(ctx, serverURL); err != nil {
+		if err := api.ProbeTeamCity(ctx, serverURL, headerOpts...); err != nil {
 			p.Info("%s", output.Red("✗"))
 			if errors.Is(err, context.Canceled) {
 				return "", err
@@ -154,13 +159,15 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 	}
 }
 
-func finishGuestLogin(ctx context.Context, f *cmdutil.Factory, serverURL string) error {
+func finishGuestLogin(ctx context.Context, f *cmdutil.Factory, serverURL string, headerOpts []api.ClientOption) error {
 	p := f.Printer
 	p.Progress("Validating guest access... ")
 
 	client := api.NewGuestClient(serverURL,
-		api.WithDebugFunc(p.Debug),
-		api.WithVersion(version.String()),
+		append([]api.ClientOption{
+			api.WithDebugFunc(p.Debug),
+			api.WithVersion(version.String()),
+		}, headerOpts...)...,
 	).WithContext(ctx)
 	server, err := client.GetServer()
 	if err != nil {
@@ -182,16 +189,16 @@ func finishGuestLogin(ctx context.Context, f *cmdutil.Factory, serverURL string)
 	return nil
 }
 
-func finishTokenLogin(ctx context.Context, f *cmdutil.Factory, serverURL string, opts *loginOpts, interactive bool) error {
+func finishTokenLogin(ctx context.Context, f *cmdutil.Factory, serverURL string, opts *loginOpts, interactive bool, headerOpts []api.ClientOption) error {
 	p := f.Printer
 	token := opts.token
 	var tokenValidUntil string
 	pkceTried := token == "" && !opts.noBrowser && interactive
 	if pkceTried {
-		token, tokenValidUntil = attemptPkceLogin(ctx, p, serverURL)
+		token, tokenValidUntil = attemptPkceLogin(ctx, p, serverURL, headerOpts)
 	}
 
-	token, user, err := resolveToken(ctx, p, serverURL, token, pkceTried, interactive)
+	token, user, err := resolveToken(ctx, p, serverURL, token, pkceTried, interactive, headerOpts)
 	if err != nil {
 		return err
 	}
@@ -220,7 +227,7 @@ func finishTokenLogin(ctx context.Context, f *cmdutil.Factory, serverURL string,
 }
 
 // resolveToken prompts for a token and validates it, looping on invalid tokens when interactive.
-func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial string, pkceTried, interactive bool) (string, *api.User, error) {
+func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial string, pkceTried, interactive bool, headerOpts []api.ClientOption) (string, *api.User, error) {
 	token := initial
 	instructionsShown := false
 	for {
@@ -241,8 +248,10 @@ func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial str
 
 		p.Progress("Validating... ")
 		client := api.NewClient(serverURL, token,
-			api.WithDebugFunc(p.Debug),
-			api.WithVersion(version.String()),
+			append([]api.ClientOption{
+				api.WithDebugFunc(p.Debug),
+				api.WithVersion(version.String()),
+			}, headerOpts...)...,
 		).WithContext(ctx)
 		user, err := client.GetCurrentUser()
 		if err != nil {

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -68,11 +68,6 @@ func runAuthLogin(f *cmdutil.Factory, opts *loginOpts) error {
 		)
 	}
 
-	headerOpts, err := f.ExtraHeaderOpts()
-	if err != nil {
-		return err
-	}
-
 	p := f.Printer
 	ctx := f.Context()
 	interactive := f.IsInteractive()
@@ -82,7 +77,13 @@ func runAuthLogin(f *cmdutil.Factory, opts *loginOpts) error {
 		_, _ = fmt.Fprintln(p.Out)
 	}
 
-	serverURL, err := resolveServerURL(ctx, p, opts.serverURL, interactive, headerOpts)
+	serverURL, err := resolveServerURL(ctx, p, f, opts.serverURL, interactive)
+	if err != nil {
+		return err
+	}
+
+	// Compute headers for the confirmed server URL so per-server config headers are used.
+	headerOpts, err := f.ExtraHeaderOptsForServer(serverURL)
 	if err != nil {
 		return err
 	}
@@ -100,7 +101,8 @@ func runAuthLogin(f *cmdutil.Factory, opts *loginOpts) error {
 }
 
 // resolveServerURL prompts and probes in a loop until a reachable TeamCity server is found or the user cancels.
-func resolveServerURL(ctx context.Context, p *output.Printer, initial string, interactive bool, headerOpts []api.ClientOption) (string, error) {
+// It uses f.ExtraHeaderOptsForServer per iteration so that per-server config headers are applied to each probe.
+func resolveServerURL(ctx context.Context, p *output.Printer, f *cmdutil.Factory, initial string, interactive bool) (string, error) {
 	serverURL := initial
 	detected := ""
 	savedDefault := ""
@@ -139,6 +141,11 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 		}
 
 		serverURL = config.NormalizeURL(serverURL)
+
+		headerOpts, err := f.ExtraHeaderOptsForServer(serverURL)
+		if err != nil {
+			return "", err
+		}
 
 		p.Progress("Checking %s... ", output.Cyan(serverURL))
 		if err := api.ProbeTeamCity(ctx, serverURL, headerOpts...); err != nil {

--- a/internal/cmd/auth/pkce.go
+++ b/internal/cmd/auth/pkce.go
@@ -18,9 +18,9 @@ import (
 const authCodeLifetime = 5 * time.Minute
 
 // attemptPkceLogin probes for PKCE support, lets the user pick which scopes to grant, then runs the browser flow.
-func attemptPkceLogin(ctx context.Context, p *output.Printer, serverURL string) (token, validUntil string) {
+func attemptPkceLogin(ctx context.Context, p *output.Printer, serverURL string, headerOpts []api.ClientOption) (token, validUntil string) {
 	pctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	enabled, _ := api.IsPkceEnabled(pctx, serverURL)
+	enabled, _ := api.IsPkceEnabled(pctx, serverURL, headerOpts...)
 	cancel()
 	if !enabled {
 		return "", ""
@@ -30,7 +30,7 @@ func attemptPkceLogin(ctx context.Context, p *output.Printer, serverURL string) 
 		p.Info("Skipping browser login, entering token manually...")
 		return "", ""
 	}
-	resp, err := runPkceLogin(ctx, p, serverURL, scopes)
+	resp, err := runPkceLogin(ctx, p, serverURL, scopes, headerOpts)
 	if err != nil {
 		p.Warn("Browser auth failed: %v", err)
 		p.Info("Falling back to manual token entry...")
@@ -75,7 +75,7 @@ func selectPkceScopes() []string {
 }
 
 // runPkceLogin orchestrates the browser-based PKCE auth flow with the given scopes and returns the minted access token.
-func runPkceLogin(parent context.Context, p *output.Printer, serverURL string, scopes []string) (*api.TokenResponse, error) {
+func runPkceLogin(parent context.Context, p *output.Printer, serverURL string, scopes []string, headerOpts []api.ClientOption) (*api.TokenResponse, error) {
 	verifier, err := api.GenerateCodeVerifier()
 	if err != nil {
 		return nil, fmt.Errorf("generate code verifier: %w", err)
@@ -121,7 +121,7 @@ func runPkceLogin(parent context.Context, p *output.Printer, serverURL string, s
 
 		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 		defer cancel()
-		return api.ExchangeCodeForToken(ctx, serverURL, result.Code, verifier, redirectURI)
+		return api.ExchangeCodeForToken(ctx, serverURL, result.Code, verifier, redirectURI, headerOpts...)
 
 	case <-time.After(authCodeLifetime):
 		return nil, fmt.Errorf("timeout waiting for callback (exceeded %v)", authCodeLifetime)

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -68,11 +68,7 @@ func newAuthStatusCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runAuthStatus(f *cmdutil.Factory, opts *authStatusOptions) error {
-	headerOpts, err := f.ExtraHeaderOpts()
-	if err != nil {
-		return err
-	}
-	results := collectAuthStatuses(f, headerOpts)
+	results := collectAuthStatuses(f)
 	if opts.json {
 		if len(results) == 0 {
 			results = []authStatus{{Status: "error", Error: "not logged in to any TeamCity server"}}
@@ -82,19 +78,19 @@ func runAuthStatus(f *cmdutil.Factory, opts *authStatusOptions) error {
 	return renderAuthStatusHuman(f, results)
 }
 
-func collectAuthStatuses(f *cmdutil.Factory, headerOpts []api.ClientOption) []authStatus {
+func collectAuthStatuses(f *cmdutil.Factory) []authStatus {
 	if envURL := os.Getenv(config.EnvServerURL); envURL != "" {
 		envURL = config.NormalizeURL(envURL)
 		if config.IsGuestAuth() {
-			return []authStatus{collectGuestStatus(f, envURL, false, headerOpts)}
+			return []authStatus{collectGuestStatus(f, envURL, false)}
 		}
 		if envToken := os.Getenv(config.EnvToken); envToken != "" {
-			return []authStatus{collectTokenStatus(f, envURL, envToken, "env", false, headerOpts)}
+			return []authStatus{collectTokenStatus(f, envURL, envToken, "env", false)}
 		}
 	}
 
 	if buildAuth, ok := config.GetBuildAuth(); ok {
-		return []authStatus{collectBuildStatus(f, buildAuth, headerOpts)}
+		return []authStatus{collectBuildStatus(f, buildAuth)}
 	}
 
 	cfg := config.Get()
@@ -105,7 +101,7 @@ func collectAuthStatuses(f *cmdutil.Factory, headerOpts []api.ClientOption) []au
 		sc := cfg.Servers[serverURL]
 		isDefault := len(urls) > 1 && serverURL == cfg.DefaultServer
 		wg.Go(func() {
-			results[i] = collectServerStatus(f, serverURL, sc, isDefault, headerOpts)
+			results[i] = collectServerStatus(f, serverURL, sc, isDefault)
 		})
 	}
 	wg.Wait()
@@ -113,13 +109,13 @@ func collectAuthStatuses(f *cmdutil.Factory, headerOpts []api.ClientOption) []au
 }
 
 // collectServerStatus fetches the status for a single configured server (guest, token, or missing).
-func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerConfig, isDefault bool, headerOpts []api.ClientOption) authStatus {
+func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerConfig, isDefault bool) authStatus {
 	if sc.Guest {
-		return collectGuestStatus(f, serverURL, isDefault, headerOpts)
+		return collectGuestStatus(f, serverURL, isDefault)
 	}
 	token, src, krErr := config.GetTokenForServer(serverURL)
 	if token != "" {
-		return collectTokenStatus(f, serverURL, token, src, isDefault, headerOpts)
+		return collectTokenStatus(f, serverURL, token, src, isDefault)
 	}
 	return authStatus{
 		Server:     serverURL,
@@ -131,8 +127,14 @@ func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerC
 	}
 }
 
-func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool, headerOpts []api.ClientOption) authStatus {
+func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "guest", IsDefault: isDefault}
+	headerOpts, err := f.ExtraHeaderOptsForServer(serverURL)
+	if err != nil {
+		s.Status = "error"
+		s.Error = err.Error()
+		return s
+	}
 	if err := api.ProbeTeamCity(f.Context(), serverURL, headerOpts...); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
@@ -155,8 +157,14 @@ func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool, he
 	return s
 }
 
-func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool, headerOpts []api.ClientOption) authStatus {
+func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "token", TokenSource: tokenSource, IsDefault: isDefault}
+	headerOpts, err := f.ExtraHeaderOptsForServer(serverURL)
+	if err != nil {
+		s.Status = "error"
+		s.Error = err.Error()
+		return s
+	}
 	if err := api.ProbeTeamCity(f.Context(), serverURL, headerOpts...); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
@@ -198,8 +206,14 @@ func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string
 	return s
 }
 
-func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth, headerOpts []api.ClientOption) authStatus {
+func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth) authStatus {
 	s := authStatus{Server: buildAuth.ServerURL, AuthMethod: "build"}
+	headerOpts, err := f.ExtraHeaderOptsForServer(buildAuth.ServerURL)
+	if err != nil {
+		s.Status = "error"
+		s.Error = err.Error()
+		return s
+	}
 	if err := api.ProbeTeamCity(f.Context(), buildAuth.ServerURL, headerOpts...); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, buildAuth.ServerURL)

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -68,7 +68,11 @@ func newAuthStatusCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runAuthStatus(f *cmdutil.Factory, opts *authStatusOptions) error {
-	results := collectAuthStatuses(f)
+	headerOpts, err := f.ExtraHeaderOpts()
+	if err != nil {
+		return err
+	}
+	results := collectAuthStatuses(f, headerOpts)
 	if opts.json {
 		if len(results) == 0 {
 			results = []authStatus{{Status: "error", Error: "not logged in to any TeamCity server"}}
@@ -78,19 +82,19 @@ func runAuthStatus(f *cmdutil.Factory, opts *authStatusOptions) error {
 	return renderAuthStatusHuman(f, results)
 }
 
-func collectAuthStatuses(f *cmdutil.Factory) []authStatus {
+func collectAuthStatuses(f *cmdutil.Factory, headerOpts []api.ClientOption) []authStatus {
 	if envURL := os.Getenv(config.EnvServerURL); envURL != "" {
 		envURL = config.NormalizeURL(envURL)
 		if config.IsGuestAuth() {
-			return []authStatus{collectGuestStatus(f, envURL, false)}
+			return []authStatus{collectGuestStatus(f, envURL, false, headerOpts)}
 		}
 		if envToken := os.Getenv(config.EnvToken); envToken != "" {
-			return []authStatus{collectTokenStatus(f, envURL, envToken, "env", false)}
+			return []authStatus{collectTokenStatus(f, envURL, envToken, "env", false, headerOpts)}
 		}
 	}
 
 	if buildAuth, ok := config.GetBuildAuth(); ok {
-		return []authStatus{collectBuildStatus(f, buildAuth)}
+		return []authStatus{collectBuildStatus(f, buildAuth, headerOpts)}
 	}
 
 	cfg := config.Get()
@@ -101,7 +105,7 @@ func collectAuthStatuses(f *cmdutil.Factory) []authStatus {
 		sc := cfg.Servers[serverURL]
 		isDefault := len(urls) > 1 && serverURL == cfg.DefaultServer
 		wg.Go(func() {
-			results[i] = collectServerStatus(f, serverURL, sc, isDefault)
+			results[i] = collectServerStatus(f, serverURL, sc, isDefault, headerOpts)
 		})
 	}
 	wg.Wait()
@@ -109,13 +113,13 @@ func collectAuthStatuses(f *cmdutil.Factory) []authStatus {
 }
 
 // collectServerStatus fetches the status for a single configured server (guest, token, or missing).
-func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerConfig, isDefault bool) authStatus {
+func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerConfig, isDefault bool, headerOpts []api.ClientOption) authStatus {
 	if sc.Guest {
-		return collectGuestStatus(f, serverURL, isDefault)
+		return collectGuestStatus(f, serverURL, isDefault, headerOpts)
 	}
 	token, src, krErr := config.GetTokenForServer(serverURL)
 	if token != "" {
-		return collectTokenStatus(f, serverURL, token, src, isDefault)
+		return collectTokenStatus(f, serverURL, token, src, isDefault, headerOpts)
 	}
 	return authStatus{
 		Server:     serverURL,
@@ -127,14 +131,16 @@ func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerC
 	}
 }
 
-func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) authStatus {
+func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool, headerOpts []api.ClientOption) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "guest", IsDefault: isDefault}
-	if err := api.ProbeTeamCity(f.Context(), serverURL); err != nil {
+	if err := api.ProbeTeamCity(f.Context(), serverURL, headerOpts...); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
 		return s
 	}
-	client := api.NewGuestClient(serverURL, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	client := api.NewGuestClient(serverURL,
+		append([]api.ClientOption{api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())}, headerOpts...)...,
+	).WithContext(f.Context())
 	server, err := client.GetServer()
 	if err != nil {
 		s.Status = "error"
@@ -149,14 +155,16 @@ func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) au
 	return s
 }
 
-func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool) authStatus {
+func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool, headerOpts []api.ClientOption) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "token", TokenSource: tokenSource, IsDefault: isDefault}
-	if err := api.ProbeTeamCity(f.Context(), serverURL); err != nil {
+	if err := api.ProbeTeamCity(f.Context(), serverURL, headerOpts...); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
 		return s
 	}
-	client := api.NewClient(serverURL, token, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	client := api.NewClient(serverURL, token,
+		append([]api.ClientOption{api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())}, headerOpts...)...,
+	).WithContext(f.Context())
 	user, err := client.GetCurrentUser()
 	if err != nil {
 		s.Status = "error"
@@ -190,14 +198,16 @@ func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string
 	return s
 }
 
-func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth) authStatus {
+func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth, headerOpts []api.ClientOption) authStatus {
 	s := authStatus{Server: buildAuth.ServerURL, AuthMethod: "build"}
-	if err := api.ProbeTeamCity(f.Context(), buildAuth.ServerURL); err != nil {
+	if err := api.ProbeTeamCity(f.Context(), buildAuth.ServerURL, headerOpts...); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, buildAuth.ServerURL)
 		return s
 	}
-	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password,
+		append([]api.ClientOption{api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())}, headerOpts...)...,
+	).WithContext(f.Context())
 	server, err := client.GetServer()
 	if err != nil {
 		s.Status = "error"

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -76,6 +76,7 @@ Report issues:  https://jb.gg/tc/issues`,
 	cmd.PersistentFlags().BoolVarP(&f.Verbose, "verbose", "V", false, "Show detailed output including debug info")
 	cmd.PersistentFlags().BoolVar(&f.Verbose, "debug", false, "Alias for --verbose")
 	cmd.PersistentFlags().BoolVar(&f.NoInput, "no-input", false, "Disable interactive prompts")
+	cmd.PersistentFlags().StringArrayVar(&f.ExtraHeaders, "header", nil, "Extra HTTP header for all requests (format: 'Name: Value'); may be repeated. Overrides config-file headers.")
 
 	cmd.MarkFlagsMutuallyExclusive("quiet", "verbose")
 	cmd.MarkFlagsMutuallyExclusive("quiet", "debug")

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -88,7 +88,16 @@ func ProbeGuestAccess(ctx context.Context, serverURL string) bool {
 
 // ExtraHeaderOpts resolves extra headers from CLI flags or config and returns them as a
 // ClientOption slice ready to append to any api constructor or probe call.
+// When headers come from config, it uses the current default server URL.
+// Prefer ExtraHeaderOptsForServer when the target server URL is known.
 func (f *Factory) ExtraHeaderOpts() ([]api.ClientOption, error) {
+	return f.ExtraHeaderOptsForServer(config.GetServerURL())
+}
+
+// ExtraHeaderOptsForServer resolves extra headers for a specific server URL.
+// CLI --header flags override config and apply regardless of serverURL.
+// When CLI flags are absent, only headers configured for serverURL are returned.
+func (f *Factory) ExtraHeaderOptsForServer(serverURL string) ([]api.ClientOption, error) {
 	var headers map[string]string
 	var err error
 	if len(f.ExtraHeaders) > 0 {
@@ -97,7 +106,7 @@ func (f *Factory) ExtraHeaderOpts() ([]api.ClientOption, error) {
 			return nil, err
 		}
 	} else {
-		headers = config.GetExtraHeaders()
+		headers = config.GetExtraHeadersForServer(serverURL)
 	}
 	if len(headers) == 0 {
 		return nil, nil

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -3,6 +3,7 @@ package cmdutil
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/config"
@@ -18,6 +19,17 @@ func (f *Factory) defaultGetClient() (api.ClientInterface, error) {
 	verOpt := api.WithVersion(version.String())
 
 	opts := []api.ClientOption{debugOpt, roOpt, verOpt}
+
+	// CLI --header flags take exclusive precedence over config-file extra_headers.
+	if len(f.ExtraHeaders) > 0 {
+		headers, err := parseExtraHeaders(f.ExtraHeaders)
+		if err != nil {
+			return nil, err
+		}
+		opts = append(opts, api.WithExtraHeaders(headers))
+	} else if headers := config.GetExtraHeaders(); len(headers) > 0 {
+		opts = append(opts, api.WithExtraHeaders(headers))
+	}
 
 	if config.IsGuestAuth() {
 		if serverURL == "" {
@@ -72,6 +84,44 @@ func ProbeGuestAccess(ctx context.Context, serverURL string) bool {
 	guest := api.NewGuestClient(serverURL, api.WithVersion(version.String())).WithContext(ctx)
 	_, err := guest.GetServer()
 	return err == nil
+}
+
+// ExtraHeaderOpts resolves extra headers from CLI flags or config and returns them as a
+// ClientOption slice ready to append to any api constructor or probe call.
+func (f *Factory) ExtraHeaderOpts() ([]api.ClientOption, error) {
+	var headers map[string]string
+	var err error
+	if len(f.ExtraHeaders) > 0 {
+		headers, err = parseExtraHeaders(f.ExtraHeaders)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		headers = config.GetExtraHeaders()
+	}
+	if len(headers) == 0 {
+		return nil, nil
+	}
+	return []api.ClientOption{api.WithExtraHeaders(headers)}, nil
+}
+
+// parseExtraHeaders parses a slice of "Name: Value" strings (curl-style) into a map.
+// The colon is the separator; whitespace around the name and value is trimmed.
+func parseExtraHeaders(raw []string) (map[string]string, error) {
+	headers := make(map[string]string, len(raw))
+	for _, h := range raw {
+		before, after, ok := strings.Cut(h, ":")
+		if !ok {
+			return nil, fmt.Errorf("invalid header %q: expected 'Name: Value' format", h)
+		}
+		name := strings.TrimSpace(before)
+		value := strings.TrimSpace(after)
+		if name == "" {
+			return nil, fmt.Errorf("invalid header %q: name cannot be empty", h)
+		}
+		headers[name] = value
+	}
+	return headers, nil
 }
 
 // NotAuthenticatedError returns a not-authenticated error with a hint that covers all authentication methods.

--- a/internal/cmdutil/client_test.go
+++ b/internal/cmdutil/client_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveAuthSource(t *testing.T) {
@@ -40,6 +41,73 @@ func TestResolveAuthSource(t *testing.T) {
 			t.Cleanup(config.ResetForTest)
 
 			assert.Equal(t, tc.want, resolveAuthSource(tc.tokenSource))
+		})
+	}
+}
+
+func TestParseExtraHeaders(T *testing.T) {
+	T.Parallel()
+
+	tests := []struct {
+		name    string
+		input   []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name:  "single header with space after colon",
+			input: []string{"CF-Access-Client-Id: team.access"},
+			want:  map[string]string{"CF-Access-Client-Id": "team.access"},
+		},
+		{
+			name:  "single header without space after colon",
+			input: []string{"CF-Access-Client-Id:team.access"},
+			want:  map[string]string{"CF-Access-Client-Id": "team.access"},
+		},
+		{
+			name: "multiple headers",
+			input: []string{
+				"CF-Access-Client-Id: team.access",
+				"CF-Access-Client-Secret: secret123",
+			},
+			want: map[string]string{
+				"CF-Access-Client-Id":     "team.access",
+				"CF-Access-Client-Secret": "secret123",
+			},
+		},
+		{
+			name:  "value containing a colon",
+			input: []string{"Authorization: Bearer tok:en"},
+			want:  map[string]string{"Authorization": "Bearer tok:en"},
+		},
+		{
+			name:    "missing colon separator",
+			input:   []string{"CF-Access-Client-Id"},
+			wantErr: true,
+		},
+		{
+			name:    "empty name",
+			input:   []string{": value"},
+			wantErr: true,
+		},
+		{
+			name:  "empty input",
+			input: []string{},
+			want:  map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		T.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseExtraHeaders(tc.input)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
 		})
 	}
 }

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -24,10 +24,11 @@ type IOStreams struct {
 // and use its methods/fields to get clients, check flags, etc.
 type Factory struct {
 	// Global flags — set once by root command, read by subcommands.
-	NoColor bool
-	Quiet   bool
-	Verbose bool
-	NoInput bool
+	NoColor      bool
+	Quiet        bool
+	Verbose      bool
+	NoInput      bool
+	ExtraHeaders []string // raw "--header" flag values, e.g. "Name: Value"
 
 	// JSONOutput is set by commands that accept --json to signal that errors
 	// should be emitted as structured JSON instead of human-readable text.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,11 +31,12 @@ const (
 )
 
 type ServerConfig struct {
-	Token       string `mapstructure:"token"`
-	User        string `mapstructure:"user"`
-	Guest       bool   `mapstructure:"guest,omitempty"`
-	RO          bool   `mapstructure:"ro,omitempty"`
-	TokenExpiry string `mapstructure:"token_expiry,omitempty"`
+	Token        string            `mapstructure:"token"`
+	User         string            `mapstructure:"user"`
+	Guest        bool              `mapstructure:"guest,omitempty"`
+	RO           bool              `mapstructure:"ro,omitempty"`
+	TokenExpiry  string            `mapstructure:"token_expiry,omitempty"`
+	ExtraHeaders map[string]string `mapstructure:"extra_headers,omitempty"`
 }
 
 type Config struct {
@@ -247,6 +248,37 @@ func GetTokenExpiry() string {
 	return ""
 }
 
+// GetExtraHeaders returns the configured extra headers for the current server,
+// expanding any $VAR or ${VAR} references in values from the environment.
+// Use $$ to produce a literal $ in the value.
+// Returns nil if no headers are configured.
+func GetExtraHeaders() map[string]string {
+	serverURL := GetServerURL()
+	if serverURL == "" || cfg == nil {
+		return nil
+	}
+	server, ok := cfg.Servers[serverURL]
+	if !ok || len(server.ExtraHeaders) == 0 {
+		return nil
+	}
+	resolved := make(map[string]string, len(server.ExtraHeaders))
+	for k, v := range server.ExtraHeaders {
+		resolved[k] = expandHeaderValue(v)
+	}
+	return resolved
+}
+
+// expandHeaderValue expands $VAR/${VAR} from the environment. $$ produces a
+// literal $; each additional $$ pair adds another $.
+func expandHeaderValue(s string) string {
+	return os.Expand(s, func(key string) string {
+		if key == "$" {
+			return "$"
+		}
+		return os.Getenv(key)
+	})
+}
+
 func serverConfigToMap(sc ServerConfig) map[string]any {
 	m := map[string]any{}
 	if sc.Token != "" {
@@ -263,6 +295,9 @@ func serverConfigToMap(sc ServerConfig) map[string]any {
 	}
 	if sc.TokenExpiry != "" {
 		m["token_expiry"] = sc.TokenExpiry
+	}
+	if len(sc.ExtraHeaders) > 0 {
+		m["extra_headers"] = sc.ExtraHeaders
 	}
 	return m
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -253,7 +253,14 @@ func GetTokenExpiry() string {
 // Use $$ to produce a literal $ in the value.
 // Returns nil if no headers are configured.
 func GetExtraHeaders() map[string]string {
-	serverURL := GetServerURL()
+	return GetExtraHeadersForServer(GetServerURL())
+}
+
+// GetExtraHeadersForServer returns the configured extra headers for the given server URL,
+// expanding any $VAR or ${VAR} references in values from the environment.
+// Use $$ to produce a literal $ in the value.
+// Returns nil if no headers are configured for that server.
+func GetExtraHeadersForServer(serverURL string) map[string]string {
 	if serverURL == "" || cfg == nil {
 		return nil
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -957,3 +957,177 @@ func TestIsReadOnly(T *testing.T) {
 		assert.False(t, IsReadOnly())
 	})
 }
+
+func TestGetExtraHeaders(T *testing.T) {
+	saveCfgState(T)
+
+	const serverURL = "https://tc.example.com"
+
+	T.Run("returns nil when no server configured", func(t *testing.T) {
+		t.Setenv(EnvServerURL, "")
+		cfg = &Config{Servers: make(map[string]ServerConfig)}
+
+		assert.Nil(t, GetExtraHeaders())
+	})
+
+	T.Run("returns nil when server has no extra headers", func(t *testing.T) {
+		t.Setenv(EnvServerURL, serverURL)
+		cfg = &Config{
+			DefaultServer: serverURL,
+			Servers: map[string]ServerConfig{
+				serverURL: {Token: "token", User: "user"},
+			},
+		}
+
+		assert.Nil(t, GetExtraHeaders())
+	})
+
+	T.Run("returns configured headers", func(t *testing.T) {
+		t.Setenv(EnvServerURL, serverURL)
+		cfg = &Config{
+			DefaultServer: serverURL,
+			Servers: map[string]ServerConfig{
+				serverURL: {
+					Token: "token",
+					User:  "user",
+					ExtraHeaders: map[string]string{
+						"CF-Access-Client-Id":     "team.access",
+						"CF-Access-Client-Secret": "literal-secret",
+					},
+				},
+			},
+		}
+
+		got := GetExtraHeaders()
+		require.NotNil(t, got)
+		assert.Equal(t, "team.access", got["CF-Access-Client-Id"])
+		assert.Equal(t, "literal-secret", got["CF-Access-Client-Secret"])
+	})
+
+	T.Run("expands env var references in values", func(t *testing.T) {
+		t.Setenv(EnvServerURL, serverURL)
+		t.Setenv("CF_SECRET", "env-secret-value")
+		cfg = &Config{
+			DefaultServer: serverURL,
+			Servers: map[string]ServerConfig{
+				serverURL: {
+					Token: "token",
+					User:  "user",
+					ExtraHeaders: map[string]string{
+						"CF-Access-Client-Secret": "$CF_SECRET",
+					},
+				},
+			},
+		}
+
+		got := GetExtraHeaders()
+		require.NotNil(t, got)
+		assert.Equal(t, "env-secret-value", got["CF-Access-Client-Secret"])
+	})
+
+	T.Run("expands braced env var references in values", func(t *testing.T) {
+		t.Setenv(EnvServerURL, serverURL)
+		t.Setenv("CF_SECRET", "braced-secret-value")
+		cfg = &Config{
+			DefaultServer: serverURL,
+			Servers: map[string]ServerConfig{
+				serverURL: {
+					Token: "token",
+					User:  "user",
+					ExtraHeaders: map[string]string{
+						"CF-Access-Client-Secret": "${CF_SECRET}",
+					},
+				},
+			},
+		}
+
+		got := GetExtraHeaders()
+		require.NotNil(t, got)
+		assert.Equal(t, "braced-secret-value", got["CF-Access-Client-Secret"])
+	})
+
+	T.Run("unset env var expands to empty string", func(t *testing.T) {
+		t.Setenv(EnvServerURL, serverURL)
+		t.Setenv("UNSET_HEADER_VAR", "")
+		cfg = &Config{
+			DefaultServer: serverURL,
+			Servers: map[string]ServerConfig{
+				serverURL: {
+					Token: "token",
+					User:  "user",
+					ExtraHeaders: map[string]string{
+						"X-Header": "$UNSET_HEADER_VAR",
+					},
+				},
+			},
+		}
+
+		got := GetExtraHeaders()
+		require.NotNil(t, got)
+		assert.Equal(t, "", got["X-Header"])
+	})
+}
+
+func TestExpandHeaderValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		env   map[string]string
+		want  string
+	}{
+		{
+			name:  "plain value unchanged",
+			input: "literal-value",
+			want:  "literal-value",
+		},
+		{
+			name:  "$VAR expands from env",
+			input: "$MY_VAR",
+			env:   map[string]string{"MY_VAR": "hello"},
+			want:  "hello",
+		},
+		{
+			name:  "${VAR} expands from env",
+			input: "${MY_VAR}",
+			env:   map[string]string{"MY_VAR": "hello"},
+			want:  "hello",
+		},
+		{
+			name:  "$$ produces literal $",
+			input: "$$",
+			want:  "$",
+		},
+		{
+			name:  "$$$$ produces literal $$",
+			input: "$$$$",
+			want:  "$$",
+		},
+		{
+			name:  "$$VAR produces literal $ followed by literal VAR (no expansion)",
+			input: "$$MY_VAR",
+			env:   map[string]string{"MY_VAR": "should-not-appear"},
+			want:  "$MY_VAR",
+		},
+		{
+			name:  "$$$VAR produces literal $ then expanded VAR",
+			input: "$$$MY_VAR",
+			env:   map[string]string{"MY_VAR": "world"},
+			want:  "$world",
+		},
+		{
+			name:  "backslash is not special",
+			input: `\$MY_VAR`,
+			env:   map[string]string{"MY_VAR": "hello"},
+			want:  `\hello`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			assert.Equal(t, tc.want, expandHeaderValue(tc.input))
+		})
+	}
+}

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -481,6 +481,7 @@ Available on all commands:
 - `-q, --quiet` - Suppress non-essential output
 - `--verbose` - Show detailed output including debug info
 - `--no-input` - Disable interactive prompts
+- `--header <Name: Value>` - Add extra HTTP header to all requests (repeatable); overrides config-file `extra_headers`
 - `-w, --web` - Open in browser (on view commands)
 
 ## List Output Flags


### PR DESCRIPTION
## Summary

Adds the ability to inject additional HTTP headers into every request the CLI makes. The motivating use case is TeamCity servers that sit behind an authenticating proxy such as Cloudflare Access. Per the [Cloudflare Access CLI tutorial](https://developers.cloudflare.com/cloudflare-one/tutorials/cli/#using-the-token-as-an-environment-variable), tools that call a Cloudflare-protected API must include a `cf-access-token` header on every HTTP request — a short-lived JWT obtained via `cloudflared access token`. Without a way to supply that header, the CLI cannot reach the TeamCity API at all.

## Changes

- **`api/client.go`** — new `extraHeaders` field on `Client` and `WithExtraHeaders` option; headers are applied in both `doRequestFull` (all typed API calls) and `doRawRequest` (`teamcity api` subcommand), inserted before per-request headers so those can still override
- **`internal/config/config.go`** — new `extra_headers` map on `ServerConfig`; `GetExtraHeaders()` reads and expands values; `expandHeaderValue()` handles `$VAR`/`${VAR}` env expansion with `$$` as a literal-`$` escape
- **`internal/cmdutil/factory.go`** — new `ExtraHeaders []string` field for the persistent flag
- **`internal/cmd/root.go`** — new `--header "Name: Value"` persistent flag, repeatable, applies to all commands
- **`internal/cmdutil/client.go`** — `parseExtraHeaders` parser; wires CLI flags and config into `defaultGetClient` with CLI-wins-over-config precedence
- **`acceptance/testdata/config/extra-headers.txtar`** — acceptance tests for invalid format rejection and valid header pass-through
- **`acceptance/testdata/help/help.txtar`** — asserts `--header` appears in global help output
- **`docs/topics/teamcity-cli-configuration.md`** — documents `--header` flag, `extra_headers` config field, and updates the example config and field descriptions
- **`skills/teamcity-cli/references/commands.md`** — adds `--header` to the global flags list

## Design Decisions

**Config file — per-server `extra_headers` map with env-var expansion.** Values support `$VAR` / `${VAR}` expansion so secrets stay out of the config file. `$$` collapses to a literal `$` (and `$$$$` to `$$`, etc.), matching the convention used by Make, GitHub Actions, and similar tools.

**CLI `--header` flag takes exclusive precedence over config.** When `--header` is supplied, config-file `extra_headers` are ignored entirely. This makes ad-hoc overrides predictable — you get exactly what you asked for on the command line, nothing more.

**`map[string]string` for the header store.** HTTP allows multiple values for the same header name, but the YAML map format already prevents duplicate keys in the config file, and last-wins for duplicate `--header` flags is consistent with that constraint. For headers that accept comma-separated lists, users can include multiple values in a single flag value.

## Example

**Config file** (`~/.config/tc/config.yml`), keeping the token in an environment variable:
```yaml
servers:
  https://teamcity.example.com:
    user: alice
    extra_headers:
      cf-access-token: $CF_ACCESS_TOKEN
```

**CLI flag** — useful for one-off invocations or CI scripts:
```bash
export CF_ACCESS_TOKEN=$(cloudflared access token --app=https://teamcity.example.com)
teamcity --header "cf-access-token: $CF_ACCESS_TOKEN" run list
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`