### PR TITLE
feat: add offline shell completions for flags and positional arguments

### DIFF
--- a/internal/cmd/alias/alias.go
+++ b/internal/cmd/alias/alias.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -177,11 +178,12 @@ func collectBuiltinAliases(rootCmd *cobra.Command) map[string]string {
 
 func newAliasDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 	return &cobra.Command{
-		Use:     "delete <name>",
-		Short:   "Delete an alias",
-		Aliases: []string{"rm"},
-		Args:    cobra.ExactArgs(1),
-		Example: `  teamcity alias delete rl`,
+		Use:               "delete <name>",
+		Short:             "Delete an alias",
+		Aliases:           []string{"rm"},
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.AliasNames(),
+		Example:           `  teamcity alias delete rl`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 			if err := config.DeleteAlias(name); err != nil {

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -82,6 +83,9 @@ See: https://www.jetbrains.com/help/teamcity/rest/teamcity-rest-api-documentatio
 	cmd.Flags().BoolVar(&opts.slurp, "slurp", false, "Combine paginated results into a JSON array (requires --paginate)")
 
 	cmd.MarkFlagsMutuallyExclusive("input", "field")
+
+	_ = cmd.RegisterFlagCompletionFunc("method", completion.HTTPMethods())
+	_ = cmd.MarkFlagFilename("input")
 
 	return cmd
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/JetBrains/teamcity-cli/internal/version"
@@ -56,6 +57,8 @@ For CI/CD, set TEAMCITY_URL and TEAMCITY_TOKEN environment variables
 	cmd.Flags().BoolVar(&opts.guest, "guest", false, "Use guest authentication (no token needed; must be enabled on the server)")
 	cmd.Flags().BoolVar(&opts.insecureStorage, "insecure-storage", false, "Store token in plain text config file instead of system keyring")
 	cmd.Flags().BoolVar(&opts.noBrowser, "no-browser", false, "Skip browser-based auth, use manual token entry")
+
+	_ = cmd.RegisterFlagCompletionFunc("server", completion.ConfiguredServers())
 
 	return cmd
 }

--- a/internal/cmd/auth/logout.go
+++ b/internal/cmd/auth/logout.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,9 @@ func newAuthLogoutCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&serverFlag, "server", "s", "", "Server URL to log out from")
+
+	_ = cmd.RegisterFlagCompletionFunc("server", completion.ConfiguredServers())
+
 	return cmd
 }
 

