### PR TITLE
feat(config): TEAMCITY_HEADER_* env-only support for proxied servers

### DIFF
--- a/acceptance/testdata/config/extra-headers.txtar
+++ b/acceptance/testdata/config/extra-headers.txtar
@@ -1,0 +1,11 @@
+# Verify TEAMCITY_HEADER_* env vars don't break ordinary operation against
+# a vanilla TeamCity server. (When a real corporate proxy like Cloudflare
+# Access is in front, these headers gate the request — but the server
+# itself simply ignores unknown headers.)
+
+env TEAMCITY_HEADER_X_TC_CLI_TEST=test-value
+env TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID=fake.id
+
+exec teamcity run list --limit 1 --no-input
+! stderr 'invalid'
+! stderr 'header'

--- a/api/agents.go
+++ b/api/agents.go
@@ -211,6 +211,7 @@ func (c *Client) RebootAgent(ctx context.Context, id int, afterBuild bool) error
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	c.setAuth(req)
+	c.applyStandardHeaders(req)
 
 	c.debugLogRequest(req)
 

--- a/api/builds_artifacts.go
+++ b/api/builds_artifacts.go
@@ -93,6 +93,7 @@ func (c *Client) DownloadArtifactTo(ctx context.Context, buildID, artifactPath s
 			return nil, err
 		}
 		c.setAuth(req)
+		c.applyStandardHeaders(req)
 		return streamClient.Do(req)
 	})
 	if err != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -161,9 +161,7 @@ func WithCommandName(name string) ClientOption {
 	}
 }
 
-// WithExtraHeaders adds the given headers to every request the client makes.
-// Names are canonicalized (CanonicalHeaderKey); values containing CR/LF/NUL are dropped
-// to prevent header-injection. Empty names are dropped. Pass an empty/nil map to no-op.
+// WithExtraHeaders sets headers applied to every request; CR/LF/NUL values and empty names are dropped.
 func WithExtraHeaders(h map[string]string) ClientOption {
 	return func(c *Client) {
 		if len(h) == 0 {
@@ -184,67 +182,47 @@ func WithExtraHeaders(h map[string]string) ClientOption {
 	}
 }
 
-// NewClient creates a new TeamCity API client with Bearer token authentication
+// newClientBase returns a Client populated with shared defaults: trimmed BaseURL, default HTTPClient, env extras.
+func newClientBase(baseURL string) *Client {
+	return &Client{
+		BaseURL: strings.TrimSuffix(baseURL, "/"),
+		HTTPClient: &http.Client{
+			Timeout:   30 * time.Second,
+			Transport: defaultTransport(),
+		},
+		serverInfo:   &serverInfoCache{},
+		extraHeaders: EnvHeaders(),
+	}
+}
+
+// NewClient creates a TeamCity API client authenticated with a Bearer token; TEAMCITY_HEADER_* env vars are honored.
 func NewClient(baseURL, token string, opts ...ClientOption) *Client {
-	baseURL = strings.TrimSuffix(baseURL, "/")
-
-	c := &Client{
-		BaseURL: baseURL,
-		Token:   token,
-		HTTPClient: &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: defaultTransport(),
-		},
-		serverInfo: &serverInfoCache{},
-	}
-
+	c := newClientBase(baseURL)
+	c.Token = token
 	for _, opt := range opts {
 		opt(c)
 	}
-
 	return c
 }
 
-// NewClientWithBasicAuth creates a TeamCity API client with Basic authentication.
+// NewClientWithBasicAuth creates a TeamCity API client authenticated with HTTP Basic; TEAMCITY_HEADER_* env vars are honored.
 func NewClientWithBasicAuth(baseURL, username, password string, opts ...ClientOption) *Client {
-	baseURL = strings.TrimSuffix(baseURL, "/")
-
-	c := &Client{
-		BaseURL:   baseURL,
-		basicUser: username,
-		basicPass: password,
-		HTTPClient: &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: defaultTransport(),
-		},
-		serverInfo: &serverInfoCache{},
-	}
-
+	c := newClientBase(baseURL)
+	c.basicUser = username
+	c.basicPass = password
 	for _, opt := range opts {
 		opt(c)
 	}
-
 	return c
 }
 
-// NewGuestClient creates a TeamCity API client with guest authentication (no credentials).
+// NewGuestClient creates a TeamCity API client using /guestAuth/ paths; TEAMCITY_HEADER_* env vars are honored.
 func NewGuestClient(baseURL string, opts ...ClientOption) *Client {
-	baseURL = strings.TrimSuffix(baseURL, "/")
-
-	c := &Client{
-		BaseURL:   baseURL,
-		guestAuth: true,
-		HTTPClient: &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: defaultTransport(),
-		},
-		serverInfo: &serverInfoCache{},
-	}
-
+	c := newClientBase(baseURL)
+	c.guestAuth = true
 	for _, opt := range opts {
 		opt(c)
 	}
-
 	return c
 }
 
@@ -283,9 +261,7 @@ func (c *Client) SetCommandName(name string) {
 	c.commandName = name
 }
 
