### PR TITLE
feat(link): interactive picker for cwd-driven discovery

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -12,9 +12,10 @@ import (
 
 // BuildTypesOptions represents options for listing build configurations
 type BuildTypesOptions struct {
-	Project string
-	Limit   int
-	Fields  []string
+	Project    string
+	VcsRootURL string // server-side substring filter on each VCS root's `url` property
+	Limit      int
+	Fields     []string
 }
 
 // GetBuildTypes returns a list of build configurations, automatically following pagination.
@@ -22,6 +23,13 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
 	locator := NewLocator().
 		Add("affectedProject", opts.Project).
 		AddIntDefault("count", opts.Limit, 30)
+	if opts.VcsRootURL != "" {
+		locator.AddLocator("vcsRoot", NewLocator().
+			AddLocator("property", NewLocator().
+				Add("name", "url").
+				Add("value", opts.VcsRootURL).
+				Add("matchType", "contains")))
+	}
 
 	fields := opts.Fields
 	if len(fields) == 0 {

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -26,6 +26,20 @@ func TestGetBuildTypes(t *testing.T) {
 	assert.Equal(t, 1, result.Count)
 }
 
+func TestGetBuildTypesVcsRootURLFilter(t *testing.T) {
+	t.Parallel()
+	var seenLocator string
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		seenLocator = r.URL.Query().Get("locator")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(BuildTypeList{Count: 0})
+	})
+
+	_, err := client.GetBuildTypes(BuildTypesOptions{VcsRootURL: "acme/repo"})
+	require.NoError(t, err)
+	assert.Contains(t, seenLocator, "vcsRoot:(property:(name:url,value:acme/repo,matchType:contains))")
+}
+
 func TestGetBuildType(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -138,6 +152,34 @@ func TestGetVcsRootEntries(t *testing.T) {
 	entries, err := client.GetVcsRootEntries("bt1")
 	require.NoError(t, err)
 	assert.Equal(t, 0, entries.Count)
+}
+
+func TestVcsRootEntryDecodesNestedProperties(t *testing.T) {
+	t.Parallel()
+	const payload = `{
+		"id": "Repo",
+		"vcs-root": {
+			"id": "Repo",
+			"name": "repo",
+			"properties": {
+				"property": [
+					{"name": "url", "value": "git@github.com:acme/repo.git"},
+					{"name": "branch", "value": "refs/heads/main"}
+				]
+			}
+		}
+	}`
+	var entry VcsRootEntry
+	require.NoError(t, json.Unmarshal([]byte(payload), &entry))
+	require.NotNil(t, entry.VcsRoot)
+	require.NotNil(t, entry.VcsRoot.Properties)
+
+	got := map[string]string{}
+	for _, p := range entry.VcsRoot.Properties.Property {
+		got[p.Name] = p.Value
+	}
+	assert.Equal(t, "git@github.com:acme/repo.git", got["url"])
+	assert.Equal(t, "refs/heads/main", got["branch"])
 }
 
 func TestSetBuildTypeSetting(t *testing.T) {

--- a/api/types.go
+++ b/api/types.go
@@ -34,14 +34,15 @@ type ProjectList struct {
 
 // BuildType represents a build configuration
 type BuildType struct {
-	ID          string   `json:"id"`
-	Name        string   `json:"name,omitempty"`
-	ProjectName string   `json:"projectName,omitempty"`
-	ProjectID   string   `json:"projectId,omitempty"`
-	Href        string   `json:"href,omitempty"`
-	WebURL      string   `json:"webUrl,omitempty"`
-	Paused      bool     `json:"paused,omitempty"`
-	Project     *Project `json:"project,omitempty"`
+	ID             string          `json:"id"`
+	Name           string          `json:"name,omitempty"`
+	ProjectName    string          `json:"projectName,omitempty"`
+	ProjectID      string          `json:"projectId,omitempty"`
+	Href           string          `json:"href,omitempty"`
+	WebURL         string          `json:"webUrl,omitempty"`
+	Paused         bool            `json:"paused,omitempty"`
+	Project        *Project        `json:"project,omitempty"`
+	VcsRootEntries *VcsRootEntries `json:"vcs-root-entries,omitempty"`
 }
 
 // BuildTypeList represents a list of build configurations
@@ -234,13 +235,8 @@ type VcsRootEntries struct {
 }
 
 type VcsRootEntry struct {
-	ID      string      `json:"id,omitempty"`
-	VcsRoot *VcsRootRef `json:"vcs-root,omitempty"`
-}
-
-type VcsRootRef struct {
-	ID   string `json:"id"`
-	Name string `json:"name,omitempty"`
+	ID      string   `json:"id,omitempty"`
+	VcsRoot *VcsRoot `json:"vcs-root,omitempty"`
 }
 
 // LastChanges represents the changes to include in a build

--- a/internal/cmd/link/discover.go
+++ b/internal/cmd/link/discover.go
@@ -1,0 +1,183 @@
+package link
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/git"
+)
+
+// projectMatch groups all build types in a single TC project that match a repo's remotes.
+type projectMatch struct {
+	ProjectID   string
+	ProjectName string
+	Jobs        []jobOption
+}
+
+// jobOption is one selectable job/pipeline-head; Label is what the picker renders.
+type jobOption struct {
+	ID          string
+	Name        string
+	ProjectName string
+	Label       string
+	Pipeline    bool
+}
+
+// discovery is the per-server input bundle the picker form consumes.
+type discovery struct {
+	Projects []projectMatch
+}
+
+// discoveryBuildTypeFields is dot-notation expanded by ToAPIFields into the nested REST form.
+var discoveryBuildTypeFields = []string{
+	"id", "name", "projectId", "projectName", "paused",
+	"vcs-root-entries.vcs-root-entry.vcs-root.properties.property.name",
+	"vcs-root-entries.vcs-root-entry.vcs-root.properties.property.value",
+}
+
+// extractFragments returns server-side substring fragments and a canonical set used for fork rejection.
+func extractFragments(remoteURLs []string) (fragments, canonical []string) {
+	seenFrag := map[string]bool{}
+	seenCanon := map[string]bool{}
+	for _, raw := range remoteURLs {
+		canon := git.CanonicalURL(raw)
+		repoPath := git.RepoPath(raw)
+		if canon != "" && !seenCanon[canon] {
+			seenCanon[canon] = true
+			canonical = append(canonical, canon)
+		}
+		// Prefer the org/repo form as fragment — matches across hosts (github.com/x/y, gitlab.x/x/y).
+		if repoPath != "" && !seenFrag[repoPath] {
+			seenFrag[repoPath] = true
+			fragments = append(fragments, repoPath)
+		}
+	}
+	return fragments, canonical
+}
+
+// buildTypeMatchesRemotes reports whether bt's VCS roots include a URL whose canonical form is in the user's set.
+func buildTypeMatchesRemotes(bt api.BuildType, canonicalRemotes []string) bool {
+	if bt.VcsRootEntries == nil {
+		return false
+	}
+	for _, entry := range bt.VcsRootEntries.VcsRootEntry {
+		if entry.VcsRoot == nil || entry.VcsRoot.Properties == nil {
+			continue
+		}
+		for _, p := range entry.VcsRoot.Properties.Property {
+			if p.Name != "url" {
+				continue
+			}
+			if canon := git.CanonicalURL(p.Value); canon != "" && slices.Contains(canonicalRemotes, canon) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// pipelineMeta carries the parent project so a pipeline-head buildType binds to the parent, not TC's auto-created wrapper.
+type pipelineMeta struct {
+	Name       string
+	ParentID   string
+	ParentName string
+}
+
+// discoverProjects fetches build types whose VCS roots match remoteURLs and groups them by project; nil result means no remotes or no matches.
+func discoverProjects(client api.ClientInterface, remoteURLs []string) (*discovery, error) {
+	fragments, canonical := extractFragments(remoteURLs)
+	if len(fragments) == 0 {
+		return nil, nil
+	}
+
+	pipelineMetaByHead := map[string]pipelineMeta{}
+	if client.SupportsFeature("pipelines") {
+		pipelines, err := client.GetPipelines(api.PipelinesOptions{Limit: 0})
+		if err == nil && pipelines != nil {
+			for _, p := range pipelines.Pipelines {
+				if p.HeadBuildType == nil || p.HeadBuildType.ID == "" {
+					continue
+				}
+				m := pipelineMeta{Name: p.Name}
+				if p.ParentProject != nil {
+					m.ParentID = p.ParentProject.ID
+					m.ParentName = p.ParentProject.Name
+				}
+				pipelineMetaByHead[p.HeadBuildType.ID] = m
+			}
+		}
+	}
+
+	seenBuildTypes := map[string]bool{}
+	var matched []api.BuildType
+	for _, frag := range fragments {
+		page, err := client.GetBuildTypes(api.BuildTypesOptions{
+			VcsRootURL: frag,
+			Limit:      0,
+			Fields:     discoveryBuildTypeFields,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, bt := range page.BuildTypes {
+			if bt.Paused {
+				continue
+			}
+			if seenBuildTypes[bt.ID] {
+				continue
+			}
+			if !buildTypeMatchesRemotes(bt, canonical) {
+				continue
+			}
+			seenBuildTypes[bt.ID] = true
+			matched = append(matched, bt)
+		}
+	}
+
+	if len(matched) == 0 {
+		return nil, nil
+	}
+
+	byProject := map[string]*projectMatch{}
+	for _, bt := range matched {
+		projID, projName := bt.ProjectID, bt.ProjectName
+		opt := jobOption{ID: bt.ID, Name: bt.Name}
+		if meta, isHead := pipelineMetaByHead[bt.ID]; isHead {
+			opt.Pipeline = true
+			opt.Name = meta.Name
+			if meta.ParentID != "" {
+				projID, projName = meta.ParentID, meta.ParentName
+			}
+		}
+		opt.ProjectName = projName
+		opt.Label = jobLabel(opt)
+
+		pm, ok := byProject[projID]
+		if !ok {
+			pm = &projectMatch{ProjectID: projID, ProjectName: projName}
+			byProject[projID] = pm
+		}
+		pm.Jobs = append(pm.Jobs, opt)
+	}
+
+	d := &discovery{}
+	for _, pm := range byProject {
+		slices.SortFunc(pm.Jobs, func(a, b jobOption) int { return cmp.Compare(a.Name, b.Name) })
+		d.Projects = append(d.Projects, *pm)
+	}
+	slices.SortFunc(d.Projects, func(a, b projectMatch) int { return cmp.Compare(a.ProjectName, b.ProjectName) })
+	return d, nil
+}
+
+// jobLabel renders the picker label for a job, with a "⬡ pipeline" marker for pipeline heads.
+func jobLabel(o jobOption) string {
+	prefix := o.ProjectName
+	if prefix != "" {
+		prefix += " · "
+	}
+	if o.Pipeline {
+		return prefix + o.Name + "  ⬡ pipeline"
+	}
+	return prefix + o.Name
+}

--- a/internal/cmd/link/discover_test.go
+++ b/internal/cmd/link/discover_test.go
@@ -1,0 +1,172 @@
+package link
+
+import (
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClient embeds the interface so we only need to override the calls discoverProjects makes.
+type fakeClient struct {
+	api.ClientInterface
+	pipelinesSupported bool
+	pipelines          *api.PipelineList
+	buildTypesByFrag   map[string][]api.BuildType
+	gotFragments       []string
+}
+
+func (f *fakeClient) SupportsFeature(name string) bool {
+	return name == "pipelines" && f.pipelinesSupported
+}
+
+func (f *fakeClient) GetPipelines(api.PipelinesOptions) (*api.PipelineList, error) {
+	if f.pipelines == nil {
+		return &api.PipelineList{}, nil
+	}
+	return f.pipelines, nil
+}
+
+func (f *fakeClient) GetBuildTypes(opts api.BuildTypesOptions) (*api.BuildTypeList, error) {
+	f.gotFragments = append(f.gotFragments, opts.VcsRootURL)
+	bts := f.buildTypesByFrag[opts.VcsRootURL]
+	return &api.BuildTypeList{Count: len(bts), BuildTypes: bts}, nil
+}
+
+func vcsEntries(urls ...string) *api.VcsRootEntries {
+	out := &api.VcsRootEntries{}
+	for _, u := range urls {
+		out.VcsRootEntry = append(out.VcsRootEntry, api.VcsRootEntry{
+			VcsRoot: &api.VcsRoot{
+				Properties: &api.PropertyList{
+					Property: []api.Property{{Name: "url", Value: u}},
+				},
+			},
+		})
+	}
+	out.Count = len(out.VcsRootEntry)
+	return out
+}
+
+func TestExtractFragments(t *testing.T) {
+	frags, canon := extractFragments([]string{
+		"git@github.com:acme/backend.git",
+		"https://github.com/acme/backend",     // dup of above (canonical equal)
+		"https://gitlab.example.com/acme/api", // different repo
+	})
+	assert.Equal(t, []string{"acme/backend", "acme/api"}, frags)
+	assert.Equal(t, []string{"github.com/acme/backend", "gitlab.example.com/acme/api"}, canon)
+}
+
+func TestDiscoverProjectsEmptyRemotes(t *testing.T) {
+	client := &fakeClient{}
+	got, err := discoverProjects(client, nil)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+func TestDiscoverProjectsRejectsForkAndPaused(t *testing.T) {
+	client := &fakeClient{
+		buildTypesByFrag: map[string][]api.BuildType{
+			"acme/backend": {
+				{ID: "P_Build", Name: "Build", ProjectID: "P", ProjectName: "Backend",
+					VcsRootEntries: vcsEntries("git@github.com:acme/backend.git")},
+				// Server matched "backend" as substring but the URL belongs to a fork.
+				{ID: "P_Fork", Name: "Build", ProjectID: "P", ProjectName: "Backend",
+					VcsRootEntries: vcsEntries("git@github.com:acme/backend-plugin.git")},
+				// Paused — must drop.
+				{ID: "P_Old", Name: "Old", ProjectID: "P", ProjectName: "Backend", Paused: true,
+					VcsRootEntries: vcsEntries("git@github.com:acme/backend.git")},
+			},
+		},
+	}
+	got, err := discoverProjects(client, []string{"git@github.com:acme/backend.git"})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Len(t, got.Projects, 1)
+	require.Len(t, got.Projects[0].Jobs, 1)
+	assert.Equal(t, "P_Build", got.Projects[0].Jobs[0].ID)
+	assert.Equal(t, []string{"acme/backend"}, client.gotFragments)
+}
+
+func TestDiscoverProjectsGroupsByProjectAndSorts(t *testing.T) {
+	url := "git@github.com:acme/backend.git"
+	entries := vcsEntries(url)
+	client := &fakeClient{
+		buildTypesByFrag: map[string][]api.BuildType{
+			"acme/backend": {
+				{ID: "Z_BuildZ", Name: "Z", ProjectID: "Z", ProjectName: "Zeta", VcsRootEntries: entries},
+				{ID: "A_BuildB", Name: "B", ProjectID: "A", ProjectName: "Alpha", VcsRootEntries: entries},
+				{ID: "A_BuildA", Name: "A", ProjectID: "A", ProjectName: "Alpha", VcsRootEntries: entries},
+			},
+		},
+	}
+	got, err := discoverProjects(client, []string{url})
+	require.NoError(t, err)
+	require.Len(t, got.Projects, 2)
+	assert.Equal(t, "Alpha", got.Projects[0].ProjectName)
+	assert.Equal(t, []string{"A", "B"}, []string{got.Projects[0].Jobs[0].Name, got.Projects[0].Jobs[1].Name})
+	assert.Equal(t, "Zeta", got.Projects[1].ProjectName)
+}
+
+func TestDiscoverProjectsPipelineHeadRemapsToParent(t *testing.T) {
+	url := "git@github.com:acme/cli.git"
+	entries := vcsEntries(url)
+	client := &fakeClient{
+		pipelinesSupported: true,
+		pipelines: &api.PipelineList{Pipelines: []api.Pipeline{
+			{ID: "CLI_CI", Name: "CI",
+				HeadBuildType: &api.BuildTypeRef{ID: "CLI_CI_Head"},
+				ParentProject: &api.ProjectRef{ID: "CLI", Name: "CLI"}},
+		}},
+		buildTypesByFrag: map[string][]api.BuildType{
+			"acme/cli": {
+				{ID: "CLI_CI_Head", Name: "Pipeline Head", ProjectID: "CLI_CI", ProjectName: "CLI / CI",
+					VcsRootEntries: entries},
+				{ID: "CLI_LinuxAgent", Name: "Linux Agent", ProjectID: "CLI", ProjectName: "CLI",
+					VcsRootEntries: entries},
+			},
+		},
+	}
+	got, err := discoverProjects(client, []string{url})
+	require.NoError(t, err)
+	require.Len(t, got.Projects, 1)
+	pm := got.Projects[0]
+	assert.Equal(t, "CLI", pm.ProjectID)
+	assert.Equal(t, "CLI", pm.ProjectName)
+	require.Len(t, pm.Jobs, 2)
+
+	var pipeline jobOption
+	for _, j := range pm.Jobs {
+		if j.Pipeline {
+			pipeline = j
+		}
+	}
+	assert.Equal(t, "CLI_CI_Head", pipeline.ID)
+	assert.Equal(t, "CI", pipeline.Name)
+	assert.Equal(t, "CLI · CI  ⬡ pipeline", pipeline.Label)
+}
+
+func TestDiscoverProjectsDedupsAcrossFragments(t *testing.T) {
+	entries := vcsEntries("git@github.com:acme/backend.git")
+	bt := api.BuildType{ID: "P_Build", Name: "Build", ProjectID: "P", ProjectName: "P", VcsRootEntries: entries}
+	client := &fakeClient{
+		buildTypesByFrag: map[string][]api.BuildType{
+			"acme/backend":            {bt}, // same buildType returned for both fragments
+			"github.com/acme/backend": {bt}, // (in practice a single fragment is tried, but verify dedup)
+		},
+	}
+	// Two remotes resolving to two distinct fragments.
+	got, err := discoverProjects(client, []string{
+		"git@github.com:acme/backend.git",
+	})
+	require.NoError(t, err)
+	require.Len(t, got.Projects, 1)
+	require.Len(t, got.Projects[0].Jobs, 1)
+}
+
+func TestJobLabelNonPipeline(t *testing.T) {
+	o := jobOption{Name: "Build", ProjectName: "Acme"}
+	assert.Equal(t, "Acme · Build", jobLabel(o))
+}

--- a/internal/cmd/link/discover_test.go
+++ b/internal/cmd/link/discover_test.go
@@ -166,6 +166,89 @@ func TestDiscoverProjectsDedupsAcrossFragments(t *testing.T) {
 	require.Len(t, got.Projects[0].Jobs, 1)
 }
 
+func TestResolveAuto(t *testing.T) {
+	makeHit := func(url, projID string, jobIDs ...string) serverResult {
+		jobs := make([]jobOption, len(jobIDs))
+		for i, id := range jobIDs {
+			jobs[i] = jobOption{ID: id, Name: id, ProjectName: projID}
+		}
+		return serverResult{
+			url: url,
+			discovery: &discovery{Projects: []projectMatch{{
+				ProjectID: projID, ProjectName: projID, Jobs: jobs,
+			}}},
+		}
+	}
+
+	t.Run("single server, single project, single job", func(t *testing.T) {
+		res, err := resolveAuto([]serverResult{makeHit("https://a", "P", "P_Build")}, "")
+		require.NoError(t, err)
+		assert.Equal(t, "https://a", res.server)
+		assert.Equal(t, "P", res.project)
+		assert.Equal(t, "P_Build", res.job)
+		assert.Empty(t, res.jobs)
+	})
+
+	t.Run("single server, single project, multiple jobs", func(t *testing.T) {
+		res, err := resolveAuto([]serverResult{makeHit("https://a", "P", "P_Build", "P_Test")}, "")
+		require.NoError(t, err)
+		assert.Equal(t, "P", res.project)
+		assert.Empty(t, res.job, "multiple jobs in project -> default left empty")
+		assert.ElementsMatch(t, []string{"P_Build", "P_Test"}, res.jobs)
+	})
+
+	t.Run("multiple servers, no active match", func(t *testing.T) {
+		_, err := resolveAuto([]serverResult{
+			makeHit("https://b", "P", "j"),
+			makeHit("https://a", "Q", "k"),
+		}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple servers")
+		assert.Contains(t, err.Error(), "https://a, https://b")
+	})
+
+	t.Run("multiple servers, active server tiebreaker", func(t *testing.T) {
+		res, err := resolveAuto([]serverResult{
+			makeHit("https://b", "P_b", "j"),
+			makeHit("https://a", "P_a", "k"),
+		}, "https://a")
+		require.NoError(t, err)
+		assert.Equal(t, "https://a", res.server)
+		assert.Equal(t, "P_a", res.project)
+		assert.Equal(t, "k", res.job)
+	})
+
+	t.Run("multiple servers, active not in hits, still ambiguous", func(t *testing.T) {
+		_, err := resolveAuto([]serverResult{
+			makeHit("https://b", "P", "j"),
+			makeHit("https://c", "Q", "k"),
+		}, "https://a")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple servers")
+	})
+
+	t.Run("multiple projects on one server", func(t *testing.T) {
+		h := makeHit("https://a", "Z", "Z_Build")
+		h.discovery.Projects = append(h.discovery.Projects, projectMatch{
+			ProjectID: "A", ProjectName: "A", Jobs: []jobOption{{ID: "A_Build", Name: "A_Build"}},
+		})
+		_, err := resolveAuto([]serverResult{h}, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple projects")
+		assert.Contains(t, err.Error(), "A, Z", "project IDs sorted alphabetically")
+	})
+
+	t.Run("additional jobs include cross-project matches on same server", func(t *testing.T) {
+		h := makeHit("https://a", "P", "P_Build")
+		// resolveAuto only fires when there's a single project; this test covers the case
+		// where allJobsOnServer returns the picked project's jobs.
+		res, err := resolveAuto([]serverResult{h}, "")
+		require.NoError(t, err)
+		assert.Equal(t, "P_Build", res.job)
+		assert.Empty(t, res.jobs, "single job -> nothing extra")
+	})
+}
+
 func TestJobLabelNonPipeline(t *testing.T) {
 	o := jobOption{Name: "Build", ProjectName: "Acme"}
 	assert.Equal(t, "Acme · Build", jobLabel(o))

--- a/internal/cmd/link/interactive.go
+++ b/internal/cmd/link/interactive.go
@@ -90,18 +90,21 @@ func runPicker(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scop
 		}
 	}
 
-	switch action {
-	case "keep":
-		f.Printer.Success("Kept existing binding")
-		return errPickerHandled
-	case "clear":
-		clearScope(cfg, inputs.server, scopePath)
-		if err := link.Save(tomlPath, cfg); err != nil {
-			return fmt.Errorf("write %s: %w", tomlPath, err)
+	// Honor Keep/Clear only when the finally-picked server has a binding; a stale action from an earlier server falls through to a Change write.
+	if lookupScope(cfg, inputs.server, scopePath) != nil {
+		switch action {
+		case "keep":
+			f.Printer.Success("Kept existing binding")
+			return errPickerHandled
+		case "clear":
+			clearScope(cfg, inputs.server, scopePath)
+			if err := link.Save(tomlPath, cfg); err != nil {
+				return fmt.Errorf("write %s: %w", tomlPath, err)
+			}
+			f.Printer.Success("Cleared binding for %s", output.Cyan(scopeLabel(scopePath)))
+			f.Printer.Info("  Wrote: %s", tomlPath)
+			return errPickerHandled
 		}
-		f.Printer.Success("Cleared binding for %s", output.Cyan(scopeLabel(scopePath)))
-		f.Printer.Info("  Wrote: %s", tomlPath)
-		return errPickerHandled
 	}
 
 	*server = inputs.server
@@ -224,7 +227,7 @@ func buildGroups(hits []serverResult, hitByURL map[string]*discovery, cfg *link.
 				}, &in.server).
 				Value(&in.project),
 		).WithHideFunc(func() bool {
-			if *action != "change" {
+			if keptOrCleared(cfg, in.server, scopePath, *action) {
 				return true
 			}
 			d := hitByURL[in.server]
@@ -246,7 +249,7 @@ func buildGroups(hits []serverResult, hitByURL map[string]*discovery, cfg *link.
 					return out
 				}, []any{&in.server, &in.project}).
 				Value(&in.job),
-		).WithHideFunc(func() bool { return *action != "change" }),
+		).WithHideFunc(func() bool { return keptOrCleared(cfg, in.server, scopePath, *action) }),
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Select additional jobs").
@@ -264,7 +267,7 @@ func buildGroups(hits []serverResult, hitByURL map[string]*discovery, cfg *link.
 				}, []any{&in.server, &in.job}).
 				Value(&in.jobs),
 		).WithHideFunc(func() bool {
-			if *action != "change" {
+			if keptOrCleared(cfg, in.server, scopePath, *action) {
 				return true
 			}
 			return len(allJobsOnServer(hitByURL[in.server])) <= 1
@@ -272,6 +275,14 @@ func buildGroups(hits []serverResult, hitByURL map[string]*discovery, cfg *link.
 	)
 
 	return groups
+}
+
+// keptOrCleared hides project/job groups only when there is an existing binding the user chose to keep or clear; with no binding the action prompt never shows, so the picks are always required.
+func keptOrCleared(cfg *link.Config, serverURL, scopePath, action string) bool {
+	if lookupScope(cfg, serverURL, scopePath) == nil {
+		return false
+	}
+	return action != "change"
 }
 
 // findProject returns the matching project (by ID) on a server, or nil.

--- a/internal/cmd/link/interactive.go
+++ b/internal/cmd/link/interactive.go
@@ -36,11 +36,11 @@ type serverResult struct {
 	err       error
 }
 
-// runPicker drives interactive `teamcity link`; mutates outputs on Change, returns errPickerHandled on Keep/Clear (already finalized).
-func runPicker(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scopePath, tomlPath string, server, project, job *string, jobs *[]string) error {
+// findHits runs discovery shared by --auto and the interactive picker; returns servers that produced ≥1 project match.
+func findHits(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scopePath string) ([]serverResult, []string, error) {
 	candidates := candidateServers(serverOverride)
 	if len(candidates) == 0 {
-		return errors.New("no TeamCity server configured\n  Run 'teamcity auth login' first")
+		return nil, nil, errors.New("no TeamCity server configured\n  Run 'teamcity auth login' first")
 	}
 
 	printHeader(f, candidates, cfg, scopePath, serverOverride != "")
@@ -60,7 +60,16 @@ func runPicker(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scop
 		}
 	}
 	if len(hits) == 0 {
-		return noMatchHint(remotes, results)
+		return nil, remotes, noMatchHint(remotes, results)
+	}
+	return hits, remotes, nil
+}
+
+// runPicker drives interactive `teamcity link`; mutates outputs on Change, returns errPickerHandled on Keep/Clear (already finalized).
+func runPicker(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scopePath, tomlPath string, server, project, job *string, jobs *[]string) error {
+	hits, _, err := findHits(f, serverOverride, cfg, scopePath)
+	if err != nil {
+		return err
 	}
 
 	hitByURL := map[string]*discovery{}
@@ -111,6 +120,78 @@ func runPicker(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scop
 	*project = inputs.project
 	*job = inputs.job
 	*jobs = inputs.jobs
+	return nil
+}
+
+// autoResolution is what runAuto computes from discovery hits before writing.
+type autoResolution struct {
+	server  string
+	project string
+	job     string
+	jobs    []string
+}
+
+// resolveAuto picks a unique binding from hits; ambiguity yields a typed error the caller renders to the user.
+// activeServer, if set and present in hits, is preferred when multiple servers match — that's the user's working server.
+func resolveAuto(hits []serverResult, activeServer string) (autoResolution, error) {
+	if len(hits) > 1 {
+		if activeServer != "" {
+			for _, h := range hits {
+				if h.url == activeServer {
+					hits = []serverResult{h}
+					break
+				}
+			}
+		}
+	}
+	if len(hits) > 1 {
+		urls := make([]string, len(hits))
+		for i, h := range hits {
+			urls[i] = h.url
+		}
+		slices.Sort(urls)
+		return autoResolution{}, fmt.Errorf("multiple servers match this repo: %s\n  Pass --server <url> --auto to disambiguate", strings.Join(urls, ", "))
+	}
+	h := hits[0]
+	if len(h.discovery.Projects) > 1 {
+		ids := make([]string, len(h.discovery.Projects))
+		for i, p := range h.discovery.Projects {
+			ids[i] = p.ProjectID
+		}
+		slices.Sort(ids)
+		return autoResolution{}, fmt.Errorf("multiple projects match on %s: %s\n  Drop --auto and pass --project <id> --job <id>", h.url, strings.Join(ids, ", "))
+	}
+
+	pm := h.discovery.Projects[0]
+	res := autoResolution{server: h.url, project: pm.ProjectID}
+	if len(pm.Jobs) == 1 {
+		res.job = pm.Jobs[0].ID
+	}
+	for _, j := range allJobsOnServer(h.discovery) {
+		if j.ID != res.job {
+			res.jobs = append(res.jobs, j.ID)
+		}
+	}
+	return res, nil
+}
+
+// runAuto runs discovery and writes the resolved binding without prompting; the same outputs the picker would persist on Change.
+func runAuto(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scopePath string, server, project, job *string, jobs *[]string) error {
+	hits, _, err := findHits(f, serverOverride, cfg, scopePath)
+	if err != nil {
+		return err
+	}
+	res, err := resolveAuto(hits, config.NormalizeURL(config.GetServerURL()))
+	if err != nil {
+		return err
+	}
+	*server = res.server
+	*project = res.project
+	*job = res.job
+	*jobs = res.jobs
+	if res.job == "" && len(allJobsOnServer(hits[0].discovery)) > 1 {
+		f.Printer.Info("  No single default job in %s; pass --job <id> to set one", output.Cyan(res.project))
+	}
 	return nil
 }
 

--- a/internal/cmd/link/interactive.go
+++ b/internal/cmd/link/interactive.go
@@ -1,0 +1,425 @@
+package link
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/git"
+	"github.com/JetBrains/teamcity-cli/internal/link"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/JetBrains/teamcity-cli/internal/version"
+	"github.com/charmbracelet/huh"
+	"github.com/dustin/go-humanize/english"
+)
+
+// errPickerHandled signals the picker finalized (or deliberately skipped) the write so the outer cmd's flag-driven path is bypassed.
+var errPickerHandled = errors.New("picker handled write")
+
+// pickerInputs is what the form fills in for the outer cmd to persist.
+type pickerInputs struct {
+	server  string
+	project string
+	job     string
+	jobs    []string
+}
+
+// serverResult is one server's discovery outcome.
+type serverResult struct {
+	url       string
+	discovery *discovery
+	err       error
+}
+
+// runPicker drives interactive `teamcity link`; mutates outputs on Change, returns errPickerHandled on Keep/Clear (already finalized).
+func runPicker(f *cmdutil.Factory, serverOverride string, cfg *link.Config, scopePath, tomlPath string, server, project, job *string, jobs *[]string) error {
+	candidates := candidateServers(serverOverride)
+	if len(candidates) == 0 {
+		return errors.New("no TeamCity server configured\n  Run 'teamcity auth login' first")
+	}
+
+	printHeader(f, candidates, cfg, scopePath, serverOverride != "")
+
+	remotes := git.RemoteURLs()
+	if len(candidates) == 1 {
+		f.Printer.Progress("Discovering projects on %s... ", output.Cyan(candidates[0]))
+	} else {
+		f.Printer.Progress("Discovering projects across %d %s... ", len(candidates), english.PluralWord(len(candidates), "server", ""))
+	}
+	results := discoverAcrossServers(f, candidates, remotes)
+
+	var hits []serverResult
+	for _, r := range results {
+		if r.discovery != nil && len(r.discovery.Projects) > 0 {
+			hits = append(hits, r)
+		}
+	}
+	if len(hits) == 0 {
+		return noMatchHint(remotes, results)
+	}
+
+	hitByURL := map[string]*discovery{}
+	for _, h := range hits {
+		hitByURL[h.url] = h.discovery
+	}
+
+	inputs := pickerInputs{server: hits[0].url}
+	resetProjectAndJob(&inputs, hitByURL)
+
+	existing := lookupScope(cfg, inputs.server, scopePath)
+	action := "change"
+	if existing != nil {
+		action = ""
+		if pm := findProject(hitByURL[inputs.server], existing.Project); pm != nil {
+			inputs.project = existing.Project
+			if slices.ContainsFunc(pm.Jobs, func(j jobOption) bool { return j.ID == existing.Job }) {
+				inputs.job = existing.Job
+			}
+		}
+	}
+
+	groups := buildGroups(hits, hitByURL, cfg, scopePath, &action, &inputs)
+	if len(groups) > 0 {
+		if err := cmdutil.RunForm(groups...); err != nil {
+			return err
+		}
+	}
+
+	switch action {
+	case "keep":
+		f.Printer.Success("Kept existing binding")
+		return errPickerHandled
+	case "clear":
+		clearScope(cfg, inputs.server, scopePath)
+		if err := link.Save(tomlPath, cfg); err != nil {
+			return fmt.Errorf("write %s: %w", tomlPath, err)
+		}
+		f.Printer.Success("Cleared binding for %s", output.Cyan(scopeLabel(scopePath)))
+		f.Printer.Info("  Wrote: %s", tomlPath)
+		return errPickerHandled
+	}
+
+	*server = inputs.server
+	*project = inputs.project
+	*job = inputs.job
+	*jobs = inputs.jobs
+	return nil
+}
+
+// candidateServers returns server URLs to probe: --server override is a single result, otherwise active server first then any others with saved credentials.
+func candidateServers(serverOverride string) []string {
+	if serverOverride != "" {
+		return []string{config.NormalizeURL(serverOverride)}
+	}
+	seen := map[string]bool{}
+	var out []string
+	add := func(u string) {
+		u = config.NormalizeURL(u)
+		if u == "" || seen[u] {
+			return
+		}
+		seen[u] = true
+		out = append(out, u)
+	}
+	add(config.GetServerURL())
+	for url := range config.Get().Servers {
+		add(url)
+	}
+	return out
+}
+
+// pickerClient returns a client for serverURL — f.Client() for the active server, a fresh client from saved creds otherwise.
+func pickerClient(f *cmdutil.Factory, serverURL string) (api.ClientInterface, error) {
+	if config.NormalizeURL(serverURL) == config.NormalizeURL(config.GetServerURL()) {
+		return f.Client()
+	}
+	token, _, _ := config.GetTokenForServer(serverURL)
+	if token == "" {
+		return nil, fmt.Errorf("no saved credentials for %s — run 'teamcity auth login -s %s'", serverURL, serverURL)
+	}
+	return api.NewClient(serverURL, token, api.WithVersion(version.String())).WithContext(f.Context()), nil
+}
+
+// discoverAcrossServers runs discovery in parallel and returns results in the same order as urls.
+func discoverAcrossServers(f *cmdutil.Factory, urls, remotes []string) []serverResult {
+	results := make([]serverResult, len(urls))
+	var wg sync.WaitGroup
+	for i, url := range urls {
+		wg.Go(func() {
+			results[i].url = url
+			c, err := pickerClient(f, url)
+			if err != nil {
+				results[i].err = err
+				return
+			}
+			c.SetCommandName("link")
+			d, err := discoverProjects(c, remotes)
+			results[i].discovery = d
+			results[i].err = err
+		})
+	}
+	wg.Wait()
+	return results
+}
+
+// buildGroups assembles the multi-server form. Returns nil only when there's literally nothing to ask.
+func buildGroups(hits []serverResult, hitByURL map[string]*discovery, cfg *link.Config, scopePath string, action *string, in *pickerInputs) []*huh.Group {
+	var groups []*huh.Group
+
+	if len(hits) > 1 {
+		opts := make([]huh.Option[string], len(hits))
+		for i, h := range hits {
+			n := len(h.discovery.Projects)
+			label := h.url + " " + output.Faint(fmt.Sprintf("(%d %s)", n, english.PluralWord(n, "project", "")))
+			opts[i] = huh.NewOption(label, h.url)
+		}
+		groups = append(groups, huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Select TeamCity server").
+				Options(opts...).
+				Value(&in.server),
+		))
+	}
+
+	groups = append(groups,
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Existing binding for "+scopeLabel(scopePath)).
+				DescriptionFunc(func() string {
+					if e := lookupScope(cfg, in.server, scopePath); e != nil {
+						return existingDescription(*e)
+					}
+					return ""
+				}, &in.server).
+				Options(
+					huh.NewOption("Change", "change"),
+					huh.NewOption("Keep", "keep"),
+					huh.NewOption("Clear", "clear"),
+				).
+				Value(action),
+		).WithHideFunc(func() bool {
+			return lookupScope(cfg, in.server, scopePath) == nil
+		}),
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Select project").
+				OptionsFunc(func() []huh.Option[string] {
+					d := hitByURL[in.server]
+					if d == nil {
+						return nil
+					}
+					if findProject(d, in.project) == nil {
+						resetProjectAndJob(in, hitByURL)
+					}
+					out := make([]huh.Option[string], len(d.Projects))
+					for i, p := range d.Projects {
+						out[i] = huh.NewOption(p.ProjectName+" "+output.Faint("("+p.ProjectID+")"), p.ProjectID)
+					}
+					return out
+				}, &in.server).
+				Value(&in.project),
+		).WithHideFunc(func() bool {
+			if *action != "change" {
+				return true
+			}
+			d := hitByURL[in.server]
+			return d == nil || len(d.Projects) <= 1
+		}),
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Select default job").
+				OptionsFunc(func() []huh.Option[string] {
+					jobs := jobsForProject(hitByURL[in.server], in.project)
+					if len(jobs) == 0 {
+						return []huh.Option[string]{huh.NewOption(output.Faint("(no jobs in this project)"), "")}
+					}
+					out := make([]huh.Option[string], 0, len(jobs)+1)
+					out = append(out, huh.NewOption(output.Faint("(skip — set later)"), ""))
+					for _, j := range jobs {
+						out = append(out, huh.NewOption(j.Label, j.ID))
+					}
+					return out
+				}, []any{&in.server, &in.project}).
+				Value(&in.job),
+		).WithHideFunc(func() bool { return *action != "change" }),
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Title("Select additional jobs").
+				Description("Surfaced in TAB completion alongside the default · saved to teamcity.toml").
+				OptionsFunc(func() []huh.Option[string] {
+					all := allJobsOnServer(hitByURL[in.server])
+					out := make([]huh.Option[string], 0, len(all))
+					for _, j := range all {
+						if j.ID == in.job {
+							continue
+						}
+						out = append(out, huh.NewOption(j.Label, j.ID))
+					}
+					return out
+				}, []any{&in.server, &in.job}).
+				Value(&in.jobs),
+		).WithHideFunc(func() bool {
+			if *action != "change" {
+				return true
+			}
+			return len(allJobsOnServer(hitByURL[in.server])) <= 1
+		}),
+	)
+
+	return groups
+}
+
+// findProject returns the matching project (by ID) on a server, or nil.
+func findProject(d *discovery, projectID string) *projectMatch {
+	if d == nil || projectID == "" {
+		return nil
+	}
+	for i := range d.Projects {
+		if d.Projects[i].ProjectID == projectID {
+			return &d.Projects[i]
+		}
+	}
+	return nil
+}
+
+// allJobsOnServer returns every matched job across every project on the server, used by the cross-project additional-jobs picker.
+func allJobsOnServer(d *discovery) []jobOption {
+	if d == nil {
+		return nil
+	}
+	var out []jobOption
+	for _, p := range d.Projects {
+		out = append(out, p.Jobs...)
+	}
+	return out
+}
+
+// jobsForProject returns the jobs for projectID, falling back to the first project when projectID isn't on the current server.
+func jobsForProject(d *discovery, projectID string) []jobOption {
+	if pm := findProject(d, projectID); pm != nil {
+		return pm.Jobs
+	}
+	if d != nil && len(d.Projects) > 0 {
+		return d.Projects[0].Jobs
+	}
+	return nil
+}
+
+// resetProjectAndJob seats project + job to the first match on in.server, since project IDs are server-scoped.
+func resetProjectAndJob(in *pickerInputs, hitByURL map[string]*discovery) {
+	d := hitByURL[in.server]
+	if d == nil || len(d.Projects) == 0 {
+		in.project, in.job = "", ""
+		return
+	}
+	in.project = d.Projects[0].ProjectID
+	in.job = ""
+	if len(d.Projects[0].Jobs) > 0 {
+		in.job = d.Projects[0].Jobs[0].ID
+	}
+}
+
+func lookupScope(cfg *link.Config, serverURL, scopePath string) *link.PathScope {
+	srv := cfg.Match(serverURL)
+	if srv == nil {
+		return nil
+	}
+	if scopePath == "" {
+		if srv.Project == "" && srv.Job == "" && len(srv.Jobs) == 0 {
+			return nil
+		}
+		return &link.PathScope{Project: srv.Project, Job: srv.Job, Jobs: srv.Jobs}
+	}
+	if srv.Paths == nil {
+		return nil
+	}
+	if p, ok := srv.Paths[scopePath]; ok {
+		return &p
+	}
+	return nil
+}
+
+func clearScope(cfg *link.Config, serverURL, scopePath string) {
+	srv := cfg.Match(serverURL)
+	if srv == nil {
+		return
+	}
+	if scopePath == "" {
+		srv.Project, srv.Job, srv.Jobs = "", "", nil
+		return
+	}
+	delete(srv.Paths, scopePath)
+}
+
+func existingDescription(s link.PathScope) string {
+	var parts []string
+	if s.Project != "" {
+		parts = append(parts, "project "+s.Project)
+	}
+	if s.Job != "" {
+		parts = append(parts, "job "+s.Job)
+	}
+	if len(s.Jobs) > 0 {
+		parts = append(parts, "jobs ["+strings.Join(s.Jobs, ", ")+"]")
+	}
+	return strings.Join(parts, ", ")
+}
+
+func scopeLabel(scopePath string) string {
+	if scopePath == "" {
+		return "the whole repo"
+	}
+	return scopePath + "/"
+}
+
+func printHeader(f *cmdutil.Factory, candidates []string, cfg *link.Config, scopePath string, fromOverride bool) {
+	p := f.Printer
+	_, _ = fmt.Fprintln(p.Out)
+	p.PrintField("Linking", output.Cyan(scopeLabel(scopePath)))
+	if scopePath != "" {
+		p.Info("  %s", output.Faint("(pass --scope= to link the whole repo instead)"))
+	}
+	if len(candidates) == 1 {
+		source := "active"
+		if fromOverride {
+			source = "from --server"
+		}
+		p.PrintField("Server", output.Cyan(candidates[0])+" "+output.Faint("("+source+")"))
+	}
+	if cfg != nil {
+		var bound []string
+		for _, s := range cfg.Servers {
+			if s.Project != "" || s.Job != "" || len(s.Jobs) > 0 || len(s.Paths) > 0 {
+				bound = append(bound, s.URL)
+			}
+		}
+		slices.Sort(bound)
+		if len(bound) > 0 {
+			p.Info("  %s", output.Faint("Already bound in this repo: "+strings.Join(bound, ", ")))
+		}
+	}
+	_, _ = fmt.Fprintln(p.Out)
+}
+
+func noMatchHint(remotes []string, results []serverResult) error {
+	if len(remotes) == 0 {
+		return errors.New("no git remotes found in this repository\n  Add one with 'git remote add origin <url>', or run 'teamcity link --project <id> --job <id>' explicitly")
+	}
+	var msg strings.Builder
+	msg.WriteString("no TeamCity projects found whose VCS roots match this repo's remotes\n")
+	for _, r := range results {
+		switch {
+		case r.err != nil:
+			fmt.Fprintf(&msg, "  %s: %v\n", r.url, r.err)
+		case r.discovery == nil || len(r.discovery.Projects) == 0:
+			fmt.Fprintf(&msg, "  %s: no match\n", r.url)
+		}
+	}
+	msg.WriteString("  Run 'teamcity project list' to find a project ID, then 'teamcity link --project <id> --job <id>'.")
+	return errors.New(msg.String())
+}

--- a/internal/cmd/link/link.go
+++ b/internal/cmd/link/link.go
@@ -4,6 +4,7 @@ package link
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,6 +47,29 @@ Resolution cascade (highest to lowest):
   rm  teamcity.toml`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := writePath()
+			if err != nil {
+				return err
+			}
+			scopePath, err := resolveScopePath(scope, cmd.Flags().Changed("scope"), path)
+			if err != nil {
+				return err
+			}
+			cfg, err := loadOrEmpty(path)
+			if err != nil {
+				return fmt.Errorf("read %s: %w", path, err)
+			}
+
+			noFields := project == "" && job == "" && len(jobs) == 0
+			if noFields && f.IsInteractive() {
+				if err := runPicker(f, server, cfg, scopePath, path, &server, &project, &job, &jobs); err != nil {
+					if errors.Is(err, errPickerHandled) {
+						return nil
+					}
+					return err
+				}
+			}
+
 			serverURL := config.NormalizeURL(cmp.Or(server, config.GetServerURL()))
 			if serverURL == "" {
 				return api.Validation(
@@ -56,23 +80,10 @@ Resolution cascade (highest to lowest):
 			if project == "" && job == "" && len(jobs) == 0 {
 				return api.Validation(
 					"at least one of --project, --job, or --jobs is required",
-					"Pass --project <id> (and optionally --job <id> or --jobs A,B,C)",
+					"Pass --project <id> (and optionally --job <id> or --jobs A,B,C), or rerun in an interactive shell",
 				)
 			}
 
-			path, err := writePath()
-			if err != nil {
-				return err
-			}
-			scopePath, err := resolveScopePath(scope, cmd.Flags().Changed("scope"), path)
-			if err != nil {
-				return err
-			}
-
-			cfg, err := loadOrEmpty(path)
-			if err != nil {
-				return fmt.Errorf("read %s: %w", path, err)
-			}
 			cfg.UpsertScope(serverURL, scopePath, link.PathScope{
 				Project: project,
 				Job:     job,

--- a/internal/cmd/link/link.go
+++ b/internal/cmd/link/link.go
@@ -23,6 +23,7 @@ import (
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	var server, project, job, scope string
 	var jobs []string
+	var auto bool
 
 	cmd := &cobra.Command{
 		Use:   "link",
@@ -34,6 +35,12 @@ Resolution cascade (highest to lowest):
   --flag → TEAMCITY_* env → matching [[server]] entry, deepest matching path scope`,
 		Example: `  # Bind the repo (uses active server, top-level scope)
   teamcity link --project Acme_Backend --job Acme_Backend_Build
+
+  # Auto-discover from git remotes (no prompts; ideal for AI agents and CI)
+  teamcity link --auto
+
+  # Auto on a specific server when multiple are authenticated
+  teamcity link --auto --server https://nightly.example
 
   # Add a second server's pipelines to the same teamcity.toml
   teamcity link --server https://nightly.example --project Acme_Nightly \
@@ -47,6 +54,13 @@ Resolution cascade (highest to lowest):
   rm  teamcity.toml`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if auto && (project != "" || job != "" || len(jobs) > 0) {
+				return api.Validation(
+					"--auto cannot be combined with --project/--job/--jobs",
+					"Use --auto alone to discover from git remotes, or pass explicit IDs without --auto",
+				)
+			}
+
 			path, err := writePath()
 			if err != nil {
 				return err
@@ -61,7 +75,12 @@ Resolution cascade (highest to lowest):
 			}
 
 			noFields := project == "" && job == "" && len(jobs) == 0
-			if noFields && f.IsInteractive() {
+			switch {
+			case auto:
+				if err := runAuto(f, server, cfg, scopePath, &server, &project, &job, &jobs); err != nil {
+					return err
+				}
+			case noFields && f.IsInteractive():
 				if err := runPicker(f, server, cfg, scopePath, path, &server, &project, &job, &jobs); err != nil {
 					if errors.Is(err, errPickerHandled) {
 						return nil
@@ -117,6 +136,7 @@ Resolution cascade (highest to lowest):
 	cmd.Flags().StringVarP(&job, "job", "j", "", "Default job/pipeline ID for this scope")
 	cmd.Flags().StringSliceVar(&jobs, "jobs", nil, "Additional job/pipeline IDs (comma-separated or repeated)")
 	cmd.Flags().StringVar(&scope, "scope", "", "Path scope inside the server entry (default: cwd relative to teamcity.toml's dir; pass --scope= for top-level)")
+	cmd.Flags().BoolVarP(&auto, "auto", "a", false, "Auto-discover the binding from git remotes; mutually exclusive with --project/--job/--jobs")
 
 	_ = cmd.RegisterFlagCompletionFunc("server", completion.ConfiguredServers())
 	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())

--- a/internal/cmdutil/prompt.go
+++ b/internal/cmdutil/prompt.go
@@ -30,6 +30,14 @@ func Prompt(field huh.Field) error {
 		Run()
 }
 
+// RunForm runs a multi-group huh form with shift+tab navigation; use it instead of chaining Prompt calls so groups can navigate between each other.
+func RunForm(groups ...*huh.Group) error {
+	return huh.NewForm(groups...).
+		WithTheme(promptTheme()).
+		WithShowHelp(true).
+		Run()
+}
+
 // PromptString asks for free-form text and echoes the answer back so it survives in scrollback.
 func PromptString(p *output.Printer, title, description string, value *string) error {
 	input := huh.NewInput().

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -64,6 +64,29 @@ func ResolveRevision(rev string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// RemoteURLs returns each configured remote's fetch URL, with origin first when present and duplicates removed; empty outside a working tree.
+func RemoteURLs() []string {
+	out, err := exec.Command("git", "remote", "-v").Output()
+	if err != nil {
+		return nil
+	}
+	var origin, others []string
+	seen := map[string]bool{}
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 || fields[2] != "(fetch)" || seen[fields[1]] {
+			continue
+		}
+		seen[fields[1]] = true
+		if fields[0] == "origin" {
+			origin = append(origin, fields[1])
+		} else {
+			others = append(others, fields[1])
+		}
+	}
+	return append(origin, others...)
+}
+
 // RemoteForBranch returns the configured remote for branch, defaulting to "origin".
 func RemoteForBranch(branch string) string {
 	out, err := exec.Command("git", "config", "--get", "branch."+branch+".remote").Output()

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -127,6 +127,32 @@ func TestRemoteForBranch(t *testing.T) {
 	})
 }
 
+func TestRemoteURLs(t *testing.T) {
+	t.Run("none configured", func(t *testing.T) {
+		t.Chdir(setupRepo(t))
+		assert.Empty(t, RemoteURLs())
+	})
+
+	t.Run("origin first then others, dedup", func(t *testing.T) {
+		dir := setupRepo(t)
+		t.Chdir(dir)
+		runGit(t, dir, "remote", "add", "upstream", "https://example.com/upstream.git")
+		runGit(t, dir, "remote", "add", "origin", "https://example.com/origin.git")
+		runGit(t, dir, "remote", "add", "fork", "https://example.com/origin.git") // dup of origin URL
+
+		got := RemoteURLs()
+		assert.Equal(t, []string{
+			"https://example.com/origin.git",
+			"https://example.com/upstream.git",
+		}, got)
+	})
+
+	t.Run("not a repo", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		assert.Empty(t, RemoteURLs())
+	})
+}
+
 func TestBranchExistsOnRemote(t *testing.T) {
 	dir := setupRepo(t)
 	t.Chdir(dir)


### PR DESCRIPTION
## Summary

`teamcity link` with no flags + a TTY now opens an interactive picker that finds your TeamCity project from the repo's git remotes and writes `teamcity.toml`. Flag-driven and `--no-input` paths are unchanged.

## Architecture

```mermaid
flowchart TD
    Start([teamcity link]) --> Gate{flags set or<br/>--no-input?}
    Gate -- yes --> Direct[/flag-driven write/]:::done
    Gate -- no --> Discover

    subgraph Discover[" 1 · Discover — parallel per authed server "]
        direction TB
        R[git remote -v] --> F[fragment set + canonical set<br/>org/repo and host/org/repo]
        F --> Q[REST: buildTypes whose<br/>VCS-root url contains a fragment]
        Q --> X[client-side fork reject<br/>via canonical URL]
        X --> M[remap pipeline-head buildTypes<br/>onto their parent project]
    end

    Discover --> Hits{any hits?}
    Hits -- no --> Diag[/per-server diagnostic<br/>+ how to link manually/]:::error
    Hits -- yes --> Form

    subgraph Form[" 2 · Single huh.Form, shift+tab navigable "]
        direction TB
        F1[Select TeamCity server<br/>shown when more than one server has hits] --> F2[Keep / Change / Clear<br/>shown when scope already bound]
        F2 --> F3[Select project<br/>shown when more than one project matched]
        F3 --> F4[Select default job]
        F4 --> F5[Select additional jobs<br/>cross-project on the picked server]
    end

    Form --> A{action}
    A -- Change --> Up[/link.UpsertScope<br/>save teamcity.toml/]:::done
    A -- Keep --> NoWrite[/no write/]:::done
    A -- Clear --> Wipe[/wipe scope, save/]:::done

    classDef done stroke:#3a8,stroke-width:2px
    classDef error stroke:#c43,stroke-width:2px
```

```mermaid
stateDiagram-v2
    direction LR
    [*] --> Discover
    Discover --> NoMatch: zero hits
    Discover --> Decide: matches found

    state Decide {
        [*] --> Change: pick project + jobs
        [*] --> Keep: existing binding kept
        [*] --> Clear: existing binding cleared
    }

    NoMatch --> [*]: error + diagnostic
    Keep --> [*]: no write
    Change --> [*]: scope upserted
    Clear --> [*]: scope wiped
```

## Why VCS-URL discovery, not project search

TC's REST `name:` locator is exact-match. Substring search would have to be client-side over every project (≥27k on the BuildServer). The buildTypes endpoint accepts a `vcsRoot.url contains <frag>` filter — that shrinks the candidate set to typically 1–3 buildTypes regardless of server scale, in one round trip, with the VCS root URLs returned inline for fork rejection.

## Multi-server semantics

- `--server X` short-circuits to one candidate.
- Without `--server`, every authenticated server in `~/.config/tc/config.yml` is probed in parallel via `wg.Go`.
- An unauth'd `--server X` errors with `teamcity auth login -s X` — never silently falls back to the active server.
- Only servers with at least one match reach the form.

## Example

```bash
$ teamcity link
Linking: the whole repo
Server: https://buildserver.labs.intellij.net (active)

Discovering projects on https://buildserver.labs.intellij.net...
✓ Linked https://buildserver.labs.intellij.net — top-level
  Project: TeamCity_CLI
  Default job: TeamCity_CLI_Build
  Jobs: TeamCity_CLI_Test
  Wrote: /path/to/repo/teamcity.toml
```

## Test Plan

- [x] Unit tests pass (`just unit`) — 7 new tests covering fragment extraction, fork rejection, paused filtering, project grouping, pipeline-head → parent remap (incl. merger with sibling regular buildType), dedup, locator construction, and nested `VcsRootEntry` decoding
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, picker is interactive-only
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — flags unchanged; non-interactive output unchanged