--- a/internal/cmd/completion_integration_test.go
+++ b/internal/cmd/completion_integration_test.go
@@ -1,0 +1,125 @@
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/internal/cmd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStaticCompletions drives cobra's hidden __complete command to confirm each handler is wired to the right flag or positional.
+func TestStaticCompletions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "run list --status",
+			args: []string{"__complete", "run", "list", "--status", ""},
+			want: []string{"success", "failure", "running", "queued", "error", "unknown", "canceled"},
+		},
+		{
+			name: "job tree --only",
+			args: []string{"__complete", "job", "tree", "--only", ""},
+			want: []string{"dependents", "dependencies"},
+		},
+		{
+			name: "api --method",
+			args: []string{"__complete", "api", "--method", ""},
+			want: []string{"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"},
+		},
+		{
+			name: "project ssh generate --type",
+			args: []string{"__complete", "project", "ssh", "generate", "--type", ""},
+			want: []string{"ed25519", "rsa"},
+		},
+		{
+			name: "project vcs create --auth",
+			args: []string{"__complete", "project", "vcs", "create", "--auth", ""},
+			want: []string{"password", "ssh-key", "ssh-agent", "ssh-file", "token", "anonymous"},
+		},
+		{
+			name: "config get <key>",
+			args: []string{"__complete", "config", "get", ""},
+			want: []string{"default_server", "guest", "ro", "token_expiry"},
+		},
+		{
+			name: "config set <key>",
+			args: []string{"__complete", "config", "set", ""},
+			want: []string{"default_server", "guest", "ro", "token_expiry"},
+		},
+		{
+			name: "config set guest <value>",
+			args: []string{"__complete", "config", "set", "guest", ""},
+			want: []string{"true", "false"},
+		},
+		{
+			name: "skill install [name]",
+			args: []string{"__complete", "skill", "install", ""},
+			want: []string{"teamcity-cli"},
+		},
+		{
+			name: "run list --user",
+			args: []string{"__complete", "run", "list", "--user", ""},
+			want: []string{"@me"},
+		},
+		{
+			name: "run list --revision",
+			args: []string{"__complete", "run", "list", "--revision", ""},
+			want: []string{"@head"},
+		},
+		{
+			name: "run list --branch includes @this",
+			args: []string{"__complete", "run", "list", "--branch", ""},
+			want: []string{"@this"},
+		},
+		{
+			name: "project view positional includes _Root",
+			args: []string{"__complete", "project", "view", ""},
+			want: []string{"_Root"},
+		},
+		{
+			name: "project token put positional includes _Root",
+			args: []string{"__complete", "project", "token", "put", ""},
+			want: []string{"_Root"},
+		},
+		{
+			name: "pool link <project-id> second positional",
+			args: []string{"__complete", "pool", "link", "1", ""},
+			want: []string{"_Root"},
+		},
+		{
+			// --local-changes has NoOptDefVal, so cobra needs --flag= form to request value completion.
+			name: "run start --local-changes includes git",
+			args: []string{"__complete", "run", "start", "Foo", "--local-changes="},
+			want: []string{"git"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := runComplete(t, tc.args...)
+			for _, value := range tc.want {
+				assert.Contains(t, out, value, "expected %q in completion output:\n%s", value, out)
+			}
+		})
+	}
+}
+
+func runComplete(t *testing.T, args ...string) string {
+	t.Helper()
+	rootCmd := cmd.NewCommand(nil)
+	rootCmd.SetArgs(args)
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	require.NoError(t, rootCmd.Execute())
+	return strings.TrimSpace(out.String())
+}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	cfg "github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/charmbracelet/huh"
@@ -169,7 +170,8 @@ func newGetCmd(f *cmdutil.Factory) *cobra.Command {
 		Example: `  teamcity config get default_server
   teamcity config get ro
   teamcity config get guest --server tc.example.com`,
-		Args: cobra.ExactArgs(1),
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.ConfigKeys(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			value, err := cfg.GetField(args[0], serverURL)
 			if err != nil {
@@ -185,6 +187,9 @@ func newGetCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&serverURL, "server", "s", "", "Server URL for per-server settings")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+
+	_ = cmd.RegisterFlagCompletionFunc("server", completion.ConfiguredServers())
+
 	return cmd
 }
 
@@ -207,6 +212,20 @@ func newSetCmd(f *cmdutil.Factory) *cobra.Command {
   # Enable guest auth for the default server
   teamcity config set guest true`,
 		Args: cobra.RangeArgs(1, 2),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			switch len(args) {
+			case 0:
+				return completion.ConfigKeys()(cmd, args, toComplete)
+			case 1:
+				if args[0] == "default_server" {
+					return completion.ConfiguredServers()(cmd, args, toComplete)
+				}
+				if args[0] == "guest" || args[0] == "ro" {
+					return completion.Fixed("true", "false")(cmd, args, toComplete)
+				}
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			key := args[0]
 			var value string
@@ -232,6 +251,9 @@ func newSetCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&serverURL, "server", "s", "", "Server URL for per-server settings")
+
+	_ = cmd.RegisterFlagCompletionFunc("server", completion.ConfiguredServers())
+
 	return cmd
 }
 

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -21,10 +21,11 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Manage CLI configuration",
 		Long: `Get, set, and list CLI configuration values.
 
-Configuration is stored in ~/.teamcity/config.toml and covers the
-default server, per-server flags (guest, read-only), and aliases.
-Environment variables (TEAMCITY_URL, TEAMCITY_TOKEN, ...) override
-the persisted values at runtime.`,
+Configuration is stored in $XDG_CONFIG_HOME/tc/config.yml (defaults
+to ~/.config/tc/config.yml) and covers the default server, per-server
+flags (guest, read-only), and aliases. Environment variables
+(TEAMCITY_URL, TEAMCITY_TOKEN, ...) override the persisted values
+at runtime.`,
 		Args: cobra.NoArgs,
 		RunE: cmdutil.SubcommandRequired,
 	}

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -43,6 +44,8 @@ them alongside classic build configurations.`,
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "Include pipelines")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }
@@ -119,11 +122,12 @@ func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (
 func newJobViewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &cmdutil.ViewOptions{}
 	cmd := &cobra.Command{
-		Use:     "view [job-id]",
-		Short:   "View job details",
-		Long:    "View details of a TeamCity build configuration. With no argument, uses the linked default job from teamcity.toml.",
-		Aliases: []string{"show"},
-		Args:    cobra.MaximumNArgs(1),
+		Use:               "view [job-id]",
+		Short:             "View job details",
+		Long:              "View details of a TeamCity build configuration. With no argument, uses the linked default job from teamcity.toml.",
+		Aliases:           []string{"show"},
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completion.LinkedJobs(),
 		Example: `  teamcity job view Falcon_Build
   teamcity job view Falcon_Build --web
   teamcity job view              # uses linked default job (see 'teamcity link')`,

--- a/internal/cmd/job/state.go
+++ b/internal/cmd/job/state.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -23,10 +24,11 @@ var jobStateActions = map[string]jobStateAction{
 
 func newJobStateCmd(f *cmdutil.Factory, a jobStateAction) *cobra.Command {
 	return &cobra.Command{
-		Use:   a.use + " [job-id]",
-		Short: a.short,
-		Long:  a.long + " With no argument, uses the linked default job from teamcity.toml.",
-		Args:  cobra.MaximumNArgs(1),
+		Use:               a.use + " [job-id]",
+		Short:             a.short,
+		Long:              a.long + " With no argument, uses the linked default job from teamcity.toml.",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completion.LinkedJobs(),
 		Example: fmt.Sprintf(`  teamcity job %s Falcon_Build
   teamcity job %s                # uses linked default job (see 'teamcity link')`, a.use, a.use),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/job/tree.go
+++ b/internal/cmd/job/tree.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -40,9 +41,10 @@ func newJobTreeCmd(f *cmdutil.Factory) *cobra.Command {
 	var jsonOut bool
 
 	cmd := &cobra.Command{
-		Use:   "tree [job-id]",
-		Short: "Display snapshot dependency tree",
-		Long:  "Display the snapshot dependency tree for a build configuration. With no argument, uses the linked default job from teamcity.toml.",
+		Use:               "tree [job-id]",
+		Short:             "Display snapshot dependency tree",
+		ValidArgsFunction: completion.LinkedJobs(),
+		Long:              "Display the snapshot dependency tree for a build configuration. With no argument, uses the linked default job from teamcity.toml.",
 		Example: `  teamcity job tree MyProject_Build
   teamcity job tree                          # uses linked default job
   teamcity job tree Falcon_Deploy --depth 2
@@ -69,6 +71,8 @@ func newJobTreeCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntVarP(&depth, "depth", "d", 0, "Limit tree depth (0 = unlimited)")
 	cmd.Flags().StringVar(&only, "only", "", "Show only 'dependents' or 'dependencies'")
 	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output as JSON")
+
+	_ = cmd.RegisterFlagCompletionFunc("only", completion.JobTreeOnly())
 
 	return cmd
 }

--- a/internal/cmd/link/link.go
+++ b/internal/cmd/link/link.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/git"
 	"github.com/JetBrains/teamcity-cli/internal/link"
@@ -105,6 +106,12 @@ Resolution cascade (highest to lowest):
 	cmd.Flags().StringVarP(&job, "job", "j", "", "Default job/pipeline ID for this scope")
 	cmd.Flags().StringSliceVar(&jobs, "jobs", nil, "Additional job/pipeline IDs (comma-separated or repeated)")
 	cmd.Flags().StringVar(&scope, "scope", "", "Path scope inside the server entry (default: cwd relative to teamcity.toml's dir; pass --scope= for top-level)")
+
+	_ = cmd.RegisterFlagCompletionFunc("server", completion.ConfiguredServers())
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
+	_ = cmd.RegisterFlagCompletionFunc("job", completion.LinkedJobs())
+	_ = cmd.RegisterFlagCompletionFunc("jobs", completion.LinkedJobs())
+	_ = cmd.RegisterFlagCompletionFunc("scope", completion.LinkScopes())
 
 	return cmd
 }

--- a/internal/cmd/param/param.go
+++ b/internal/cmd/param/param.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +48,10 @@ var JobParamAPI = ParamAPI{
 // NewCmd creates a param subcommand for a resource (project or job). resolveID supplies the
 // linked default when the user omits the resource-id positional.
 func NewCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver) *cobra.Command {
+	idComplete := completion.LinkedProjects()
+	if resource == "job" {
+		idComplete = completion.LinkedJobs()
+	}
 	cmd := &cobra.Command{
 		Use:   "param",
 		Short: fmt.Sprintf("Manage %s parameters", resource),
@@ -64,10 +69,10 @@ See: https://www.jetbrains.com/help/teamcity/configuring-build-parameters.html`,
 		RunE: cmdutil.SubcommandRequired,
 	}
 
-	cmd.AddCommand(newParamListCmd(f, resource, paramAPI, resolveID))
-	cmd.AddCommand(newParamGetCmd(f, resource, paramAPI, resolveID))
-	cmd.AddCommand(newParamSetCmd(f, resource, paramAPI, resolveID))
-	cmd.AddCommand(newParamDeleteCmd(f, resource, paramAPI, resolveID))
+	cmd.AddCommand(newParamListCmd(f, resource, paramAPI, resolveID, idComplete))
+	cmd.AddCommand(newParamGetCmd(f, resource, paramAPI, resolveID, idComplete))
+	cmd.AddCommand(newParamSetCmd(f, resource, paramAPI, resolveID, idComplete))
+	cmd.AddCommand(newParamDeleteCmd(f, resource, paramAPI, resolveID, idComplete))
 
 	return cmd
 }
@@ -94,13 +99,14 @@ type paramListOptions struct {
 	noHeader bool
 }
 
-func newParamListCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver) *cobra.Command {
+func newParamListCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver, idComplete completion.CompFunc) *cobra.Command {
 	opts := &paramListOptions{}
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("list [%s-id]", resource),
-		Short: fmt.Sprintf("List %s parameters", resource),
-		Args:  cobra.MaximumNArgs(1),
+		Use:               fmt.Sprintf("list [%s-id]", resource),
+		Short:             fmt.Sprintf("List %s parameters", resource),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: idComplete,
 		Example: fmt.Sprintf(`  teamcity %s param list MyID
   teamcity %s param list                # uses linked %s (see 'teamcity link')
   teamcity %s param list MyID --json
@@ -167,13 +173,14 @@ func runParamList(f *cmdutil.Factory, id string, opts *paramListOptions, paramAP
 	return nil
 }
 
-func newParamGetCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver) *cobra.Command {
+func newParamGetCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver, idComplete completion.CompFunc) *cobra.Command {
 	var jsonOutput bool
 
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("get [%s-id] <name>", resource),
-		Short: fmt.Sprintf("Get a %s parameter value", resource),
-		Args:  cobra.RangeArgs(1, 2),
+		Use:               fmt.Sprintf("get [%s-id] <name>", resource),
+		Short:             fmt.Sprintf("Get a %s parameter value", resource),
+		Args:              cobra.RangeArgs(1, 2),
+		ValidArgsFunction: paramFirstArgComplete(idComplete),
 		Example: fmt.Sprintf(`  teamcity %s param get MyID MY_PARAM
   teamcity %s param get MY_PARAM         # uses linked %s
   teamcity %s param get MyID VERSION`, resource, resource, resource, resource),
@@ -218,7 +225,7 @@ type paramSetOptions struct {
 	secure bool
 }
 
-func newParamSetCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver) *cobra.Command {
+func newParamSetCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver, idComplete completion.CompFunc) *cobra.Command {
 	opts := &paramSetOptions{}
 
 	cmd := &cobra.Command{
@@ -230,7 +237,8 @@ Use --secure to mark the parameter as a password. Secure values are
 stored encrypted server-side and masked in logs and UI output.
 
 Omit the <%s-id> when this repo is linked via 'teamcity link'.`, resource, resource),
-		Args: cobra.RangeArgs(2, 3),
+		Args:              cobra.RangeArgs(2, 3),
+		ValidArgsFunction: paramFirstArgComplete(idComplete),
 		Example: fmt.Sprintf(`  teamcity %s param set MyID MY_PARAM "my value"
   teamcity %s param set MY_PARAM "my value"           # uses linked %s
   teamcity %s param set MyID SECRET_KEY "****" --secure`, resource, resource, resource, resource),
@@ -262,11 +270,12 @@ func runParamSet(f *cmdutil.Factory, id, name, value string, opts *paramSetOptio
 	return nil
 }
 
-func newParamDeleteCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver) *cobra.Command {
+func newParamDeleteCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver, idComplete completion.CompFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   fmt.Sprintf("delete [%s-id] <name>", resource),
-		Short: fmt.Sprintf("Delete a %s parameter", resource),
-		Args:  cobra.RangeArgs(1, 2),
+		Use:               fmt.Sprintf("delete [%s-id] <name>", resource),
+		Short:             fmt.Sprintf("Delete a %s parameter", resource),
+		Args:              cobra.RangeArgs(1, 2),
+		ValidArgsFunction: paramFirstArgComplete(idComplete),
 		Example: fmt.Sprintf(`  teamcity %s param delete MyID MY_PARAM
   teamcity %s param delete MY_PARAM      # uses linked %s`, resource, resource, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -293,4 +302,14 @@ func runParamDelete(f *cmdutil.Factory, id, name string, paramAPI ParamAPI) erro
 
 	f.Printer.Success("Deleted parameter %s", name)
 	return nil
+}
+
+// paramFirstArgComplete applies idComplete only to the resource-id slot (args[0]).
+func paramFirstArgComplete(idComplete completion.CompFunc) completion.CompFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return idComplete(cmd, args, toComplete)
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/internal/cmd/pipeline/create.go
+++ b/internal/cmd/pipeline/create.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
 )
@@ -36,6 +37,9 @@ func newPipelineCreateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.vcsRoot, "vcs-root", "", "VCS root ID (interactive selection if omitted)")
 	cmd.Flags().StringVarP(&opts.file, "file", "f", ".teamcity.yml", "Path to pipeline YAML file")
 	_ = cmd.MarkFlagRequired("project")
+	_ = cmd.MarkFlagFilename("file", "yml", "yaml")
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/pipeline/delete.go
+++ b/internal/cmd/pipeline/delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -16,9 +17,10 @@ func newPipelineDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &deleteOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "delete <pipeline-id>",
-		Short: "Delete a pipeline",
-		Args:  cobra.ExactArgs(1),
+		Use:               "delete <pipeline-id>",
+		Short:             "Delete a pipeline",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.LinkedJobs(),
 		Example: `  teamcity pipeline delete CLI_MyPipeline
   teamcity pipeline delete CLI_MyPipeline --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +34,8 @@ func newPipelineListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/pipeline/pull.go
+++ b/internal/cmd/pipeline/pull.go
@@ -30,6 +30,8 @@ func newPipelinePullCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "Write YAML to file instead of stdout")
 
+	_ = cmd.MarkFlagFilename("output", "yml", "yaml")
+
 	return cmd
 }
 

--- a/internal/cmd/pipeline/pull.go
+++ b/internal/cmd/pipeline/pull.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -17,9 +18,10 @@ func newPipelinePullCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &pullOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "pull <pipeline-id>",
-		Short: "Download pipeline YAML",
-		Args:  cobra.ExactArgs(1),
+		Use:               "pull <pipeline-id>",
+		Short:             "Download pipeline YAML",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.LinkedJobs(),
 		Example: `  teamcity pipeline pull CLI_CiCd
   teamcity pipeline pull CLI_CiCd -o .teamcity.yml
   teamcity pipeline pull CLI_CiCd > pipeline.yml`,

--- a/internal/cmd/pipeline/push.go
+++ b/internal/cmd/pipeline/push.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,12 @@ func newPipelinePushCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "push <pipeline-id> [file]",
 		Short: "Upload pipeline YAML",
 		Args:  cobra.RangeArgs(1, 2),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				return completion.LinkedJobs()(cmd, args, toComplete)
+			}
+			return []string{"yml", "yaml"}, cobra.ShellCompDirectiveFilterFileExt
+		},
 		Example: `  teamcity pipeline push CLI_CiCd
   teamcity pipeline push CLI_CiCd .teamcity.yml
   teamcity pipeline push CLI_CiCd pipeline.yml`,

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -27,6 +27,9 @@ func newPipelineValidateCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "validate [file]",
 		Short: "Validate pipeline YAML against server schema",
 		Args:  cobra.MaximumNArgs(1),
+		ValidArgsFunction: func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			return []string{"yml", "yaml"}, cobra.ShellCompDirectiveFilterFileExt
+		},
 		Example: `  teamcity pipeline validate
   teamcity pipeline validate .teamcity.yml
   teamcity pipeline validate --schema custom-schema.json
@@ -42,6 +45,8 @@ func newPipelineValidateCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVar(&opts.schemaPath, "schema", "", "Path to a local JSON schema file")
 	cmd.Flags().BoolVar(&opts.refreshSchema, "refresh-schema", false, "Force re-fetch schema from server")
+
+	_ = cmd.MarkFlagFilename("schema", "json")
 
 	return cmd
 }

--- a/internal/cmd/pipeline/view.go
+++ b/internal/cmd/pipeline/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -13,10 +14,11 @@ func newPipelineViewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &cmdutil.ViewOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "view <pipeline-id>",
-		Short:   "View pipeline details",
-		Aliases: []string{"show"},
-		Args:    cobra.ExactArgs(1),
+		Use:               "view <pipeline-id>",
+		Short:             "View pipeline details",
+		Aliases:           []string{"show"},
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completion.LinkedJobs(),
 		Example: `  teamcity pipeline view CLI_CiCd
   teamcity pipeline view CLI_CiCd --web
   teamcity pipeline view CLI_CiCd --json`,

--- a/internal/cmd/pool/link.go
+++ b/internal/cmd/pool/link.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -44,6 +45,12 @@ func newPoolProjectCmd(f *cmdutil.Factory, a poolProjectAction) *cobra.Command {
 		Long:    a.long,
 		Args:    cobra.ExactArgs(2),
 		Example: fmt.Sprintf("  teamcity pool %s 1 MyProject", a.use),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 1 {
+				return completion.LinkedProjects()(cmd, args, toComplete)
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			poolID, err := cmdutil.ParseID(args[0], "pool")
 			if err != nil {

--- a/internal/cmd/project/cloud.go
+++ b/internal/cmd/project/cloud.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -69,6 +70,8 @@ func newCloudProfileListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }
@@ -193,6 +196,8 @@ func newCloudImageListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().StringVar(&opts.profile, "profile", "", "Filter by cloud profile")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }
@@ -367,6 +372,8 @@ func newCloudInstanceListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().StringVar(&opts.image, "image", "", "Filter by cloud image")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/project/connection.go
+++ b/internal/cmd/project/connection.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -55,6 +56,8 @@ func newConnectionListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/project/connection_authorize.go
+++ b/internal/cmd/project/connection_authorize.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -52,6 +53,8 @@ Connection types that don't have a per-user OAuth flow (Docker, AWS) error out.`
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/project/connection_create.go
+++ b/internal/cmd/project/connection_create.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -85,6 +86,9 @@ automatically. Use --no-manifest to enter existing credentials manually.`,
 	cmd.Flags().StringVar(&opts.privateKeyFile, "private-key-file", "", "Path to GitHub App private key (manual mode)")
 	cmd.Flags().BoolVar(&opts.noManifest, "no-manifest", false, "Skip the manifest flow; collect credentials manually")
 	cmd.Flags().BoolVar(&opts.noAuthorize, "no-authorize", false, "Skip the post-create authorize prompt")
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
+	_ = cmd.MarkFlagFilename("private-key-file", "pem")
 
 	return cmd
 }
@@ -299,6 +303,8 @@ over a personal account.`,
 	cmd.Flags().StringVar(&opts.username, "username", "", "Registry username")
 	cmd.Flags().StringVar(&opts.password, "password", "", "Registry password (prefer --stdin)")
 	cmd.Flags().BoolVar(&opts.stdin, "stdin", false, "Read password from stdin")
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/project/connection_delete.go
+++ b/internal/cmd/project/connection_delete.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -32,6 +33,8 @@ The id is the one shown in the first column of 'connection list'.`,
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation")
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/project/create.go
+++ b/internal/cmd/project/create.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -40,6 +41,8 @@ If --parent is omitted, the project is created under the Root project.`,
 	cmd.Flags().StringVarP(&opts.parent, "parent", "p", "", "Parent project ID (default: _Root)")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser after creation")
+
+	_ = cmd.RegisterFlagCompletionFunc("parent", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -11,6 +11,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmd/param"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -73,6 +74,8 @@ func newProjectListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.parent, "parent", "p", "", "Filter by parent project ID")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
 
+	_ = cmd.RegisterFlagCompletionFunc("parent", completion.LinkedProjects())
+
 	return cmd
 }
 
@@ -113,11 +116,12 @@ func (opts *projectListOptions) fetch(client api.ClientInterface, fields []strin
 func newProjectViewCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &cmdutil.ViewOptions{}
 	cmd := &cobra.Command{
-		Use:     "view [project-id]",
-		Short:   "View project details",
-		Long:    `View details of a TeamCity project. With no argument, uses the linked project from teamcity.toml.`,
-		Aliases: []string{"show"},
-		Args:    cobra.MaximumNArgs(1),
+		Use:               "view [project-id]",
+		Short:             "View project details",
+		Long:              `View details of a TeamCity project. With no argument, uses the linked project from teamcity.toml.`,
+		Aliases:           []string{"show"},
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completion.LinkedProjects(),
 		Example: `  teamcity project view Falcon
   teamcity project view Falcon --web
   teamcity project view              # uses linked project (see 'teamcity link')`,
@@ -201,8 +205,9 @@ func newProjectTokenPutCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &projectTokenPutOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "put <project-id> [value]",
-		Short: "Store a secret and get a secure token",
+		Use:               "put <project-id> [value]",
+		Short:             "Store a secret and get a secure token",
+		ValidArgsFunction: completion.LinkedProjects(),
 		Long: `Store a sensitive value and get a secure token reference.
 
 The returned token can be used in versioned settings configuration files
@@ -284,8 +289,9 @@ func runProjectTokenPut(f *cmdutil.Factory, projectID, value string, opts *proje
 
 func newProjectTokenGetCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "get <project-id> <token>",
-		Short: "Get the value of a secure token",
+		Use:               "get <project-id> <token>",
+		Short:             "Get the value of a secure token",
+		ValidArgsFunction: firstArgComplete(completion.LinkedProjects()),
 		Long: `Retrieve the original value for a secure token.
 
 This operation requires CHANGE_SERVER_SETTINGS permission,
@@ -351,7 +357,8 @@ func newProjectTreeCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity project tree --no-jobs
   teamcity project tree --depth 2
   teamcity project tree --json`,
-		Args: cobra.MaximumNArgs(1),
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completion.LinkedProjects(),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			explicit := ""
 			if len(args) > 0 {
@@ -524,4 +531,14 @@ func resolveHiddenProjects(client api.ClientInterface, known map[string]*api.Pro
 
 func newProjectSettingsCmd(f *cmdutil.Factory) *cobra.Command {
 	return newSettingsCmd(f)
+}
+
+// firstArgComplete applies fn only to args[0]; later positionals get no completions.
+func firstArgComplete(fn completion.CompFunc) completion.CompFunc {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) == 0 {
+			return fn(cmd, args, toComplete)
+		}
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
 }

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -49,8 +50,9 @@ func newProjectSettingsStatusCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &projectSettingsStatusOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "status <project-id>",
-		Short: "Show versioned settings sync status",
+		Use:               "status <project-id>",
+		Short:             "Show versioned settings sync status",
+		ValidArgsFunction: completion.LinkedProjects(),
 		Long: `Show the synchronization status of versioned settings for a project.
 
 Displays:
@@ -192,8 +194,9 @@ func newProjectSettingsExportCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &projectSettingsExportOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "export <project-id>",
-		Short: "Export project settings as Kotlin DSL or XML",
+		Use:               "export <project-id>",
+		Short:             "Export project settings as Kotlin DSL or XML",
+		ValidArgsFunction: completion.LinkedProjects(),
 		Long: `Export project settings as a ZIP archive containing Kotlin DSL or XML configuration.
 
 The exported archive can be used to:
@@ -224,6 +227,8 @@ By default, exports in Kotlin DSL format.`,
 	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "Output file path (default: projectSettings.zip)")
 	cmd.Flags().BoolVar(&opts.useRelativeIds, "relative-ids", true, "Use relative IDs in exported settings")
 	cmd.MarkFlagsMutuallyExclusive("kotlin", "xml")
+
+	_ = cmd.MarkFlagFilename("output", "zip")
 
 	return cmd
 }

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -339,6 +339,9 @@ This command does not accept TeamCity project IDs and has no --dir flag.`,
   teamcity project settings validate --verbose`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
+		ValidArgsFunction: func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+			return nil, cobra.ShellCompDirectiveFilterDirs
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				opts.path = args[0]

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
 )
 
@@ -57,6 +58,8 @@ func newSSHListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }
@@ -120,6 +123,8 @@ func newSSHUploadCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmd.Flags().StringVar(&opts.name, "name", "", "Key name (default: filename)")
 
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
+
 	return cmd
 }
 
