### PR TITLE
feat(pipeline): add `pipeline schema` to print the per-instance JSON schema

### DIFF
--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -156,6 +156,9 @@ func (c *Client) DeletePipeline(id string) error {
 	return c.doNoContent(c.ctx(), "DELETE", "/app/rest/projects/id:"+id, nil, "")
 }
 
+// ErrPipelineSchemaUnsupported is returned when the server's schema endpoint exists but does not produce JSON, indicating a TeamCity version older than 2026.1.
+var ErrPipelineSchemaUnsupported = errors.New("schema endpoint not available on this server")
+
 // GetPipelineSchema fetches the pipeline JSON schema from the server.
 func (c *Client) GetPipelineSchema() ([]byte, error) {
 	resp, err := c.doRequest(c.ctx(), "POST", "/app/pipeline/schema/generate", nil)
@@ -170,7 +173,7 @@ func (c *Client) GetPipelineSchema() ([]byte, error) {
 
 	ct := resp.Header.Get("Content-Type")
 	if !strings.Contains(ct, "application/json") {
-		return nil, errors.New("schema endpoint not available on this server")
+		return nil, ErrPipelineSchemaUnsupported
 	}
 
 	return io.ReadAll(resp.Body)

--- a/docs/topics/teamcity-cli-commands.md
+++ b/docs/topics/teamcity-cli-commands.md
@@ -1285,6 +1285,18 @@ Upload pipeline YAML
 <tr>
 <td>
 
+`teamcity pipeline schema`
+
+</td>
+<td>
+
+Print the pipeline JSON schema for the current server
+
+</td>
+</tr>
+<tr>
+<td>
+
 `teamcity pipeline validate`
 
 </td>

--- a/internal/cmd/pipeline/pipeline.go
+++ b/internal/cmd/pipeline/pipeline.go
@@ -27,6 +27,7 @@ See: https://www.jetbrains.com/help/teamcity/create-and-edit-pipelines.html`,
 	cmd.AddCommand(newPipelineDeleteCmd(f))
 	cmd.AddCommand(newPipelinePullCmd(f))
 	cmd.AddCommand(newPipelinePushCmd(f))
+	cmd.AddCommand(newPipelineSchemaCmd(f))
 
 	return cmd
 }

--- a/internal/cmd/pipeline/pipeline_test.go
+++ b/internal/cmd/pipeline/pipeline_test.go
@@ -1,6 +1,8 @@
 package pipeline_test
 
 import (
+	"net/http"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -46,4 +48,47 @@ func TestPipelineViewJSON(t *testing.T) {
 	out := cmdtest.CaptureOutput(t, ts.Factory, "pipeline", "view", "TestProject_CI", "--json")
 	assert.Contains(t, out, `"id"`)
 	assert.Contains(t, out, `"TestProject_CI"`)
+}
+
+func TestPipelineSchema(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "pipeline", "schema")
+	assert.Contains(t, out, `"type"`)
+	assert.Contains(t, out, `"object"`)
+	assert.NotContains(t, out, "warning:")
+}
+
+func TestPipelineSchemaRefresh(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	ts := cmdtest.SetupMockClient(t)
+	hits := 0
+	ts.Handle("POST /app/pipeline/schema/generate", func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"type":"object","x-hits":` + strconv.Itoa(hits) + `}`))
+	})
+
+	cmdtest.CaptureOutput(t, ts.Factory, "pipeline", "schema")
+	cmdtest.CaptureOutput(t, ts.Factory, "pipeline", "schema")
+	assert.Equal(t, 1, hits)
+	cmdtest.CaptureOutput(t, ts.Factory, "pipeline", "schema", "--refresh")
+	assert.Equal(t, 2, hits)
+}
+
+func TestPipelineSchemaEmbeddedFallback(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("POST /app/pipeline/schema/generate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html></html>"))
+	})
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "pipeline", "schema")
+	assert.Contains(t, out, "warning:")
+	assert.Contains(t, out, "predate TeamCity 2026.1")
+
+	err := cmdtest.CaptureErr(t, ts.Factory, "pipeline", "schema", "--refresh")
+	assert.Contains(t, err.Error(), "schema endpoint not available")
 }

--- a/internal/cmd/pipeline/pipeline_test.go
+++ b/internal/cmd/pipeline/pipeline_test.go
@@ -92,3 +92,15 @@ func TestPipelineSchemaEmbeddedFallback(t *testing.T) {
 	err := cmdtest.CaptureErr(t, ts.Factory, "pipeline", "schema", "--refresh")
 	assert.Contains(t, err.Error(), "schema endpoint not available")
 }
+
+func TestPipelineSchemaServerErrorPropagates(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("POST /app/pipeline/schema/generate", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+
+	err := cmdtest.CaptureErr(t, ts.Factory, "pipeline", "schema")
+	assert.Contains(t, err.Error(), "failed to fetch pipeline schema")
+	assert.NotContains(t, err.Error(), "predate TeamCity 2026.1")
+}

--- a/internal/cmd/pipeline/schema.go
+++ b/internal/cmd/pipeline/schema.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/spf13/cobra"
 )
 
 const schemaTTL = 24 * time.Hour
@@ -69,21 +71,66 @@ func saveSchemaCache(serverURL string, schema []byte) error {
 	return os.WriteFile(path, schema, 0600)
 }
 
-func fetchOrCacheSchema(client *api.Client, refresh bool) ([]byte, error) {
+// fetchOrCacheSchema returns the pipeline JSON schema. The bool is true when
+// the embedded fallback was returned because the server doesn't support the
+// endpoint (e.g. TeamCity < 2026.1). The bool is meaningless when err != nil.
+func fetchOrCacheSchema(client *api.Client, refresh bool) ([]byte, bool, error) {
 	if !refresh {
 		if cached, err := loadCachedSchema(client.BaseURL); err == nil {
-			return cached, nil
+			return cached, false, nil
 		}
 	}
 
 	schema, err := client.GetPipelineSchema()
 	if err == nil {
 		_ = saveSchemaCache(client.BaseURL, schema)
-		return schema, nil
+		return schema, false, nil
 	}
 
 	if !refresh {
-		return embeddedSchema, nil
+		return embeddedSchema, true, nil
 	}
-	return nil, fmt.Errorf("failed to fetch pipeline schema from server: %w", err)
+	return nil, false, fmt.Errorf("failed to fetch pipeline schema from server: %w", err)
+}
+
+func newPipelineSchemaCmd(f *cmdutil.Factory) *cobra.Command {
+	var refresh bool
+
+	cmd := &cobra.Command{
+		Use:   "schema",
+		Short: "Print the pipeline JSON schema for the current server",
+		Long: `Fetch the per-instance pipeline JSON schema and print it to stdout.
+
+The schema is cached locally for 24 hours. When the server does not support
+the schema endpoint (TeamCity < 2026.1), an embedded fallback is printed and
+a warning is written to stderr; pass --refresh to require a live server fetch.`,
+		Example: `  teamcity pipeline schema
+  teamcity pipeline schema > schema.json
+  teamcity pipeline schema --refresh`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			client, err := f.Client()
+			if err != nil {
+				return err
+			}
+			c, ok := client.(*api.Client)
+			if !ok {
+				return errors.New("schema requires a real API client")
+			}
+
+			data, fallback, err := fetchOrCacheSchema(c, refresh)
+			if err != nil {
+				return err
+			}
+			if fallback {
+				_, _ = fmt.Fprintln(f.Printer.ErrOut,
+					"warning: server did not return a schema (server may predate TeamCity 2026.1)")
+			}
+			_, err = f.Printer.Out.Write(data)
+			return err
+		},
+	}
+
+	cmd.Flags().BoolVar(&refresh, "refresh", false, "Force re-fetch from server, bypassing the 24h cache")
+	return cmd
 }

--- a/internal/cmd/pipeline/schema.go
+++ b/internal/cmd/pipeline/schema.go
@@ -71,9 +71,7 @@ func saveSchemaCache(serverURL string, schema []byte) error {
 	return os.WriteFile(path, schema, 0600)
 }
 
-// fetchOrCacheSchema returns the pipeline JSON schema. The bool is true when
-// the embedded fallback was returned because the server doesn't support the
-// endpoint (e.g. TeamCity < 2026.1). The bool is meaningless when err != nil.
+// fetchOrCacheSchema returns the pipeline JSON schema; the bool reports whether the embedded fallback was used.
 func fetchOrCacheSchema(client *api.Client, refresh bool) ([]byte, bool, error) {
 	if !refresh {
 		if cached, err := loadCachedSchema(client.BaseURL); err == nil {

--- a/internal/cmd/pipeline/schema.go
+++ b/internal/cmd/pipeline/schema.go
@@ -85,7 +85,7 @@ func fetchOrCacheSchema(client *api.Client, refresh bool) ([]byte, bool, error) 
 		return schema, false, nil
 	}
 
-	if !refresh {
+	if !refresh && errors.Is(err, api.ErrPipelineSchemaUnsupported) {
 		return embeddedSchema, true, nil
 	}
 	return nil, false, fmt.Errorf("failed to fetch pipeline schema from server: %w", err)

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -111,7 +111,8 @@ func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, error) {
 		return nil, errors.New("schema caching requires a real API client")
 	}
 
-	return fetchOrCacheSchema(c, opts.refreshSchema)
+	data, _, err := fetchOrCacheSchema(c, opts.refreshSchema)
+	return data, err
 }
 
 type validationError struct {


### PR DESCRIPTION
## Summary

Adds `teamcity pipeline schema`, a standalone subcommand that prints the per-instance pipeline JSON schema to stdout. Useful for tooling (e.g. AI agents grounding YAML generation) that wants the schema without running validation. Reuses the existing fetch/cache/embedded-fallback logic from `pipeline validate`.

## Changes

- `internal/cmd/pipeline/schema.go`: new `newPipelineSchemaCmd` with a `--refresh` flag that bypasses the 24h cache. `fetchOrCacheSchema` now also returns a `fallback bool` so the new command can warn the user when the embedded schema is being used.
- `internal/cmd/pipeline/validate.go`: adapted to the new `fetchOrCacheSchema` signature; behavior unchanged (still silently uses the embedded fallback).
- `internal/cmd/pipeline/pipeline.go`: registers the new subcommand.
- `internal/cmd/pipeline/pipeline_test.go`: three new unit tests covering the happy path, cache + `--refresh` behavior, and the embedded-fallback warning + `--refresh` error.
- `docs/topics/teamcity-cli-commands.md`: regenerated via `just docs-generate`.

## Design Decisions

- **Stderr warning when falling back to the embedded schema.** When the server doesn't support the `/app/pipeline/schema/generate` endpoint (TeamCity < 2026.1, e.g. cli.teamcity.com on 2025.11 today), the command still prints the embedded schema so pipes to `jq` keep working — but writes a one-line warning to stderr so the user knows the output is generic, not server-specific. `--refresh` is the escape hatch: it requires a live server fetch and errors out instead of silently falling back.
- **No `-o`/`--output` flag.** Shell redirection (`> schema.json`) covers it with less surface area.
- **No `--format`/pretty-printing flag.** Server returns JSON; passthrough is sufficient. Users can pipe through `jq` if they want it pretty.
- **`validate` still ignores the fallback signal.** It already silently uses the embedded schema today; the bool-return refactor is the minimum delta needed to surface fallback to the new command without changing `validate` behavior.

## Example

```bash
$ teamcity pipeline schema | jq -r 'keys[0:5]'
[
  "$schema",
  "definitions",
  "properties",
  "required",
  "type"
]

$ teamcity pipeline schema --refresh > schema.json   # bypass cache

$ teamcity pipeline schema 2>&1 >/dev/null           # against pre-2026.1 server
warning: server did not return a schema (server may predate TeamCity 2026.1)
```

## Test Plan

- [x] Unit tests pass (`just unit`) — 289 tests, including 3 new ones for `pipeline schema`
- [x] Linter passes (`just lint`) — 0 issues
- [ ] Acceptance tests pass (`just acceptance`) — N/A: cli.teamcity.com is on 2025.11 and doesn't support the endpoint yet; acceptance test deferred until that instance upgrades to 2026.1+
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — covered by unit tests against a mock server (the schema endpoint behavior is exercised end-to-end including the embedded-fallback path); skipping txtar for the same reason as acceptance
- [ ] If adding a data-producing command: includes `--json` support — N/A: the command's output already _is_ JSON (the schema itself); a `--json` flag would be redundant
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — `docs/topics/teamcity-cli-commands.md` regenerated; the user's local `~/.claude/skills/teamcity-cli` references were updated separately; `README.md` doesn't enumerate per-subcommand surface so no change needed there