-// applyStandardHeaders sets the per-request headers that every outgoing TeamCity request
-// must carry: User-Agent, X-TeamCity-Client, and any caller-configured extra headers
-// (WithExtraHeaders). Probe, PKCE, raw, and typed requests all pass through this chokepoint.
+// applyStandardHeaders sets User-Agent, X-TeamCity-Client, and any WithExtraHeaders extras on req.
 func (c *Client) applyStandardHeaders(req *http.Request) {
 	req.Header.Set("User-Agent", c.userAgent())
 	req.Header.Set("X-TeamCity-Client", c.teamCityClientHeader())

--- a/api/client.go
+++ b/api/client.go
@@ -61,6 +61,10 @@ type Client struct {
 
 	// serverInfo is a pointer so WithContext copies share the cache instead of copying sync.Once.
 	serverInfo *serverInfoCache
+
+	// extraHeaders is set on every outgoing request via WithExtraHeaders.
+	// Names are canonical-cased; values are scrubbed of CR/LF/NUL at construction.
+	extraHeaders map[string]string
 }
 
 // serverInfoCache memoizes the result of GetServer across copies of a Client.
@@ -101,7 +105,8 @@ func (c *Client) debugLogHeaders(prefix string, headers http.Header) {
 
 	for _, name := range names {
 		values := headers[name]
-		if sensitiveHeaders[name] {
+		_, isExtra := c.extraHeaders[name]
+		if sensitiveHeaders[name] || isExtra {
 			c.debugLog("%s %s: [REDACTED]", prefix, name)
 		} else {
 			for _, value := range values {
@@ -153,6 +158,29 @@ func WithVersion(v string) ClientOption {
 func WithCommandName(name string) ClientOption {
 	return func(c *Client) {
 		c.commandName = name
+	}
+}
+
+// WithExtraHeaders adds the given headers to every request the client makes.
+// Names are canonicalized (CanonicalHeaderKey); values containing CR/LF/NUL are dropped
+// to prevent header-injection. Empty names are dropped. Pass an empty/nil map to no-op.
+func WithExtraHeaders(h map[string]string) ClientOption {
+	return func(c *Client) {
+		if len(h) == 0 {
+			return
+		}
+		clean := make(map[string]string, len(h))
+		for k, v := range h {
+			if strings.ContainsAny(v, "\r\n\x00") {
+				continue
+			}
+			name := http.CanonicalHeaderKey(strings.TrimSpace(k))
+			if name == "" {
+				continue
+			}
+			clean[name] = v
+		}
+		c.extraHeaders = clean
 	}
 }
 
@@ -256,11 +284,14 @@ func (c *Client) SetCommandName(name string) {
 }
 
 // applyStandardHeaders sets the per-request headers that every outgoing TeamCity request
-// must carry. Caller-configurable extra headers (set via WithExtraHeaders) plug in here in
-// a follow-up commit so probe, PKCE, raw, and typed requests all pass through one chokepoint.
+// must carry: User-Agent, X-TeamCity-Client, and any caller-configured extra headers
+// (WithExtraHeaders). Probe, PKCE, raw, and typed requests all pass through this chokepoint.
 func (c *Client) applyStandardHeaders(req *http.Request) {
 	req.Header.Set("User-Agent", c.userAgent())
 	req.Header.Set("X-TeamCity-Client", c.teamCityClientHeader())
+	for k, v := range c.extraHeaders {
+		req.Header.Set(k, v)
+	}
 }
 
 // WithContext returns a shallow copy of the client whose default context is ctx; mirrors http.Request.WithContext.

--- a/api/client.go
+++ b/api/client.go
@@ -161,13 +161,10 @@ func WithCommandName(name string) ClientOption {
 	}
 }
 
-// WithExtraHeaders sets headers applied to every request; CR/LF/NUL values and empty names are dropped.
+// WithExtraHeaders replaces the headers applied to every request; nil/empty clears env-loaded extras.
 func WithExtraHeaders(h map[string]string) ClientOption {
 	return func(c *Client) {
-		if len(h) == 0 {
-			return
-		}
-		clean := make(map[string]string, len(h))
+		var clean map[string]string
 		for k, v := range h {
 			if strings.ContainsAny(v, "\r\n\x00") {
 				continue
@@ -175,6 +172,9 @@ func WithExtraHeaders(h map[string]string) ClientOption {
 			name := http.CanonicalHeaderKey(strings.TrimSpace(k))
 			if name == "" {
 				continue
+			}
+			if clean == nil {
+				clean = make(map[string]string, len(h))
 			}
 			clean[name] = v
 		}

--- a/api/client.go
+++ b/api/client.go
@@ -255,6 +255,14 @@ func (c *Client) SetCommandName(name string) {
 	c.commandName = name
 }
 
+// applyStandardHeaders sets the per-request headers that every outgoing TeamCity request
+// must carry. Caller-configurable extra headers (set via WithExtraHeaders) plug in here in
+// a follow-up commit so probe, PKCE, raw, and typed requests all pass through one chokepoint.
+func (c *Client) applyStandardHeaders(req *http.Request) {
+	req.Header.Set("User-Agent", c.userAgent())
+	req.Header.Set("X-TeamCity-Client", c.teamCityClientHeader())
+}
+
 // WithContext returns a shallow copy of the client whose default context is ctx; mirrors http.Request.WithContext.
 func (c *Client) WithContext(ctx context.Context) *Client {
 	c2 := *c
@@ -350,9 +358,8 @@ func (c *Client) doRequestFull(ctx context.Context, method, path string, body io
 	}
 
 	c.setAuth(req)
+	c.applyStandardHeaders(req)
 	req.Header.Set("Accept", accept)
-	req.Header.Set("User-Agent", c.userAgent())
-	req.Header.Set("X-TeamCity-Client", c.teamCityClientHeader())
 	if body != nil {
 		req.Header.Set("Content-Type", contentType)
 	}
@@ -535,13 +542,13 @@ func (c *Client) doRawRequest(ctx context.Context, method, path string, body io.
 	}
 
 	c.setAuth(req)
+	c.applyStandardHeaders(req)
 	req.Header.Set("Accept", accept)
-	req.Header.Set("User-Agent", c.userAgent())
-	req.Header.Set("X-TeamCity-Client", c.teamCityClientHeader())
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
+	// Per-request headers run last so callers can override Accept / Content-Type / extras.
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}

--- a/api/headers.go
+++ b/api/headers.go
@@ -10,32 +10,22 @@ import (
 // TEAMCITY_HEADER_FOO_BAR=value sends "Foo-Bar: value" — underscores become hyphens, name is canonical-cased.
 const EnvHeaderPrefix = "TEAMCITY_HEADER_"
 
-// EnvHeaders returns extra headers gathered from TEAMCITY_HEADER_* env vars.
-// Values containing CR/LF/NUL bytes are dropped at the boundary. Empty names and empty values are skipped.
-// Returns nil if no matching env vars are set.
+// EnvHeaders returns TEAMCITY_HEADER_* env vars as a canonical-cased header map; constructors call this implicitly.
 func EnvHeaders() map[string]string {
 	var headers map[string]string
 	for _, e := range os.Environ() {
-		if !strings.HasPrefix(e, EnvHeaderPrefix) {
+		key, value, ok := strings.Cut(e, "=")
+		if !ok || !strings.HasPrefix(key, EnvHeaderPrefix) {
 			continue
 		}
-		eq := strings.IndexByte(e, '=')
-		if eq < 0 {
-			continue
-		}
-		rawName := e[len(EnvHeaderPrefix):eq]
-		if rawName == "" {
-			continue
-		}
-		value := e[eq+1:]
-		if value == "" || strings.ContainsAny(value, "\r\n\x00") {
+		suffix := key[len(EnvHeaderPrefix):]
+		if suffix == "" || value == "" || strings.ContainsAny(value, "\r\n\x00") {
 			continue
 		}
 		if headers == nil {
 			headers = map[string]string{}
 		}
-		name := http.CanonicalHeaderKey(strings.ReplaceAll(rawName, "_", "-"))
-		headers[name] = value
+		headers[http.CanonicalHeaderKey(strings.ReplaceAll(suffix, "_", "-"))] = value
 	}
 	return headers
 }

--- a/api/headers.go
+++ b/api/headers.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"net/http"
+	"os"
+	"strings"
+)
+
+// EnvHeaderPrefix is the env-var prefix that contributes extra HTTP headers to every request.
+// TEAMCITY_HEADER_FOO_BAR=value sends "Foo-Bar: value" — underscores become hyphens, name is canonical-cased.
+const EnvHeaderPrefix = "TEAMCITY_HEADER_"
+
+// EnvHeaders returns extra headers gathered from TEAMCITY_HEADER_* env vars.
+// Values containing CR/LF/NUL bytes are dropped at the boundary. Empty names and empty values are skipped.
+// Returns nil if no matching env vars are set.
+func EnvHeaders() map[string]string {
+	var headers map[string]string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, EnvHeaderPrefix) {
+			continue
+		}
+		eq := strings.IndexByte(e, '=')
+		if eq < 0 {
+			continue
+		}
+		rawName := e[len(EnvHeaderPrefix):eq]
+		if rawName == "" {
+			continue
+		}
+		value := e[eq+1:]
+		if value == "" || strings.ContainsAny(value, "\r\n\x00") {
+			continue
+		}
+		if headers == nil {
+			headers = map[string]string{}
+		}
+		name := http.CanonicalHeaderKey(strings.ReplaceAll(rawName, "_", "-"))
+		headers[name] = value
+	}
+	return headers
+}

--- a/api/headers_test.go
+++ b/api/headers_test.go
@@ -2,13 +2,27 @@ package api
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// init guards against accidentally inheriting TEAMCITY_HEADER_* env vars from CI or a
+// developer shell. Tests that need them set must use t.Setenv per-test; a stray export
+// would silently change request payloads in unrelated tests.
+func init() {
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, EnvHeaderPrefix) {
+			panic(fmt.Sprintf("api tests must run with no %s* env set; found: %s", EnvHeaderPrefix, e))
+		}
+	}
+}
 
 // TestStandardHeadersOnEveryEntryPoint asserts that User-Agent and X-TeamCity-Client are
 // set on requests from every code path: typed (doRequestFull), raw (doRawRequest),
@@ -120,4 +134,159 @@ func TestStandardHeadersOnEveryEntryPoint(T *testing.T) {
 		// And content-type for the form payload is preserved.
 		assert.Equal(T, "application/x-www-form-urlencoded", got.Get("Content-Type"))
 	})
+}
+
+func TestEnvHeaders(T *testing.T) {
+	// No T.Parallel: subtests use t.Setenv, which forbids any parallel ancestor.
+
+	T.Run("nil when no matching env vars", func(t *testing.T) {
+		t.Setenv("UNRELATED_ENV", "x")
+		got := EnvHeaders()
+		assert.Nil(t, got)
+	})
+
+	T.Run("translates underscores to hyphens and canonicalizes case", func(t *testing.T) {
+		t.Setenv("TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID", "abc.id")
+		t.Setenv("TEAMCITY_HEADER_X_FOO", "bar")
+
+		got := EnvHeaders()
+		assert.Equal(t, "abc.id", got["Cf-Access-Client-Id"])
+		assert.Equal(t, "bar", got["X-Foo"])
+	})
+
+	T.Run("drops empty values", func(t *testing.T) {
+		t.Setenv("TEAMCITY_HEADER_X_EMPTY", "")
+		got := EnvHeaders()
+		_, present := got["X-Empty"]
+		assert.False(t, present, "empty value should not produce a header")
+	})
+
+	T.Run("drops values with CR or LF (header-injection guard)", func(t *testing.T) {
+		// NUL bytes can't be set via os.Setenv on most platforms; the guard for them
+		// is exercised in TestWithExtraHeaders_DropsCRLFAtConstruction below.
+		t.Setenv("TEAMCITY_HEADER_X_CR", "value\rinjected")
+		t.Setenv("TEAMCITY_HEADER_X_LF", "value\ninjected")
+		t.Setenv("TEAMCITY_HEADER_X_GOOD", "ok")
+
+		got := EnvHeaders()
+		_, hasCR := got["X-Cr"]
+		_, hasLF := got["X-Lf"]
+		assert.False(t, hasCR)
+		assert.False(t, hasLF)
+		assert.Equal(t, "ok", got["X-Good"])
+	})
+}
+
+func TestWithExtraHeaders_AppliedOnEveryEntryPoint(T *testing.T) {
+	T.Parallel()
+
+	probe := func(t *testing.T, run func(c *Client)) http.Header {
+		t.Helper()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		t.Cleanup(server.Close)
+
+		c := NewClient(server.URL, "tok", WithExtraHeaders(map[string]string{
+			"CF-Access-Client-Id":     "abc.id",
+			"CF-Access-Client-Secret": "shh",
+		}))
+		run(c)
+		return got
+	}
+
+	cases := []struct {
+		name string
+		run  func(c *Client)
+	}{
+		{"typed GET", func(c *Client) { _, _ = c.GetServer() }},
+		{"RawRequest", func(c *Client) { _, _ = c.RawRequest(T.Context(), "GET", "/x", nil, nil) }},
+		{"RebootAgent", func(c *Client) { _ = c.RebootAgent(T.Context(), 1, false) }},
+		{"DownloadArtifactTo", func(c *Client) {
+			var b bytes.Buffer
+			_, _ = c.DownloadArtifactTo(T.Context(), "1", "x.txt", &b)
+		}},
+		{"Probe", func(c *Client) { _ = c.Probe(T.Context()) }},
+		{"IsPkceEnabled", func(c *Client) { _, _ = c.IsPkceEnabled(T.Context()) }},
+	}
+	for _, tc := range cases {
+		T.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := probe(t, tc.run)
+			assert.Equal(t, "abc.id", got.Get("Cf-Access-Client-Id"))
+			assert.Equal(t, "shh", got.Get("Cf-Access-Client-Secret"))
+		})
+	}
+}
+
+func TestWithExtraHeaders_RawRequestPerRequestOverrides(T *testing.T) {
+	T.Parallel()
+
+	var got http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.WriteHeader(http.StatusOK)
+	}))
+	T.Cleanup(server.Close)
+
+	c := NewClient(server.URL, "tok", WithExtraHeaders(map[string]string{
+		"X-Common": "from-extras",
+	}))
+	_, err := c.RawRequest(T.Context(), "GET", "/x", nil, map[string]string{
+		"X-Common": "from-call-site",
+	})
+	require.NoError(T, err)
+
+	assert.Equal(T, "from-call-site", got.Get("X-Common"), "per-request headers must override extras")
+}
+
+func TestWithExtraHeaders_DropsCRLFAtConstruction(T *testing.T) {
+	T.Parallel()
+
+	var got http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	T.Cleanup(server.Close)
+
+	c := NewClient(server.URL, "tok", WithExtraHeaders(map[string]string{
+		"X-Bad":  "value\r\nInjected: yes",
+		"X-Nul":  "value\x00injected",
+		"X-Good": "ok",
+		"":       "no-name",
+	}))
+	_, _ = c.GetServer()
+	assert.Empty(T, got.Get("X-Bad"))
+	assert.Empty(T, got.Get("X-Nul"))
+	assert.Empty(T, got.Get("Injected"))
+	assert.Equal(T, "ok", got.Get("X-Good"))
+}
+
+func TestWithExtraHeaders_RedactedInDebugLog(T *testing.T) {
+	T.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{}`))
+	}))
+	T.Cleanup(server.Close)
+
+	var debug bytes.Buffer
+	c := NewClient(server.URL, "tok",
+		WithExtraHeaders(map[string]string{"X-Secret-Header": "verysecret"}),
+		WithDebugFunc(func(format string, args ...any) {
+			fmt.Fprintf(&debug, format+"\n", args...)
+		}),
+	)
+	_, _ = c.GetServer()
+
+	out := debug.String()
+	assert.Contains(T, out, "X-Secret-Header: [REDACTED]")
+	assert.NotContains(T, out, "verysecret", "extra-header values must never appear in debug output")
 }

--- a/api/headers_test.go
+++ b/api/headers_test.go
@@ -5,199 +5,17 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// init guards against accidentally inheriting TEAMCITY_HEADER_* env vars from CI or a
-// developer shell. Tests that need them set must use t.Setenv per-test; a stray export
-// would silently change request payloads in unrelated tests.
-func init() {
-	for _, e := range os.Environ() {
-		if strings.HasPrefix(e, EnvHeaderPrefix) {
-			panic(fmt.Sprintf("api tests must run with no %s* env set; found: %s", EnvHeaderPrefix, e))
-		}
-	}
-}
-
-// TestStandardHeadersOnEveryEntryPoint asserts that User-Agent and X-TeamCity-Client are
-// set on requests from every code path: typed (doRequestFull), raw (doRawRequest),
-// reboot (RebootAgent), download (DownloadArtifactTo), probe, and PKCE.
-func TestStandardHeadersOnEveryEntryPoint(T *testing.T) {
+// TestApplyStandardHeadersOnEveryEntryPoint asserts that for every code path that builds an HTTP
+// request — typed, raw, reboot, download, probe, and PKCE — the client sends User-Agent,
+// X-TeamCity-Client, and any caller-configured extra headers. This is the single chokepoint test.
+func TestApplyStandardHeadersOnEveryEntryPoint(T *testing.T) {
 	T.Parallel()
-
-	check := func(t *testing.T, h http.Header) {
-		t.Helper()
-		ua := h.Get("User-Agent")
-		tc := h.Get("X-TeamCity-Client")
-		assert.True(t, strings.HasPrefix(ua, "teamcity-cli/"), "User-Agent should be teamcity-cli/...; got %q", ua)
-		assert.True(t, strings.HasPrefix(tc, "teamcity-cli/"), "X-TeamCity-Client should be teamcity-cli/...; got %q", tc)
-	}
-
-	T.Run("typed GET via doRequestFull", func(t *testing.T) {
-		t.Parallel()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{}`))
-		}))
-		t.Cleanup(server.Close)
-
-		_, _ = NewClient(server.URL, "tok").GetServer()
-		check(t, got)
-	})
-
-	T.Run("raw via doRawRequest", func(t *testing.T) {
-		t.Parallel()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(server.Close)
-
-		_, _ = NewClient(server.URL, "tok").RawRequest(T.Context(), "GET", "/x", nil, nil)
-		check(t, got)
-	})
-
-	T.Run("RebootAgent", func(t *testing.T) {
-		t.Parallel()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(server.Close)
-
-		_ = NewClient(server.URL, "tok").RebootAgent(T.Context(), 1, false)
-		check(t, got)
-	})
-
-	T.Run("DownloadArtifactTo", func(t *testing.T) {
-		t.Parallel()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(server.Close)
-
-		var buf bytes.Buffer
-		_, _ = NewClient(server.URL, "tok").DownloadArtifactTo(T.Context(), "1", "x.txt", &buf)
-		check(t, got)
-	})
-
-	T.Run("Probe", func(t *testing.T) {
-		t.Parallel()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(server.Close)
-
-		_ = NewGuestClient(server.URL).Probe(T.Context())
-		check(t, got)
-	})
-
-	T.Run("IsPkceEnabled", func(t *testing.T) {
-		t.Parallel()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(server.Close)
-
-		_, _ = NewGuestClient(server.URL).IsPkceEnabled(T.Context())
-		check(t, got)
-	})
-
-	T.Run("ExchangeCodeForToken", func(t *testing.T) {
-		t.Parallel()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.Header().Set("Content-Type", "application/json")
-			w.Write([]byte(`{"access_token":"t"}`))
-		}))
-		t.Cleanup(server.Close)
-
-		_, _ = NewGuestClient(server.URL).ExchangeCodeForToken(T.Context(), "code", "verifier", "http://localhost/cb")
-		check(t, got)
-
-		// And content-type for the form payload is preserved.
-		assert.Equal(T, "application/x-www-form-urlencoded", got.Get("Content-Type"))
-	})
-}
-
-func TestEnvHeaders(T *testing.T) {
-	// No T.Parallel: subtests use t.Setenv, which forbids any parallel ancestor.
-
-	T.Run("nil when no matching env vars", func(t *testing.T) {
-		t.Setenv("UNRELATED_ENV", "x")
-		got := EnvHeaders()
-		assert.Nil(t, got)
-	})
-
-	T.Run("translates underscores to hyphens and canonicalizes case", func(t *testing.T) {
-		t.Setenv("TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID", "abc.id")
-		t.Setenv("TEAMCITY_HEADER_X_FOO", "bar")
-
-		got := EnvHeaders()
-		assert.Equal(t, "abc.id", got["Cf-Access-Client-Id"])
-		assert.Equal(t, "bar", got["X-Foo"])
-	})
-
-	T.Run("drops empty values", func(t *testing.T) {
-		t.Setenv("TEAMCITY_HEADER_X_EMPTY", "")
-		got := EnvHeaders()
-		_, present := got["X-Empty"]
-		assert.False(t, present, "empty value should not produce a header")
-	})
-
-	T.Run("drops values with CR or LF (header-injection guard)", func(t *testing.T) {
-		// NUL bytes can't be set via os.Setenv on most platforms; the guard for them
-		// is exercised in TestWithExtraHeaders_DropsCRLFAtConstruction below.
-		t.Setenv("TEAMCITY_HEADER_X_CR", "value\rinjected")
-		t.Setenv("TEAMCITY_HEADER_X_LF", "value\ninjected")
-		t.Setenv("TEAMCITY_HEADER_X_GOOD", "ok")
-
-		got := EnvHeaders()
-		_, hasCR := got["X-Cr"]
-		_, hasLF := got["X-Lf"]
-		assert.False(t, hasCR)
-		assert.False(t, hasLF)
-		assert.Equal(t, "ok", got["X-Good"])
-	})
-}
-
-func TestWithExtraHeaders_AppliedOnEveryEntryPoint(T *testing.T) {
-	T.Parallel()
-
-	probe := func(t *testing.T, run func(c *Client)) http.Header {
-		t.Helper()
-		var got http.Header
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Clone()
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{}`))
-		}))
-		t.Cleanup(server.Close)
-
-		c := NewClient(server.URL, "tok", WithExtraHeaders(map[string]string{
-			"CF-Access-Client-Id":     "abc.id",
-			"CF-Access-Client-Secret": "shh",
-		}))
-		run(c)
-		return got
-	}
 
 	cases := []struct {
 		name string
@@ -212,15 +30,73 @@ func TestWithExtraHeaders_AppliedOnEveryEntryPoint(T *testing.T) {
 		}},
 		{"Probe", func(c *Client) { _ = c.Probe(T.Context()) }},
 		{"IsPkceEnabled", func(c *Client) { _, _ = c.IsPkceEnabled(T.Context()) }},
+		{"ExchangeCodeForToken", func(c *Client) {
+			_, _ = c.ExchangeCodeForToken(T.Context(), "code", "verifier", "http://localhost/cb")
+		}},
 	}
 	for _, tc := range cases {
 		T.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := probe(t, tc.run)
+
+			var got http.Header
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.Header.Clone()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			t.Cleanup(server.Close)
+
+			c := NewClient(server.URL, "tok", WithExtraHeaders(map[string]string{
+				"CF-Access-Client-Id":     "abc.id",
+				"CF-Access-Client-Secret": "shh",
+			}))
+			tc.run(c)
+
+			assert.Contains(t, got.Get("User-Agent"), "teamcity-cli/")
+			assert.Contains(t, got.Get("X-TeamCity-Client"), "teamcity-cli/")
 			assert.Equal(t, "abc.id", got.Get("Cf-Access-Client-Id"))
 			assert.Equal(t, "shh", got.Get("Cf-Access-Client-Secret"))
 		})
 	}
+}
+
+func TestEnvHeaders(T *testing.T) {
+	// No T.Parallel: subtests use t.Setenv, which forbids any parallel ancestor.
+
+	T.Run("nil when no matching env vars", func(t *testing.T) {
+		t.Setenv("UNRELATED_ENV", "x")
+		assert.Nil(t, EnvHeaders())
+	})
+
+	T.Run("translates underscores to hyphens and canonicalizes case", func(t *testing.T) {
+		t.Setenv("TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID", "abc.id")
+		t.Setenv("TEAMCITY_HEADER_X_FOO", "bar")
+
+		got := EnvHeaders()
+		assert.Equal(t, "abc.id", got["Cf-Access-Client-Id"])
+		assert.Equal(t, "bar", got["X-Foo"])
+	})
+
+	T.Run("drops empty values", func(t *testing.T) {
+		t.Setenv("TEAMCITY_HEADER_X_EMPTY", "")
+		_, present := EnvHeaders()["X-Empty"]
+		assert.False(t, present)
+	})
+
+	T.Run("drops values with CR or LF (header-injection guard)", func(t *testing.T) {
+		// NUL bytes can't be set via os.Setenv on most platforms; the NUL guard is
+		// exercised via WithExtraHeaders in TestWithExtraHeaders_DropsCRLFAtConstruction.
+		t.Setenv("TEAMCITY_HEADER_X_CR", "value\rinjected")
+		t.Setenv("TEAMCITY_HEADER_X_LF", "value\ninjected")
+		t.Setenv("TEAMCITY_HEADER_X_GOOD", "ok")
+
+		got := EnvHeaders()
+		_, hasCR := got["X-Cr"]
+		_, hasLF := got["X-Lf"]
+		assert.False(t, hasCR)
+		assert.False(t, hasLF)
+		assert.Equal(t, "ok", got["X-Good"])
+	})
 }
 
 func TestWithExtraHeaders_RawRequestPerRequestOverrides(T *testing.T) {

--- a/api/headers_test.go
+++ b/api/headers_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestApplyStandardHeadersOnEveryEntryPoint asserts that for every code path that builds an HTTP
-// request — typed, raw, reboot, download, probe, and PKCE — the client sends User-Agent,
-// X-TeamCity-Client, and any caller-configured extra headers. This is the single chokepoint test.
+// TestApplyStandardHeadersOnEveryEntryPoint asserts every HTTP entry point sends UA, X-TeamCity-Client, and extras.
 func TestApplyStandardHeadersOnEveryEntryPoint(T *testing.T) {
 	T.Parallel()
 

--- a/api/headers_test.go
+++ b/api/headers_test.go
@@ -1,0 +1,123 @@
+package api
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStandardHeadersOnEveryEntryPoint asserts that User-Agent and X-TeamCity-Client are
+// set on requests from every code path: typed (doRequestFull), raw (doRawRequest),
+// reboot (RebootAgent), download (DownloadArtifactTo), probe, and PKCE.
+func TestStandardHeadersOnEveryEntryPoint(T *testing.T) {
+	T.Parallel()
+
+	check := func(t *testing.T, h http.Header) {
+		t.Helper()
+		ua := h.Get("User-Agent")
+		tc := h.Get("X-TeamCity-Client")
+		assert.True(t, strings.HasPrefix(ua, "teamcity-cli/"), "User-Agent should be teamcity-cli/...; got %q", ua)
+		assert.True(t, strings.HasPrefix(tc, "teamcity-cli/"), "X-TeamCity-Client should be teamcity-cli/...; got %q", tc)
+	}
+
+	T.Run("typed GET via doRequestFull", func(t *testing.T) {
+		t.Parallel()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{}`))
+		}))
+		t.Cleanup(server.Close)
+
+		_, _ = NewClient(server.URL, "tok").GetServer()
+		check(t, got)
+	})
+
+	T.Run("raw via doRawRequest", func(t *testing.T) {
+		t.Parallel()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		_, _ = NewClient(server.URL, "tok").RawRequest(T.Context(), "GET", "/x", nil, nil)
+		check(t, got)
+	})
+
+	T.Run("RebootAgent", func(t *testing.T) {
+		t.Parallel()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		_ = NewClient(server.URL, "tok").RebootAgent(T.Context(), 1, false)
+		check(t, got)
+	})
+
+	T.Run("DownloadArtifactTo", func(t *testing.T) {
+		t.Parallel()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		var buf bytes.Buffer
+		_, _ = NewClient(server.URL, "tok").DownloadArtifactTo(T.Context(), "1", "x.txt", &buf)
+		check(t, got)
+	})
+
+	T.Run("Probe", func(t *testing.T) {
+		t.Parallel()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		_ = NewGuestClient(server.URL).Probe(T.Context())
+		check(t, got)
+	})
+
+	T.Run("IsPkceEnabled", func(t *testing.T) {
+		t.Parallel()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		_, _ = NewGuestClient(server.URL).IsPkceEnabled(T.Context())
+		check(t, got)
+	})
+
+	T.Run("ExchangeCodeForToken", func(t *testing.T) {
+		t.Parallel()
+		var got http.Header
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Clone()
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"access_token":"t"}`))
+		}))
+		t.Cleanup(server.Close)
+
+		_, _ = NewGuestClient(server.URL).ExchangeCodeForToken(T.Context(), "code", "verifier", "http://localhost/cb")
+		check(t, got)
+
+		// And content-type for the form payload is preserved.
+		assert.Equal(T, "application/x-www-form-urlencoded", got.Get("Content-Type"))
+	})
+}

--- a/api/pkce.go
+++ b/api/pkce.go
@@ -119,12 +119,13 @@ func FindAvailableListener() (net.Listener, error) {
 	return l, nil
 }
 
-func IsPkceEnabled(ctx context.Context, serverURL string) (bool, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(serverURL, "/")+PkceIsEnabledPath, nil)
+// IsPkceEnabled reports whether the server at c.BaseURL advertises PKCE support.
+func (c *Client) IsPkceEnabled(ctx context.Context) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(c.BaseURL, "/")+PkceIsEnabledPath, nil)
 	if err != nil {
 		return false, err
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return false, fmt.Errorf("check PKCE status: %w", err)
 	}
@@ -179,7 +180,8 @@ func DefaultScopes() []string {
 	return slices.Clone(fallbackScopes)
 }
 
-func ExchangeCodeForToken(ctx context.Context, serverURL, code, verifier, redirectURI string) (*TokenResponse, error) {
+// ExchangeCodeForToken trades a PKCE authorization code for an access token at c.BaseURL.
+func (c *Client) ExchangeCodeForToken(ctx context.Context, code, verifier, redirectURI string) (*TokenResponse, error) {
 	data := url.Values{}
 	data.Set("grant_type", "authorization_code")
 	data.Set("client_id", PkceClientID)
@@ -187,13 +189,13 @@ func ExchangeCodeForToken(ctx context.Context, serverURL, code, verifier, redire
 	data.Set("code_verifier", verifier)
 	data.Set("redirect_uri", redirectURI)
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(serverURL, "/")+PkceTokenPath, strings.NewReader(data.Encode()))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, strings.TrimSuffix(c.BaseURL, "/")+PkceTokenPath, strings.NewReader(data.Encode()))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("token request: %w", err)
 	}

--- a/api/pkce.go
+++ b/api/pkce.go
@@ -125,6 +125,7 @@ func (c *Client) IsPkceEnabled(ctx context.Context) (bool, error) {
 	if err != nil {
 		return false, err
 	}
+	c.applyStandardHeaders(req)
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return false, fmt.Errorf("check PKCE status: %w", err)
@@ -194,6 +195,7 @@ func (c *Client) ExchangeCodeForToken(ctx context.Context, code, verifier, redir
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	c.applyStandardHeaders(req)
 
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {

--- a/api/pkce_test.go
+++ b/api/pkce_test.go
@@ -233,7 +233,7 @@ func TestIsPkceEnabled(T *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		enabled, err := IsPkceEnabled(T.Context(), server.URL)
+		enabled, err := NewGuestClient(server.URL).IsPkceEnabled(T.Context())
 		assert.NoError(t, err)
 		assert.True(t, enabled)
 	})
@@ -246,7 +246,7 @@ func TestIsPkceEnabled(T *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		enabled, err := IsPkceEnabled(T.Context(), server.URL)
+		enabled, err := NewGuestClient(server.URL).IsPkceEnabled(T.Context())
 		assert.NoError(t, err)
 		assert.False(t, enabled)
 	})
@@ -256,7 +256,7 @@ func TestIsPkceEnabled(T *testing.T) {
 
 		ctx, cancel := context.WithTimeout(T.Context(), 100*time.Millisecond)
 		defer cancel()
-		enabled, err := IsPkceEnabled(ctx, "http://localhost:1")
+		enabled, err := NewGuestClient("http://localhost:1").IsPkceEnabled(ctx)
 		assert.Error(t, err)
 		assert.False(t, enabled)
 	})
@@ -335,7 +335,7 @@ func TestExchangeCodeForToken(T *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		token, err := ExchangeCodeForToken(T.Context(), server.URL, "testcode", "testverifier", "http://localhost:19000/callback")
+		token, err := NewGuestClient(server.URL).ExchangeCodeForToken(T.Context(), "testcode", "testverifier", "http://localhost:19000/callback")
 		require.NoError(t, err)
 		assert.Equal(t, "token123", token.AccessToken)
 		assert.Equal(t, "Bearer", token.TokenType)
@@ -351,7 +351,7 @@ func TestExchangeCodeForToken(T *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		_, err := ExchangeCodeForToken(T.Context(), server.URL, "invalidcode", "verifier", "http://localhost:19000/callback")
+		_, err := NewGuestClient(server.URL).ExchangeCodeForToken(T.Context(), "invalidcode", "verifier", "http://localhost:19000/callback")
 		assert.Error(t, err)
 	})
 }

--- a/api/probe.go
+++ b/api/probe.go
@@ -14,17 +14,18 @@ const probeTimeout = 10 * time.Second
 // ErrLoginGatewayDetected indicates the API endpoint was served by an SSO / login gateway rather than TeamCity itself.
 var ErrLoginGatewayDetected = errors.New("login gateway detected — VPN may be required")
 
-// ProbeTeamCity checks whether serverURL points to a reachable TeamCity server without sending credentials.
-func ProbeTeamCity(ctx context.Context, serverURL string) error {
+// Probe checks whether c.BaseURL points to a reachable TeamCity server without sending credentials.
+func (c *Client) Probe(ctx context.Context) error {
 	ctx, cancel := context.WithTimeout(ctx, probeTimeout)
 	defer cancel()
-	u := strings.TrimSuffix(serverURL, "/") + "/app/rest/server/version"
+	u := strings.TrimSuffix(c.BaseURL, "/") + "/app/rest/server/version"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
 		return err
 	}
-	client := &http.Client{Transport: defaultTransport()}
-	resp, err := client.Do(req)
+	// Probe deliberately does not call setAuth — reaching the server is what we care about,
+	// not whether credentials work.
+	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return err
 	}

--- a/api/probe.go
+++ b/api/probe.go
@@ -25,6 +25,7 @@ func (c *Client) Probe(ctx context.Context) error {
 	}
 	// Probe deliberately does not call setAuth — reaching the server is what we care about,
 	// not whether credentials work.
+	c.applyStandardHeaders(req)
 	resp, err := c.HTTPClient.Do(req)
 	if err != nil {
 		return err

--- a/api/probe_test.go
+++ b/api/probe_test.go
@@ -80,11 +80,4 @@ func TestClientProbe(T *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "HTTP 500")
 	})
-
-	T.Run("preserves transport (defaultTransport not dropped)", func(t *testing.T) {
-		t.Parallel()
-
-		client := NewGuestClient("https://example.com")
-		assert.NotNil(t, client.HTTPClient.Transport, "probe path must keep the configured transport")
-	})
 }

--- a/api/probe_test.go
+++ b/api/probe_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientProbe(T *testing.T) {
+	T.Parallel()
+
+	T.Run("returns nil on 200", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/app/rest/server/version", r.URL.Path)
+			assert.Empty(t, r.Header.Get("Authorization"), "probe must not send credentials")
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(server.Close)
+
+		client := NewGuestClient(server.URL)
+		assert.NoError(t, client.Probe(T.Context()))
+	})
+
+	T.Run("returns nil on 401/403 (auth-protected but reachable)", func(t *testing.T) {
+		t.Parallel()
+
+		for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(status)
+			}))
+			t.Cleanup(server.Close)
+
+			client := NewClient(server.URL, "ignored-token")
+			assert.NoError(t, client.Probe(T.Context()))
+		}
+	})
+
+	T.Run("returns ErrLoginGatewayDetected when API returns HTML", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("<html><body>Login</body></html>"))
+		}))
+		t.Cleanup(server.Close)
+
+		client := NewGuestClient(server.URL)
+		assert.ErrorIs(t, client.Probe(T.Context()), ErrLoginGatewayDetected)
+	})
+
+	T.Run("returns error on 404", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(server.Close)
+
+		client := NewGuestClient(server.URL)
+		err := client.Probe(T.Context())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not a TeamCity server")
+	})
+
+	T.Run("returns error on unexpected status", func(t *testing.T) {
+		t.Parallel()
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(server.Close)
+
+		client := NewGuestClient(server.URL)
+		err := client.Probe(T.Context())
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP 500")
+	})
+
+	T.Run("preserves transport (defaultTransport not dropped)", func(t *testing.T) {
+		t.Parallel()
+
+		client := NewGuestClient("https://example.com")
+		assert.NotNil(t, client.HTTPClient.Transport, "probe path must keep the configured transport")
+	})
+}

--- a/docs/topics/teamcity-cli-configuration.md
+++ b/docs/topics/teamcity-cli-configuration.md
@@ -316,6 +316,18 @@ Set to `1`, `true`, or `yes` to disable automatic update checks. Update checks a
 
 </td>
 </tr>
+<tr>
+<td>
+
+`TEAMCITY_HEADER_*`
+
+</td>
+<td>
+
+Add an HTTP header to every outgoing request. The suffix becomes the header name with underscores converted to hyphens, canonical-cased: `TEAMCITY_HEADER_FOO_BAR=baz` sends `Foo-Bar: baz`. Empty values are ignored; values containing CR/LF/NUL are dropped to prevent header injection. Header values are redacted in `--verbose` output.
+
+</td>
+</tr>
 </table>
 
 Examples:
@@ -349,6 +361,40 @@ set TEAMCITY_TOKEN=your-access-token
 </tabs>
 
 Setting `TERM=dumb` also disables colored output. Color is automatically disabled when output is not a terminal (for example, when piping to another command).
+
+### Extra HTTP headers (corporate proxies)
+
+If your TeamCity server sits behind an authenticating proxy such as **Cloudflare Access** or **Google IAP**, the proxy needs its own credentials on every request. `TEAMCITY_HEADER_*` lets you supply them via env vars without editing the config file. The CLI applies them to every API call, the auth login probe, the PKCE exchange, and the agent terminal WebSocket — anywhere a request might pass through the proxy.
+
+Header names follow these rules:
+
+- Suffix is uppercased after the prefix; underscores become hyphens; the result is canonical-cased.
+- `TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID=value` → `Cf-Access-Client-Id: value`.
+- Empty values are skipped. Values containing CR/LF/NUL are dropped.
+- Values are redacted in `--verbose` output, regardless of header name.
+
+#### Cloudflare Access service token
+
+```Shell
+export TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID="abc123.access"
+export TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET="$(cat ~/.cf-access-secret)"
+teamcity run list
+```
+
+#### Google IAP
+
+IAP requires a fresh ID token signed by your service account. A small wrapper keeps the token current:
+
+```Shell
+teamcity-iap() {
+  export TEAMCITY_HEADER_PROXY_AUTHORIZATION="Bearer $(gcloud auth print-identity-token --audiences=$IAP_AUDIENCE)"
+  teamcity "$@"
+}
+
+teamcity-iap run list
+```
+
+For repository-scoped configuration, set these in [direnv](https://direnv.net/) `.envrc` so they're only present when you `cd` into the project directory.
 
 ## Global flags
 

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -136,10 +136,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 		serverURL = config.NormalizeURL(serverURL)
 
 		p.Progress("Checking %s... ", output.Cyan(serverURL))
-		probeClient := api.NewGuestClient(serverURL,
-			api.WithVersion(version.String()),
-			api.WithExtraHeaders(api.EnvHeaders()),
-		)
+		probeClient := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
 		if err := probeClient.Probe(ctx); err != nil {
 			p.Info("%s", output.Red("✗"))
 			if errors.Is(err, context.Canceled) {
@@ -165,7 +162,6 @@ func finishGuestLogin(ctx context.Context, f *cmdutil.Factory, serverURL string)
 	client := api.NewGuestClient(serverURL,
 		api.WithDebugFunc(p.Debug),
 		api.WithVersion(version.String()),
-		api.WithExtraHeaders(api.EnvHeaders()),
 	).WithContext(ctx)
 	server, err := client.GetServer()
 	if err != nil {
@@ -248,7 +244,6 @@ func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial str
 		client := api.NewClient(serverURL, token,
 			api.WithDebugFunc(p.Debug),
 			api.WithVersion(version.String()),
-			api.WithExtraHeaders(api.EnvHeaders()),
 		).WithContext(ctx)
 		user, err := client.GetCurrentUser()
 		if err != nil {

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -136,7 +136,8 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 		serverURL = config.NormalizeURL(serverURL)
 
 		p.Progress("Checking %s... ", output.Cyan(serverURL))
-		if err := api.ProbeTeamCity(ctx, serverURL); err != nil {
+		probeClient := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
+		if err := probeClient.Probe(ctx); err != nil {
 			p.Info("%s", output.Red("✗"))
 			if errors.Is(err, context.Canceled) {
 				return "", err

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -136,7 +136,10 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 		serverURL = config.NormalizeURL(serverURL)
 
 		p.Progress("Checking %s... ", output.Cyan(serverURL))
-		probeClient := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
+		probeClient := api.NewGuestClient(serverURL,
+			api.WithVersion(version.String()),
+			api.WithExtraHeaders(api.EnvHeaders()),
+		)
 		if err := probeClient.Probe(ctx); err != nil {
 			p.Info("%s", output.Red("✗"))
 			if errors.Is(err, context.Canceled) {
@@ -162,6 +165,7 @@ func finishGuestLogin(ctx context.Context, f *cmdutil.Factory, serverURL string)
 	client := api.NewGuestClient(serverURL,
 		api.WithDebugFunc(p.Debug),
 		api.WithVersion(version.String()),
+		api.WithExtraHeaders(api.EnvHeaders()),
 	).WithContext(ctx)
 	server, err := client.GetServer()
 	if err != nil {
@@ -244,6 +248,7 @@ func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial str
 		client := api.NewClient(serverURL, token,
 			api.WithDebugFunc(p.Debug),
 			api.WithVersion(version.String()),
+			api.WithExtraHeaders(api.EnvHeaders()),
 		).WithContext(ctx)
 		user, err := client.GetCurrentUser()
 		if err != nil {

--- a/internal/cmd/auth/pkce.go
+++ b/internal/cmd/auth/pkce.go
@@ -20,10 +20,7 @@ const authCodeLifetime = 5 * time.Minute
 
 // attemptPkceLogin probes for PKCE support, lets the user pick which scopes to grant, then runs the browser flow.
 func attemptPkceLogin(ctx context.Context, p *output.Printer, serverURL string) (token, validUntil string) {
-	client := api.NewGuestClient(serverURL,
-		api.WithVersion(version.String()),
-		api.WithExtraHeaders(api.EnvHeaders()),
-	)
+	client := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
 	pctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	enabled, _ := client.IsPkceEnabled(pctx)
 	cancel()

--- a/internal/cmd/auth/pkce.go
+++ b/internal/cmd/auth/pkce.go
@@ -11,6 +11,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/JetBrains/teamcity-cli/internal/version"
 	"github.com/charmbracelet/huh"
 	"github.com/pkg/browser"
 )
@@ -19,8 +20,9 @@ const authCodeLifetime = 5 * time.Minute
 
 // attemptPkceLogin probes for PKCE support, lets the user pick which scopes to grant, then runs the browser flow.
 func attemptPkceLogin(ctx context.Context, p *output.Printer, serverURL string) (token, validUntil string) {
+	client := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
 	pctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	enabled, _ := api.IsPkceEnabled(pctx, serverURL)
+	enabled, _ := client.IsPkceEnabled(pctx)
 	cancel()
 	if !enabled {
 		return "", ""
@@ -30,7 +32,7 @@ func attemptPkceLogin(ctx context.Context, p *output.Printer, serverURL string) 
 		p.Info("Skipping browser login, entering token manually...")
 		return "", ""
 	}
-	resp, err := runPkceLogin(ctx, p, serverURL, scopes)
+	resp, err := runPkceLogin(ctx, p, client, scopes)
 	if err != nil {
 		p.Warn("Browser auth failed: %v", err)
 		p.Info("Falling back to manual token entry...")
@@ -75,7 +77,7 @@ func selectPkceScopes() []string {
 }
 
 // runPkceLogin orchestrates the browser-based PKCE auth flow with the given scopes and returns the minted access token.
-func runPkceLogin(parent context.Context, p *output.Printer, serverURL string, scopes []string) (*api.TokenResponse, error) {
+func runPkceLogin(parent context.Context, p *output.Printer, client *api.Client, scopes []string) (*api.TokenResponse, error) {
 	verifier, err := api.GenerateCodeVerifier()
 	if err != nil {
 		return nil, fmt.Errorf("generate code verifier: %w", err)
@@ -95,7 +97,7 @@ func runPkceLogin(parent context.Context, p *output.Printer, serverURL string, s
 	defer callbackServer.Shutdown()
 
 	redirectURI := fmt.Sprintf("http://localhost:%d%s", callbackServer.Port, api.DefaultCallbackPath)
-	authURL := api.BuildAuthorizeURL(serverURL, redirectURI, api.GenerateCodeChallenge(verifier), state, scopes)
+	authURL := api.BuildAuthorizeURL(client.BaseURL, redirectURI, api.GenerateCodeChallenge(verifier), state, scopes)
 
 	opening := fmt.Sprintf("Opening browser to authenticate with %d permissions...", len(scopes))
 	if total := len(api.DefaultScopes()); len(scopes) < total {
@@ -121,7 +123,7 @@ func runPkceLogin(parent context.Context, p *output.Printer, serverURL string, s
 
 		ctx, cancel := context.WithTimeout(parent, 30*time.Second)
 		defer cancel()
-		return api.ExchangeCodeForToken(ctx, serverURL, result.Code, verifier, redirectURI)
+		return client.ExchangeCodeForToken(ctx, result.Code, verifier, redirectURI)
 
 	case <-time.After(authCodeLifetime):
 		return nil, fmt.Errorf("timeout waiting for callback (exceeded %v)", authCodeLifetime)

--- a/internal/cmd/auth/pkce.go
+++ b/internal/cmd/auth/pkce.go
@@ -20,7 +20,10 @@ const authCodeLifetime = 5 * time.Minute
 
 // attemptPkceLogin probes for PKCE support, lets the user pick which scopes to grant, then runs the browser flow.
 func attemptPkceLogin(ctx context.Context, p *output.Printer, serverURL string) (token, validUntil string) {
-	client := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
+	client := api.NewGuestClient(serverURL,
+		api.WithVersion(version.String()),
+		api.WithExtraHeaders(api.EnvHeaders()),
+	)
 	pctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	enabled, _ := client.IsPkceEnabled(pctx)
 	cancel()

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -129,11 +129,7 @@ func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerC
 
 func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "guest", IsDefault: isDefault}
-	client := api.NewGuestClient(serverURL,
-		api.WithDebugFunc(f.Printer.Debug),
-		api.WithVersion(version.String()),
-		api.WithExtraHeaders(api.EnvHeaders()),
-	).WithContext(f.Context())
+	client := api.NewGuestClient(serverURL, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
@@ -155,11 +151,7 @@ func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) au
 
 func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "token", TokenSource: tokenSource, IsDefault: isDefault}
-	client := api.NewClient(serverURL, token,
-		api.WithDebugFunc(f.Printer.Debug),
-		api.WithVersion(version.String()),
-		api.WithExtraHeaders(api.EnvHeaders()),
-	).WithContext(f.Context())
+	client := api.NewClient(serverURL, token, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
@@ -203,7 +195,6 @@ func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth) authSta
 	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password,
 		api.WithDebugFunc(f.Printer.Debug),
 		api.WithVersion(version.String()),
-		api.WithExtraHeaders(api.EnvHeaders()),
 	).WithContext(f.Context())
 	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -129,12 +129,12 @@ func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerC
 
 func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "guest", IsDefault: isDefault}
-	if err := api.ProbeTeamCity(f.Context(), serverURL); err != nil {
+	client := api.NewGuestClient(serverURL, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
 		return s
 	}
-	client := api.NewGuestClient(serverURL, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	server, err := client.GetServer()
 	if err != nil {
 		s.Status = "error"
@@ -151,12 +151,12 @@ func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) au
 
 func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "token", TokenSource: tokenSource, IsDefault: isDefault}
-	if err := api.ProbeTeamCity(f.Context(), serverURL); err != nil {
+	client := api.NewClient(serverURL, token, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
 		return s
 	}
-	client := api.NewClient(serverURL, token, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	user, err := client.GetCurrentUser()
 	if err != nil {
 		s.Status = "error"
@@ -192,12 +192,12 @@ func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string
 
 func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth) authStatus {
 	s := authStatus{Server: buildAuth.ServerURL, AuthMethod: "build"}
-	if err := api.ProbeTeamCity(f.Context(), buildAuth.ServerURL); err != nil {
+	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, buildAuth.ServerURL)
 		return s
 	}
-	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
 	server, err := client.GetServer()
 	if err != nil {
 		s.Status = "error"

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -129,7 +129,11 @@ func collectServerStatus(f *cmdutil.Factory, serverURL string, sc config.ServerC
 
 func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "guest", IsDefault: isDefault}
-	client := api.NewGuestClient(serverURL, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	client := api.NewGuestClient(serverURL,
+		api.WithDebugFunc(f.Printer.Debug),
+		api.WithVersion(version.String()),
+		api.WithExtraHeaders(api.EnvHeaders()),
+	).WithContext(f.Context())
 	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
@@ -151,7 +155,11 @@ func collectGuestStatus(f *cmdutil.Factory, serverURL string, isDefault bool) au
 
 func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string, isDefault bool) authStatus {
 	s := authStatus{Server: serverURL, AuthMethod: "token", TokenSource: tokenSource, IsDefault: isDefault}
-	client := api.NewClient(serverURL, token, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	client := api.NewClient(serverURL, token,
+		api.WithDebugFunc(f.Printer.Debug),
+		api.WithVersion(version.String()),
+		api.WithExtraHeaders(api.EnvHeaders()),
+	).WithContext(f.Context())
 	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, serverURL)
@@ -192,7 +200,11 @@ func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string
 
 func collectBuildStatus(f *cmdutil.Factory, buildAuth *config.BuildAuth) authStatus {
 	s := authStatus{Server: buildAuth.ServerURL, AuthMethod: "build"}
-	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password, api.WithDebugFunc(f.Printer.Debug), api.WithVersion(version.String())).WithContext(f.Context())
+	client := api.NewClientWithBasicAuth(buildAuth.ServerURL, buildAuth.Username, buildAuth.Password,
+		api.WithDebugFunc(f.Printer.Debug),
+		api.WithVersion(version.String()),
+		api.WithExtraHeaders(api.EnvHeaders()),
+	).WithContext(f.Context())
 	if err := client.Probe(f.Context()); err != nil {
 		s.Status = "error"
 		s.Error = friendlyError(err, buildAuth.ServerURL)

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -18,6 +18,9 @@ func (f *Factory) defaultGetClient() (api.ClientInterface, error) {
 	verOpt := api.WithVersion(version.String())
 
 	opts := []api.ClientOption{debugOpt, roOpt, verOpt}
+	if h := api.EnvHeaders(); len(h) > 0 {
+		opts = append(opts, api.WithExtraHeaders(h))
+	}
 
 	if config.IsGuestAuth() {
 		if serverURL == "" {

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -17,10 +17,7 @@ func (f *Factory) defaultGetClient() (api.ClientInterface, error) {
 	roOpt := api.WithReadOnly(config.IsReadOnly())
 	verOpt := api.WithVersion(version.String())
 
-	opts := []api.ClientOption{debugOpt, roOpt, verOpt}
-	if h := api.EnvHeaders(); len(h) > 0 {
-		opts = append(opts, api.WithExtraHeaders(h))
-	}
+	opts := []api.ClientOption{debugOpt, roOpt, verOpt, api.WithExtraHeaders(api.EnvHeaders())}
 
 	if config.IsGuestAuth() {
 		if serverURL == "" {

--- a/internal/cmdutil/client.go
+++ b/internal/cmdutil/client.go
@@ -17,7 +17,7 @@ func (f *Factory) defaultGetClient() (api.ClientInterface, error) {
 	roOpt := api.WithReadOnly(config.IsReadOnly())
 	verOpt := api.WithVersion(version.String())
 
-	opts := []api.ClientOption{debugOpt, roOpt, verOpt, api.WithExtraHeaders(api.EnvHeaders())}
+	opts := []api.ClientOption{debugOpt, roOpt, verOpt}
 
 	if config.IsGuestAuth() {
 		if serverURL == "" {

--- a/internal/cmdutil/client_test.go
+++ b/internal/cmdutil/client_test.go
@@ -1,11 +1,14 @@
 package cmdutil
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveAuthSource(t *testing.T) {
@@ -42,4 +45,32 @@ func TestResolveAuthSource(t *testing.T) {
 			assert.Equal(t, tc.want, resolveAuthSource(tc.tokenSource))
 		})
 	}
+}
+
+func TestDefaultGetClient_AppliesEnvHeaders(t *testing.T) {
+	var got http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	t.Cleanup(server.Close)
+
+	t.Setenv(config.EnvServerURL, server.URL)
+	t.Setenv(config.EnvToken, "tok")
+	t.Setenv("TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID", "abc.id")
+	t.Setenv("TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET", "shh")
+
+	config.ResetForTest()
+	t.Cleanup(config.ResetForTest)
+
+	f := NewFactory()
+	client, err := f.Client()
+	require.NoError(t, err)
+
+	_, err = client.GetServer()
+	require.NoError(t, err)
+
+	assert.Equal(t, "abc.id", got.Get("Cf-Access-Client-Id"))
+	assert.Equal(t, "shh", got.Get("Cf-Access-Client-Secret"))
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -44,20 +44,22 @@ type Session struct {
 }
 
 type Client struct {
-	baseURL    string
-	username   string
-	token      string
-	httpClient *http.Client
-	debugf     func(string, ...any)
+	baseURL      string
+	username     string
+	token        string
+	httpClient   *http.Client
+	debugf       func(string, ...any)
+	extraHeaders map[string]string
 }
 
 func NewClient(baseURL, username, token string, debugf func(string, ...any)) *Client {
 	jar, _ := cookiejar.New(nil)
 	return &Client{
-		baseURL:  strings.TrimSuffix(baseURL, "/"),
-		username: username,
-		token:    token,
-		debugf:   debugf,
+		baseURL:      strings.TrimSuffix(baseURL, "/"),
+		username:     username,
+		token:        token,
+		debugf:       debugf,
+		extraHeaders: api.EnvHeaders(),
 		httpClient: &http.Client{
 			Jar:     jar,
 			Timeout: 30 * time.Second,
@@ -75,6 +77,9 @@ func (c *Client) OpenSession(agentID int) (*Session, error) {
 
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
+	for k, v := range c.extraHeaders {
+		req.Header.Set(k, v)
+	}
 
 	req.SetBasicAuth(cmp.Or(c.username, "token"), c.token)
 
@@ -127,6 +132,9 @@ func (c *Client) Connect(session *Session, cols, rows int) (*Conn, error) {
 
 	header := http.Header{}
 	header.Set("Origin", c.baseURL)
+	for k, v := range c.extraHeaders {
+		header.Set(k, v)
+	}
 
 	var cookies []string
 	for _, cookie := range c.httpClient.Jar.Cookies(u) {

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -16,6 +16,7 @@ Login options:
 Environment override note:
 - `TEAMCITY_URL` + `TEAMCITY_TOKEN` should be set together when overriding auth in scripts
 - `TEAMCITY_URL` alone bypasses stored `teamcity auth login` credentials
+- `TEAMCITY_HEADER_*` adds an HTTP header to every request: `TEAMCITY_HEADER_FOO_BAR=baz` sends `Foo-Bar: baz`. Use this for proxies that gate access (Cloudflare Access, Google IAP). Values are redacted in `--verbose` output.
 
 ## Builds/Runs (`teamcity run`)
 


### PR DESCRIPTION
## Summary

Users behind authenticating proxies (Cloudflare Access, Google IAP) can now point `teamcity` at a gated server by exporting `TEAMCITY_HEADER_*`. Every outgoing request — typed API, raw `api`, probe, PKCE token exchange, agent-terminal WebSocket — honors them.

Closes #286 (env-only alternative; @mscottford co-authored the feature commit).

## Changes

- `api/headers.go` — `EnvHeaders()` parses `TEAMCITY_HEADER_*` into a canonical-cased map. `TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID=abc` → `Cf-Access-Client-Id: abc`. CR/LF/NUL values dropped at the boundary.
- `api/client.go` — new `WithExtraHeaders` option, private `applyStandardHeaders` chokepoint sets `User-Agent` + `X-TeamCity-Client` + extras. Constructors pre-populate extras from env, so the option is the override path. Debug log redacts extra-header values alongside `Authorization` / `Cookie`.
- `api/probe.go`, `api/pkce.go` — `Probe`, `IsPkceEnabled`, `ExchangeCodeForToken` are now `*Client` methods so they share the configured transport and the chokepoint.
- `api/agents.go`, `api/builds_artifacts.go` — `RebootAgent` and `DownloadArtifactTo` route through the chokepoint (small UX upgrade: they now also send UA + X-TeamCity-Client).
- `internal/cmd/auth/{login,pkce,status}.go` — switched to the new method shapes. No explicit env plumbing — constructors honor it implicitly.
- `internal/terminal/terminal.go` — separate Client type, so it reads `api.EnvHeaders()` at construction and applies headers to both the OpenSession POST and the WebSocket upgrade.
- `acceptance/testdata/config/extra-headers.txtar` — runs against `cli.teamcity.com` with env vars set.
- `docs/`, `skills/` — Cloudflare Access + Google IAP recipes.

## Design Decisions

**Env-only.** The motivating use case (CF Access service token, IAP) is per-environment, not per-invocation — `direnv` solves repo scoping without us inventing `$VAR` expansion (which #286 had to do). If invocation-level overrides matter later, `WithExtraHeaders` is already the override path; a flag is purely additive.

**Implicit at construction, not opt-in.** Constructors call `EnvHeaders()` themselves before applying opts. Same shape as `HTTP_PROXY` for `http.DefaultTransport`. A future code path can't forget to thread the headers, because there's nothing to thread.

## Example

```bash
export TEAMCITY_HEADER_CF_ACCESS_CLIENT_ID="abc.access"
export TEAMCITY_HEADER_CF_ACCESS_CLIENT_SECRET="$(cat ~/.cf-access-secret)"
teamcity run list
```

Values are redacted in `--verbose`.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`) — including the new `extra-headers.txtar`
- [x] If adding a new command/flag: added `.txtar` test
- [ ] If adding a data-producing command: includes `--json` — N/A, no new commands
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, README — `docs/` + `skills/` updated; README has no env-var section