@@ -180,6 +185,9 @@ func newSSHGenerateCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.name, "name", "", "Key name (required)")
 	cmd.Flags().StringVar(&opts.keyType, "type", "ed25519", "Key type: ed25519 or rsa")
 
+	_ = cmd.RegisterFlagCompletionFunc("type", completion.SSHKeyTypes())
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
+
 	return cmd
 }
 
@@ -236,6 +244,8 @@ func newSSHDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
 	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/git"
 	"github.com/JetBrains/teamcity-cli/internal/output"
@@ -65,6 +66,8 @@ func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }
@@ -301,6 +304,9 @@ Tests the connection before creating unless --no-test is specified.`,
 	cmd.Flags().StringVar(&opts.passphrase, "passphrase", "", "SSH key passphrase")
 	cmd.Flags().StringVar(&opts.connectionID, "connection-id", "", "OAuth connection ID")
 	cmd.Flags().BoolVar(&opts.noTest, "no-test", false, "Skip connection test before creating")
+
+	_ = cmd.RegisterFlagCompletionFunc("auth", completion.VCSAuthMethods())
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/queue/list.go
+++ b/internal/cmd/queue/list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -34,6 +35,8 @@ func newQueueListCmd(f *cmdutil.Factory) *cobra.Command {
 
 	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Filter by job ID")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
+
+	_ = cmd.RegisterFlagCompletionFunc("job", completion.LinkedJobs())
 
 	return cmd
 }

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -51,6 +51,8 @@ artifact tree). Use --output to choose the local destination directory
 	cmd.Flags().StringVarP(&opts.artifact, "artifact", "a", "", "Artifact name pattern to filter")
 	cmd.Flags().DurationVar(&opts.timeout, "timeout", 10*time.Minute, "Download timeout (e.g. 30m, 1h)")
 
+	_ = cmd.MarkFlagDirname("output")
+
 	return cmd
 }
 

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
@@ -77,6 +78,13 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 
 	cmd.MarkFlagsMutuallyExclusive("json", "plain")
+
+	_ = cmd.RegisterFlagCompletionFunc("status", completion.RunStatuses())
+	_ = cmd.RegisterFlagCompletionFunc("branch", completion.GitBranches())
+	_ = cmd.RegisterFlagCompletionFunc("revision", completion.AtHead())
+	_ = cmd.RegisterFlagCompletionFunc("user", completion.AtMe())
+	_ = cmd.RegisterFlagCompletionFunc("job", completion.LinkedJobs())
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
 	return cmd
 }

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/git"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
@@ -155,9 +156,10 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd := &cobra.Command{
-		Use:   "start [job-id]",
-		Short: "Start a new run",
-		Args:  cobra.MaximumNArgs(1),
+		Use:               "start [job-id]",
+		Short:             "Start a new run",
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completion.LinkedJobs(),
 		Example: `  teamcity run start Falcon_Build
   teamcity run start                              # uses linked default (see 'teamcity link')
   teamcity run start Falcon_Build --branch feature/test
@@ -208,6 +210,12 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Preview without triggering")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
+
+	_ = cmd.RegisterFlagCompletionFunc("branch", completion.GitBranches())
+	_ = cmd.RegisterFlagCompletionFunc("revision", completion.AtHead())
+	_ = cmd.RegisterFlagCompletionFunc("local-changes", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{"git", "-"}, cobra.ShellCompDirectiveDefault
+	})
 
 	return cmd
 }

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -6,6 +6,7 @@ import (
 
 	teamcitycli "github.com/JetBrains/teamcity-cli"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/tiulpin/instill"
@@ -120,6 +121,9 @@ func addSkillFlags(cmd *cobra.Command, opts *skillOptions) {
 	cmd.Flags().StringSliceVarP(&opts.agents, "agent", "a", nil, "Target agent(s); auto-detects if omitted")
 	cmd.Flags().BoolVar(&opts.all, "all", false, "Install/update all bundled skills")
 	cmd.Flags().BoolVar(&opts.project, "project", false, "Install to current project instead of globally")
+
+	cmd.ValidArgsFunction = completion.SkillNames()
+	_ = cmd.RegisterFlagCompletionFunc("agent", completion.SkillAgents())
 }
 
 func runSkillInstall(p *output.Printer, opts *skillOptions, args []string, checkVersion bool) error {

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -87,7 +87,7 @@ func SkillAgents() CompFunc {
 	}
 }
 
-// LinkedJobs completes job IDs from teamcity.toml in the cwd's ancestry.
+// LinkedJobs completes job/pipeline IDs from teamcity.toml in the cwd's ancestry.
 func LinkedJobs() CompFunc {
 	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		cfg := loadLinkConfig()

--- a/internal/completion/completion.go
+++ b/internal/completion/completion.go
@@ -1,0 +1,189 @@
+// Package completion exposes shell-completion helpers backed by static enums and on-disk config.
+package completion
+
+import (
+	"maps"
+	"os"
+	"slices"
+
+	teamcitycli "github.com/JetBrains/teamcity-cli"
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/git"
+	"github.com/JetBrains/teamcity-cli/internal/link"
+	"github.com/spf13/cobra"
+	"github.com/tiulpin/instill"
+)
+
+// CompFunc matches cobra's ValidArgsFunction and RegisterFlagCompletionFunc signature.
+type CompFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)
+
+// Fixed returns a CompFunc serving values with file completion suppressed.
+func Fixed(values ...string) CompFunc {
+	return cobra.FixedCompletions(values, cobra.ShellCompDirectiveNoFileComp)
+}
+
+// RunStatuses completes `run list --status`; mirrors resolveRunListStatus.
+func RunStatuses() CompFunc {
+	return Fixed("success", "failure", "running", "queued", "error", "unknown", "canceled")
+}
+
+// JobTreeOnly completes `job tree --only`.
+func JobTreeOnly() CompFunc {
+	return Fixed("dependents", "dependencies")
+}
+
+// HTTPMethods completes `api -X/--method`.
+func HTTPMethods() CompFunc {
+	return Fixed("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS")
+}
+
+// SSHKeyTypes completes `project ssh generate --type`.
+func SSHKeyTypes() CompFunc {
+	return Fixed("ed25519", "rsa")
+}
+
+// VCSAuthMethods completes `project vcs create --auth`.
+func VCSAuthMethods() CompFunc {
+	return Fixed("password", "ssh-key", "ssh-agent", "ssh-file", "token", "anonymous")
+}
+
+// ConfigKeys completes `config get|set <key>` from config.ValidKeys.
+func ConfigKeys() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return config.ValidKeys(), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// ConfiguredServers completes server URLs from the local config file.
+func ConfiguredServers() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return config.SortedServerURLs(config.Get()), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// AliasNames completes user-defined alias names from local config.
+func AliasNames() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return slices.Collect(maps.Keys(config.GetAllAliases())), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// SkillNames completes skill names from the bundled skills FS.
+func SkillNames() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		skills := instill.ListSkills(teamcitycli.SkillsFS)
+		names := make([]string, len(skills))
+		for i, s := range skills {
+			names[i] = s.Name
+		}
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// SkillAgents completes `skill --agent` from instill.AgentNames.
+func SkillAgents() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return instill.AgentNames(), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// LinkedJobs completes job IDs from teamcity.toml in the cwd's ancestry.
+func LinkedJobs() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		cfg := loadLinkConfig()
+		if cfg == nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var jobs []string
+		for _, s := range cfg.Servers {
+			if s.Job != "" {
+				jobs = append(jobs, s.Job)
+			}
+			jobs = append(jobs, s.Jobs...)
+			for _, p := range s.Paths {
+				if p.Job != "" {
+					jobs = append(jobs, p.Job)
+				}
+				jobs = append(jobs, p.Jobs...)
+			}
+		}
+		return dedupe(jobs), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// LinkedProjects completes project IDs from teamcity.toml; always includes _Root.
+func LinkedProjects() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		out := []string{"_Root"}
+		cfg := loadLinkConfig()
+		if cfg != nil {
+			for _, s := range cfg.Servers {
+				if s.Project != "" {
+					out = append(out, s.Project)
+				}
+				for _, p := range s.Paths {
+					if p.Project != "" {
+						out = append(out, p.Project)
+					}
+				}
+			}
+		}
+		return dedupe(out), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// LinkScopes completes `link --scope` from existing path scopes in teamcity.toml.
+func LinkScopes() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		cfg := loadLinkConfig()
+		if cfg == nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		var scopes []string
+		for _, s := range cfg.Servers {
+			scopes = slices.AppendSeq(scopes, maps.Keys(s.Paths))
+		}
+		return dedupe(scopes), cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// GitBranches completes branch flags from local refs/heads, prefixed with @this.
+func GitBranches() CompFunc {
+	return func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		out := []string{"@this"}
+		out = append(out, git.LocalBranches()...)
+		return out, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+// AtMe completes `run list --user` with the @me token.
+func AtMe() CompFunc {
+	return Fixed("@me")
+}
+
+// AtHead completes `--revision` with the @head token.
+func AtHead() CompFunc {
+	return Fixed("@head")
+}
+
+func loadLinkConfig() *link.Config {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil
+	}
+	path, ok := link.Find(cwd)
+	if !ok {
+		return nil
+	}
+	cfg, err := link.Load(path)
+	if err != nil {
+		return nil
+	}
+	return cfg
+}
+
+func dedupe(in []string) []string {
+	out := slices.DeleteFunc(slices.Clone(in), func(s string) bool { return s == "" })
+	slices.Sort(out)
+	return slices.Compact(out)
+}

--- a/internal/completion/completion_test.go
+++ b/internal/completion/completion_test.go
@@ -1,0 +1,43 @@
+package completion
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/internal/link"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinkedJobsAndProjectsReadFromTOML(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, link.Save(filepath.Join(dir, "teamcity.toml"), &link.Config{
+		Servers: []link.Server{{
+			URL:     "https://tc.example.com",
+			Project: "Falcon",
+			Job:     "Falcon_Build",
+			Jobs:    []string{"Falcon_BuildDocker", "Falcon_Build"}, // duplicate
+			Paths: map[string]link.PathScope{
+				"backend": {Project: "Falcon_API", Job: "Falcon_APITest"},
+				"docs":    {Project: "Falcon", Jobs: []string{"Falcon_BuildDocker"}}, // dup project + job
+			},
+		}},
+	}))
+
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+	require.NoError(t, os.Chdir(dir))
+
+	jobs, dir2 := LinkedJobs()(nil, nil, "")
+	assert.Equal(t, cobra.ShellCompDirectiveNoFileComp, dir2)
+	assert.Equal(t, []string{"Falcon_APITest", "Falcon_Build", "Falcon_BuildDocker"}, jobs)
+
+	projects, _ := LinkedProjects()(nil, nil, "")
+	assert.Equal(t, []string{"Falcon", "Falcon_API", "_Root"}, projects)
+
+	scopes, _ := LinkScopes()(nil, nil, "")
+	assert.Equal(t, []string{"backend", "docs"}, scopes)
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -128,6 +128,19 @@ func UncommittedDiff() ([]byte, error) {
 	return out, nil
 }
 
+// LocalBranches returns short names of local branches, or nil outside a working tree.
+func LocalBranches() []string {
+	out, err := exec.Command("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/").Output()
+	if err != nil {
+		return nil
+	}
+	s := strings.TrimSpace(string(out))
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, "\n")
+}
+
 // CanonicalURL reduces any supported git remote URL form (SSH short, ssh://, http(s)://) to "host/org/repo", or "" if unparseable.
 func CanonicalURL(rawURL string) string {
 	raw := strings.TrimSpace(rawURL)


### PR DESCRIPTION
## Summary

Adds offline shell completion across the CLI: static enums, local config, embedded skills FS, `teamcity.toml` ancestry, local git refs, special tokens, and filesystem extension/directory hints. Nothing here does a network round-trip on TAB, so completions are instant and work without auth. Partial fix for #158 — server-side dynamic completions (project/job IDs, agent names, run IDs) remain as tier 2.

Also corrects a stale `~/.teamcity/config.toml` reference in `teamcity config`'s help text — actual path is `$XDG_CONFIG_HOME/tc/config.yml`.

## Changes

**New `internal/completion/` package** with helpers for each offline data source:
- Static enums: `RunStatuses`, `JobTreeOnly`, `HTTPMethods`, `SSHKeyTypes`, `VCSAuthMethods`, `ConfigKeys`
- Local config: `ConfiguredServers`, `AliasNames`
- Embedded FS: `SkillNames`, `SkillAgents`
- `teamcity.toml`: `LinkedJobs`, `LinkedProjects`, `LinkScopes`
- Local git: `GitBranches` (+ `git.LocalBranches` helper)
- Special tokens: `AtMe`, `AtHead`

**Wired across 30 command files**, totaling 70 registrations:
- Flags: `--status`, `--only`, `--method`, `--type`, `--auth`, `--server`, `--project`, `--job`, `--jobs`, `--scope`, `--branch`, `--revision`, `--user`, `--agent`, `--parent`, `--input`, `--file`, `--output`, `--schema`, `--private-key-file`, `--local-changes`
- Positionals: `run start <job-id>`, `job view/tree/pause/resume <job-id>`, `project view/tree/token/settings <project-id>`, `pool link/unlink <_> <project-id>`, `param ... <id>`, `skill install/update/remove [name]`, `pipeline validate <file>`, `alias delete <name>`, `config get|set <key> [value]`

**Filesystem hints** via `MarkFlagFilename`/`MarkFlagDirname`/`ShellCompDirectiveFilterFileExt`:
- yml/yaml for pipeline files, json for schemas, zip for project settings export, pem for GitHub App keys, dirs only for `run download -o`

## Design Decisions

- **Tier separation**: this PR ships only completions whose data is resolvable without an API call. Tier 2 (project IDs from `GetProjects`, job IDs from `GetBuildTypes`, etc.) is the natural follow-up but blocked on settling timeout/caching policy and graceful degradation when the user isn't authed.
- **`teamcity.toml`-driven completion** for `--job` and `--project` covers the user's bound subset, which is usually exactly what they want. Falling through to a network call would gate completion on auth and add latency.
- **`@me`, `@head`, `@this`** are completed as discovery aids — they're documented in flag help but were not surfaced via TAB.
- **No tautological tests**: dropped early drafts that just asserted constant slices match their values. Kept one unit test that exercises real TOML walking + dedup with explicit duplicate inputs, plus an integration test that drives cobra's hidden `__complete` for 13 cases (catches typos in flag-name registration).

## Example

```bash
$ teamcity run list --status <TAB>
success   failure   running   queued   error   unknown   canceled

$ teamcity run start <TAB>            # from teamcity.toml
Falcon_Build   Falcon_BuildDocker   Falcon_APITest

$ teamcity run list --branch <TAB>    # local git + @this
@this   main   feature/auth-login   release/v1.2

$ teamcity skill install <TAB>        # embedded skills FS
teamcity-cli

$ teamcity pipeline create foo --file <TAB>   # filtered to yml/yaml
```

## Test Plan

- [x] Unit tests pass (`just unit`) — 306 tests
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [x] No new commands/flags requiring `.txtar` tests
- [x] No `--json` output changes
- [x] No docs-visible behavior changes (completion is opt-in via the user's shell)