### PR TITLE
More Quality

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,4 +1,4 @@
-//go:build integration || guest
+//go:build integration || guest || terminal_pty
 
 // Integration tests for the TeamCity API client.
 // Uses a real TeamCity server: either from TEAMCITY_URL/TEAMCITY_TOKEN env vars,

--- a/api/drift_test.go
+++ b/api/drift_test.go
@@ -1,7 +1,20 @@
-//go:build integration
+//go:build integration || guest
 
-// Drift detection tests validate that Go types match TeamCity's swagger spec.
-// Runs as part of integration tests using testcontainers.
+// Drift detection tests catch when TeamCity's API contract changes.
+//
+// Two layers, both run under `-run TestAPIDrift`:
+//
+//   - TestAPIDrift           — static drift: parses our Go structs, fetches the
+//     server's swagger.json, asserts every JSON field
+//     we declare exists in the spec.
+//   - TestAPIDriftEndpoints  — runtime drift: calls every read-only Client
+//     method against the live server and asserts the
+//     response decodes. Catches contract changes that
+//     the swagger comparison can miss (status codes,
+//     empty bodies, renamed paths, query params).
+//   - TestAPIDriftAgentEndpoints — same as above for agent-scoped endpoints,
+//     skips when no agents are connected.
+//
 // Run with: go test -tags=integration ./api -v -run TestAPIDrift
 package api_test
 
@@ -16,9 +29,12 @@ import (
 	"os"
 	"reflect"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/JetBrains/teamcity-cli/api"
 )
 
 // SwaggerSpec represents relevant parts of OpenAPI/Swagger spec
@@ -282,5 +298,169 @@ func swaggerPropertyExists(props map[string]SwaggerProperty, jsonName string) bo
 		}
 	}
 
+	return false
+}
+
+// endpointDriftCase pairs a label with a closure that exercises one read endpoint.
+// We hold heterogeneous response types behind `any` so the table is one-line per
+// endpoint; assertions are intentionally shallow (err == nil, result != nil) so
+// this layer stays cheap and fast — TestAPIDrift handles the deep field-level shape.
+type endpointDriftCase struct {
+	name string
+	call func() (any, error)
+}
+
+func TestAPIDriftEndpoints(t *testing.T) {
+	if client == nil {
+		t.Skip("no TeamCity client configured")
+	}
+	if testBuild == nil {
+		t.Skip("no test build available")
+	}
+	buildID := strconv.Itoa(testBuild.ID)
+
+	cases := []endpointDriftCase{
+		// Server / users
+		{"GetServer", func() (any, error) { return client.GetServer() }},
+		{"GetCurrentUser", func() (any, error) { return client.GetCurrentUser() }},
+
+		// Project graph
+		{"GetProjects", func() (any, error) { return client.GetProjects(api.ProjectsOptions{}) }},
+		{"GetProject", func() (any, error) { return client.GetProject(testProject) }},
+		{"GetVersionedSettingsConfig", func() (any, error) { return client.GetVersionedSettingsConfig(testProject) }},
+		{"GetVersionedSettingsStatus", func() (any, error) { return client.GetVersionedSettingsStatus(testProject) }},
+		{"GetSSHKeys", func() (any, error) { return client.GetSSHKeys(testProject) }},
+		{"GetProjectConnections", func() (any, error) { return client.GetProjectConnections(testProject) }},
+
+		// Build configurations
+		{"GetBuildTypes", func() (any, error) { return client.GetBuildTypes(api.BuildTypesOptions{}) }},
+		{"GetBuildType", func() (any, error) { return client.GetBuildType(testConfig) }},
+		{"GetBuildTypeParameters", func() (any, error) { return client.GetBuildTypeParameters(testConfig) }},
+		{"GetSnapshotDependencies", func() (any, error) { return client.GetSnapshotDependencies(testConfig) }},
+		{"GetDependentBuildTypes", func() (any, error) { return client.GetDependentBuildTypes(testConfig) }},
+		{"GetVcsRootEntries", func() (any, error) { return client.GetVcsRootEntries(testConfig) }},
+
+		// Builds (read)
+		{"GetBuilds", func() (any, error) { return client.GetBuilds(t.Context(), api.BuildsOptions{Limit: 5}) }},
+		{"GetBuild", func() (any, error) { return client.GetBuild(t.Context(), buildID) }},
+		{"GetBuildChanges", func() (any, error) { return client.GetBuildChanges(t.Context(), buildID) }},
+		{"GetBuildTags", func() (any, error) { return client.GetBuildTags(buildID) }},
+		{"GetBuildTests", func() (any, error) { return client.GetBuildTests(t.Context(), buildID, false, 0) }},
+		{"GetBuildTestSummary", func() (any, error) { return client.GetBuildTestSummary(buildID) }},
+		{"GetBuildProblems", func() (any, error) { return client.GetBuildProblems(buildID) }},
+		{"GetBuildMessages", func() (any, error) {
+			return client.GetBuildMessages(t.Context(), buildID, api.BuildMessagesOptions{})
+		}},
+		{"GetBuildSnapshotDependencies", func() (any, error) { return client.GetBuildSnapshotDependencies(buildID) }},
+		{"GetBuildResultingProperties", func() (any, error) { return client.GetBuildResultingProperties(buildID) }},
+		{"GetBuildUsedByOtherBuilds", func() (any, error) { return client.GetBuildUsedByOtherBuilds(buildID) }},
+		{"GetArtifacts", func() (any, error) { return client.GetArtifacts(t.Context(), buildID, "") }},
+
+		// Queue
+		{"GetBuildQueue", func() (any, error) { return client.GetBuildQueue(api.QueueOptions{}) }},
+
+		// Agents and pools
+		{"GetAgents", func() (any, error) { return client.GetAgents(api.AgentsOptions{}) }},
+		{"GetAgentPools", func() (any, error) { return client.GetAgentPools(nil) }},
+
+		// VCS
+		{"GetVcsRoots", func() (any, error) { return client.GetVcsRoots(api.VcsRootsOptions{}) }},
+
+		// Cloud
+		{"GetCloudProfiles", func() (any, error) { return client.GetCloudProfiles(api.CloudProfilesOptions{}) }},
+		{"GetCloudImages", func() (any, error) { return client.GetCloudImages(api.CloudImagesOptions{}) }},
+		{"GetCloudInstances", func() (any, error) { return client.GetCloudInstances(api.CloudInstancesOptions{}) }},
+
+		// Pipelines (TeamCity 2026.1+; skips cleanly on older servers)
+		{"GetPipelines", func() (any, error) { return client.GetPipelines(api.PipelinesOptions{}) }},
+		{"GetPipelineSchema", func() (any, error) { return client.GetPipelineSchema() }},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := tc.call()
+			if err != nil {
+				if isFeatureUnavailable(err) {
+					t.Skipf("endpoint not supported on this server: %v", err)
+				}
+				t.Fatalf("%s drifted: %v", tc.name, err)
+			}
+			if result == nil {
+				t.Fatalf("%s returned nil result", tc.name)
+			}
+		})
+	}
+}
+
+func TestAPIDriftAgentEndpoints(t *testing.T) {
+	if client == nil {
+		t.Skip("no TeamCity client configured")
+	}
+	agents, err := client.GetAgents(api.AgentsOptions{})
+	if err != nil {
+		t.Skipf("could not list agents: %v", err)
+	}
+	if len(agents.Agents) == 0 {
+		t.Skip("no agents available")
+	}
+	agentID := agents.Agents[0].ID
+
+	cases := []endpointDriftCase{
+		{"GetAgentCompatibleBuildTypes", func() (any, error) { return client.GetAgentCompatibleBuildTypes(agentID) }},
+		{"GetAgentIncompatibleBuildTypes", func() (any, error) { return client.GetAgentIncompatibleBuildTypes(agentID) }},
+		{"GetAgentBuildTypeCompatibility", func() (any, error) {
+			return client.GetAgentBuildTypeCompatibility(agentID, testConfig, 0)
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := tc.call()
+			if err != nil {
+				if isFeatureUnavailable(err) {
+					t.Skipf("endpoint not supported on this server: %v", err)
+				}
+				t.Fatalf("%s drifted: %v", tc.name, err)
+			}
+			if result == nil {
+				t.Fatalf("%s returned nil result", tc.name)
+			}
+		})
+	}
+}
+
+// isFeatureUnavailable reports whether err means "I can't exercise this endpoint from where I'm standing" — auth, permission, not-found, or feature-not-configured. All environmental, none real contract drift.
+func isFeatureUnavailable(err error) bool {
+	for e := err; e != nil; {
+		switch typed := e.(type) {
+		case *api.PermissionError, *api.NotFoundError:
+			return true
+		case *api.HTTPError:
+			switch typed.Status {
+			case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+				return true
+			}
+		}
+		u, ok := e.(interface{ Unwrap() error })
+		if !ok {
+			break
+		}
+		e = u.Unwrap()
+	}
+	// Message fallback for endpoints whose CLI-side wrapper hides the typed error.
+	msg := err.Error()
+	for _, marker := range []string{
+		"not supported",
+		"predates",
+		"not available",
+		"not enabled",
+		"never been enabled",
+		"not configured",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
 	return false
 }

--- a/api/errors_parse.go
+++ b/api/errors_parse.go
@@ -23,7 +23,7 @@ var (
 	// notFoundRE matches `No <kind> found by locator '…id:X…'`.
 	notFoundRE = regexp.MustCompile(`^No (build types?|build|project|user|agent) found by locator '(?:[^']*?id:)?([^,')]+)`)
 	// nothingFoundRE matches `Nothing is found by locator 'count:1,<kind>:(id:X)…'`.
-	nothingFoundRE = regexp.MustCompile(`Nothing is found by locator '[^']*?(buildType|project|user|agent):?\(?(?:[^']*?id:)([^,')]+)`)
+	nothingFoundRE = regexp.MustCompile(`Nothing is found by locator '[^']*?(buildType|project|user|agent):?\(?[^']*?id:([^,')]+)`)
 
 	resourceAliases = map[string]string{
 		"build types": "job",

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -1,0 +1,169 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustClassify(t *testing.T, status int, body string) error {
+	t.Helper()
+	resp := &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	return ErrorFromResponse(resp)
+}
+
+func TestHTTPError_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"401 no body → auth phrasing", 401, "", "authentication failed"},
+		{"403 no body → permission phrasing", 403, "", "permission denied"},
+		{"404 no body → not-found phrasing", 404, "", "resource not found"},
+		{"500 no body → status fallback", 500, "", "server returned 500"},
+		{"401 with wire message → wire wins",
+			401, `{"errors":[{"message":"token revoked"}]}`, "token revoked"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := mustClassify(t, tc.status, tc.body)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestPermissionError_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("perm + project", func(t *testing.T) {
+		err := mustClassify(t, 403, `{"errors":[{"message":"You do not have \"Run build\" permission in project: 'My_Project'"}]}`)
+		var pe *PermissionError
+		ok := errors.As(err, &pe)
+		require.True(t, ok)
+		assert.Equal(t, `missing "Run build" permission in project My_Project`, pe.Error())
+	})
+
+	t.Run("perm only", func(t *testing.T) {
+		pe := &PermissionError{Permission: "Edit project"}
+		assert.Equal(t, `missing "Edit project" permission`, pe.Error())
+	})
+
+	t.Run("neither → wire fallback", func(t *testing.T) {
+		pe := &PermissionError{HTTPError: HTTPError{Wire: Wire{Message: "go away"}}}
+		assert.Equal(t, "go away", pe.Error())
+	})
+
+	t.Run("nothing at all", func(t *testing.T) {
+		pe := &PermissionError{}
+		assert.Equal(t, "permission denied", pe.Error())
+	})
+}
+
+func TestNotFoundError_ErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resource + id", func(t *testing.T) {
+		nf := &NotFoundError{Resource: "agent", ID: "mac-01"}
+		assert.Equal(t, `agent "mac-01" not found`, nf.Error())
+	})
+	t.Run("wire fallback", func(t *testing.T) {
+		nf := &NotFoundError{HTTPError: HTTPError{Wire: Wire{Message: "no such thing"}}}
+		assert.Equal(t, "no such thing", nf.Error())
+	})
+	t.Run("nothing", func(t *testing.T) {
+		nf := &NotFoundError{}
+		assert.Equal(t, "resource not found", nf.Error())
+	})
+}
+
+func TestNetworkError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("dial tcp: connection refused")
+	ne := &NetworkError{URL: "https://x.example.com", Cause: cause}
+
+	assert.Contains(t, ne.Error(), "cannot connect to https://x.example.com")
+	assert.Contains(t, ne.Error(), "connection refused")
+	assert.Equal(t, CatNetwork, ne.Category())
+	assert.Same(t, cause, ne.Unwrap())
+	assert.True(t, errors.Is(ne, cause))
+
+	t.Run("nil cause", func(t *testing.T) {
+		bare := &NetworkError{URL: "https://y.example.com"}
+		assert.Equal(t, "cannot connect to https://y.example.com", bare.Error())
+		assert.Nil(t, bare.Unwrap())
+	})
+}
+
+func TestIsSandboxBlocked(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"forbidden", &NetworkError{Cause: errors.New("dial tcp 1.2.3.4:443: Forbidden")}, true},
+		{"blocked", &NetworkError{Cause: errors.New("dial tcp: Blocked by policy")}, true},
+		{"sandbox literal", &NetworkError{Cause: errors.New("operation blocked by sandbox")}, true},
+		{"plain timeout", &NetworkError{Cause: errors.New("dial tcp: i/o timeout")}, false},
+		{"no cause", &NetworkError{URL: "https://x"}, false},
+		{"non-network", errors.New("kaboom"), false},
+		{"nil", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, IsSandboxBlocked(tc.err))
+		})
+	}
+}
+
+func TestValidationError(t *testing.T) {
+	t.Parallel()
+
+	v := Validation("bad input", "Try --foo")
+	assert.Equal(t, "bad input", v.Error())
+	assert.Equal(t, CatValidation, v.Category())
+	assert.Equal(t, "Try --foo", v.Suggestion())
+
+	t.Run("RequiredFlag", func(t *testing.T) {
+		err := RequiredFlag("server")
+		assert.Equal(t, "--server is required in non-interactive mode", err.Error())
+		assert.Contains(t, err.Suggestion(), "--no-input")
+	})
+
+	t.Run("MutuallyExclusive", func(t *testing.T) {
+		err := MutuallyExclusive("<id>", "all")
+		assert.Equal(t, "cannot specify both <id> argument and --all flag", err.Error())
+		assert.Contains(t, err.Suggestion(), "<id>")
+		assert.Contains(t, err.Suggestion(), "--all")
+	})
+}
+
+func TestErrReadOnly(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "read-only mode: writes are blocked", ErrReadOnly.Error())
+	assert.Equal(t, CatReadOnly, ErrReadOnly.Category())
+
+	// The interesting contract: callers must be able to detect ErrReadOnly
+	// even when it's wrapped through fmt.Errorf. Identity comparison is
+	// stdlib behavior; what matters here is that the unwrap chain works.
+	wrapped := fmt.Errorf("during request: %w", ErrReadOnly)
+	assert.True(t, errors.Is(wrapped, ErrReadOnly), "must unwrap through fmt.Errorf")
+}

--- a/api/interface.go
+++ b/api/interface.go
@@ -8,13 +8,11 @@ import (
 // ClientInterface defines the TeamCity API client interface.
 // Cmd package uses this interface for dependency injection in tests.
 type ClientInterface interface {
-	// Server
 	GetServer() (*Server, error)
 	ServerVersion() (*Server, error)
 	CheckVersion() error
 	SupportsFeature(feature string) bool
 
-	// Users
 	GetCurrentUser() (*User, error)
 	GetUser(username string) (*User, error)
 	UserExists(username string) bool
@@ -22,7 +20,6 @@ type ClientInterface interface {
 	CreateAPIToken(name string) (*Token, error)
 	DeleteAPIToken(name string) error
 
-	// Projects
 	GetProjects(opts ProjectsOptions) (*ProjectList, error)
 	GetProject(id string) (*Project, error)
 	CreateProject(req CreateProjectRequest) (*Project, error)
@@ -33,7 +30,6 @@ type ClientInterface interface {
 	GetVersionedSettingsConfig(projectID string) (*VersionedSettingsConfig, error)
 	ExportProjectSettings(projectID, format string, useRelativeIds bool) ([]byte, error)
 
-	// Build Types (Jobs)
 	GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error)
 	GetBuildType(id string) (*BuildType, error)
 	SetBuildTypePaused(id string, paused bool) error
@@ -45,7 +41,6 @@ type ClientInterface interface {
 	GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error)
 	SetBuildTypeSetting(buildTypeID, setting, value string) error
 
-	// Builds (Runs)
 	GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList, error)
 	GetBuild(ctx context.Context, ref string) (*Build, error)
 	GetBuildUsedByOtherBuilds(id string) (bool, error)
@@ -71,12 +66,10 @@ type ClientInterface interface {
 	GetBuildResultingProperties(buildID string) (*ParameterList, error)
 	UploadDiffChanges(patch []byte, description string) (string, error)
 
-	// Artifacts
 	GetArtifacts(ctx context.Context, buildID string, path string) (*Artifacts, error)
 	DownloadArtifact(ctx context.Context, buildID, artifactPath string) ([]byte, error)
 	DownloadArtifactTo(ctx context.Context, buildID, artifactPath string, w io.Writer) (int64, error)
 
-	// Build Queue
 	GetBuildQueue(opts QueueOptions) (*BuildQueue, error)
 	RemoveFromQueue(id string) error
 	SetQueuedBuildPosition(buildID string, position int) error
@@ -84,7 +77,6 @@ type ClientInterface interface {
 	ApproveQueuedBuild(buildID string) error
 	GetQueuedBuildApprovalInfo(buildID string) (*ApprovalInfo, error)
 
-	// Parameters
 	GetProjectParameters(projectID string) (*ParameterList, error)
 	GetProjectParameter(projectID, name string) (*Parameter, error)
 	SetProjectParameter(projectID, name, value string, secure bool) error
@@ -95,7 +87,6 @@ type ClientInterface interface {
 	DeleteBuildTypeParameter(buildTypeID, name string) error
 	GetParameterValue(path string) (string, error)
 
-	// Agents
 	GetAgents(opts AgentsOptions) (*AgentList, error)
 	GetAgent(id int) (*Agent, error)
 	GetAgentByName(name string) (*Agent, error)
@@ -108,14 +99,12 @@ type ClientInterface interface {
 	GetBuildIncompatibleAgents(buildID int) (*AgentList, error)
 	GetAgentBuildTypeCompatibility(agentID int, buildTypeID string, maxScan int) (*Compatibility, error)
 
-	// Agent Pools
 	GetAgentPools(fields []string) (*PoolList, error)
 	GetAgentPool(id int) (*Pool, error)
 	AddProjectToPool(poolID int, projectID string) error
 	RemoveProjectFromPool(poolID int, projectID string) error
 	SetAgentPool(agentID int, poolID int) error
 
-	// Cloud
 	GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList, error)
 	GetCloudProfile(locator string) (*CloudProfile, error)
 	GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error)
@@ -125,7 +114,6 @@ type ClientInterface interface {
 	StartCloudInstance(imageID string) (*CloudInstance, error)
 	StopCloudInstance(locator string, force bool) error
 
-	// Pipelines
 	GetBuildPipelineRun(buildID string) (*PipelineRun, error)
 	GetPipelines(opts PipelinesOptions) (*PipelineList, error)
 	GetPipeline(id string) (*Pipeline, error)
@@ -135,28 +123,23 @@ type ClientInterface interface {
 	DeletePipeline(id string) error
 	GetPipelineSchema() ([]byte, error)
 
-	// VCS Roots
 	GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error)
 	GetVcsRoot(id string) (*VcsRoot, error)
 	CreateVcsRoot(root VcsRoot) (*VcsRoot, error)
 	DeleteVcsRoot(id string) error
 	TestVcsConnection(req TestConnectionRequest, projectID string) (*TestConnectionResult, error)
 
-	// SSH Keys
 	GetSSHKeys(projectID string) (*SSHKeyList, error)
 	UploadSSHKey(projectID, name string, privateKey []byte) error
 	GenerateSSHKey(projectID, name, keyType string) (*SSHKey, error)
 	DeleteSSHKey(projectID, name string) error
 
-	// Project Connections
 	GetProjectConnections(projectID string) (*ProjectFeatureList, error)
 	CreateProjectFeature(projectID string, feat ProjectFeature) (*ProjectFeature, error)
 	DeleteProjectFeature(projectID, featureID string) error
 
-	// Raw API access
 	RawRequest(ctx context.Context, method, path string, body io.Reader, headers map[string]string) (*RawResponse, error)
 
-	// Client metadata
 	SetCommandName(name string)
 	ServerURL() string
 }

--- a/api/retry.go
+++ b/api/retry.go
@@ -19,6 +19,8 @@ type RetryConfig struct {
 }
 
 // Predefined retry configurations for different operation types.
+//
+//goland:noinspection GoUnusedGlobalVariable
 var (
 	// ReadRetry is the default for idempotent read operations (GET).
 	// Retries on network errors, 429, and 5xx responses.

--- a/api/terminal_pty_test.go
+++ b/api/terminal_pty_test.go
@@ -1,39 +1,36 @@
-//go:build terminal_pty
+//go:build integration || terminal_pty
 
-// Drives `teamcity agent term` under a real pty against live agents on
-// cli.teamcity.com. Agent ids come from TC_PTY_{LINUX,WINDOWS}_AGENT_ID.
+// Drives `teamcity agent term` and `teamcity agent exec` under a real pty,
+// against whichever server the integration testenv brought up. Per-OS
+// subtests skip cleanly when no agent of that family is connected.
 package api_test
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	expect "github.com/Netflix/go-expect"
 	"github.com/stretchr/testify/require"
+
+	"github.com/JetBrains/teamcity-cli/api"
 )
 
 const (
-	ptyEnvBinary       = "TC_PTY_BINARY"
-	ptyEnvHost         = "TC_PTY_HOST"
-	ptyEnvToken        = "TC_PTY_TOKEN"
-	ptyEnvLinuxAgent   = "TC_PTY_LINUX_AGENT_ID"
-	ptyEnvWindowsAgent = "TC_PTY_WINDOWS_AGENT_ID"
-
-	ptyDefaultHost = "https://cli.teamcity.com"
-	ptyIdleWait    = 75 * time.Second // > pingInterval (60s) so a missed pong would be visible
-	ptyExitWait    = 30 * time.Second // grace period for the spawned binary to exit after remote EOF
+	ptyIdleWait = 75 * time.Second // > pingInterval (60s) so a missed pong would surface
+	ptyExitWait = 30 * time.Second // grace period for the spawned binary to exit after remote EOF
 )
 
 func ptyBinary(t *testing.T) string {
 	t.Helper()
-	if bin := os.Getenv(ptyEnvBinary); bin != "" {
-		abs, err := filepath.Abs(bin)
-		require.NoError(t, err)
-		return abs
-	}
 	bin := filepath.Join(t.TempDir(), "teamcity")
 	cmd := exec.Command("go", "build", "-o", bin, "./tc")
 	cmd.Dir = repoRoot(t)
@@ -58,26 +55,95 @@ func repoRoot(t *testing.T) string {
 	}
 }
 
+// ptyEnv hands the spawned `teamcity` process the same URL+token the test process uses.
 func ptyEnv() []string {
-	host := os.Getenv(ptyEnvHost)
-	if host == "" {
-		host = ptyDefaultHost
-	}
-	env := append(os.Environ(), "TEAMCITY_URL="+host)
-	token := os.Getenv(ptyEnvToken)
-	if token == "" {
-		token = os.Getenv("TEAMCITY_TOKEN")
-	}
-	if token != "" {
-		env = append(env, "TEAMCITY_TOKEN="+token)
+	env := os.Environ()
+	if testEnvRef != nil && testEnvRef.URL != "" {
+		env = append(env, "TEAMCITY_URL="+testEnvRef.URL)
+		if testEnvRef.Token != "" {
+			env = append(env, "TEAMCITY_TOKEN="+testEnvRef.Token)
+		}
 	}
 	return env
 }
 
+// pickAgentByOS returns the first authorized+connected agent whose teamcity.agent.os.family matches, or "" with a skip reason.
+func pickAgentByOS(t *testing.T, osFamily string) (id, skip string) {
+	t.Helper()
+
+	if testEnvRef == nil || testEnvRef.Client == nil {
+		return "", "no integration env (set TEAMCITY_URL/TEAMCITY_TOKEN or have Docker for testcontainers)"
+	}
+	if testEnvRef.guestAuth {
+		return "", "guest auth lacks CONNECT_TO_AGENT permission"
+	}
+
+	agents, err := testEnvRef.Client.GetAgents(api.AgentsOptions{})
+	if err != nil {
+		return "", fmt.Sprintf("could not list agents: %v", err)
+	}
+
+	want := strings.ToLower(osFamily)
+	for _, a := range agents.Agents {
+		if !a.Connected || !a.Authorized {
+			continue
+		}
+		family, err := agentOSFamily(t.Context(), testEnvRef.URL, testEnvRef.Token, a.ID)
+		if err != nil {
+			t.Logf("agent %d: could not read os family: %v", a.ID, err)
+			continue
+		}
+		if strings.Contains(strings.ToLower(family), want) {
+			return strconv.Itoa(a.ID), ""
+		}
+	}
+	return "", fmt.Sprintf("no authorized %s agent connected", osFamily)
+}
+
+// agentOSFamily reads a single agent's teamcity.agent.os.family property via a narrow field selector.
+func agentOSFamily(ctx context.Context, serverURL, token string, agentID int) (string, error) {
+	url := fmt.Sprintf("%s/app/rest/agents/id:%d?fields=properties(property(name,value))",
+		strings.TrimSuffix(serverURL, "/"), agentID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("agent %d: HTTP %d", agentID, resp.StatusCode)
+	}
+
+	var body struct {
+		Properties struct {
+			Property []struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			} `json:"property"`
+		} `json:"properties"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	for _, p := range body.Properties.Property {
+		if p.Name == "teamcity.agent.os.family" {
+			return p.Value, nil
+		}
+	}
+	return "", nil // property absent — caller treats as "no match"
+}
+
 // ptyProc bundles the pty console with the spawned `teamcity` process so
-// callers can assert the process exited cleanly after the remote shell EOFs.
-// Without the exit-status assertion, a subprocess that prints the expected
-// output but crashes on teardown would still pass these tests.
+// callers can assert clean exit. Without that assertion, a subprocess that
+// prints the right output but crashes on teardown would still pass.
 type ptyProc struct {
 	*expect.Console
 	cmd     *exec.Cmd
@@ -85,9 +151,6 @@ type ptyProc struct {
 	waitErr error
 }
 
-// AssertCleanExit waits for the spawned `teamcity` process to exit and fails
-// the test if it either times out or returns a non-zero status. Call after
-// `ExpectEOF`.
 func (p *ptyProc) AssertCleanExit(t *testing.T) {
 	t.Helper()
 	select {
@@ -135,9 +198,9 @@ func ptySpawn(t *testing.T, args ...string) *ptyProc {
 }
 
 func TestTerminalPtyLinux(t *testing.T) {
-	agentID := os.Getenv(ptyEnvLinuxAgent)
-	if agentID == "" {
-		t.Skipf("%s not set — bring up an agent via CLI_LinuxAgentTerminal and export its id", ptyEnvLinuxAgent)
+	agentID, skip := pickAgentByOS(t, "Linux")
+	if skip != "" {
+		t.Skipf("Linux PTY skipped: %s", skip)
 	}
 
 	t.Run("prompt echo exit", func(t *testing.T) {
@@ -176,9 +239,9 @@ func TestTerminalPtyLinux(t *testing.T) {
 }
 
 func TestTerminalPtyWindows(t *testing.T) {
-	agentID := os.Getenv(ptyEnvWindowsAgent)
-	if agentID == "" {
-		t.Skipf("%s not set — bring up an agent via CLI_WindowsAgentTerminal and export its id", ptyEnvWindowsAgent)
+	agentID, skip := pickAgentByOS(t, "Windows")
+	if skip != "" {
+		t.Skipf("Windows PTY skipped: %s", skip)
 	}
 
 	t.Run("powershell prompt echo exit", func(t *testing.T) {
@@ -197,15 +260,14 @@ func TestTerminalPtyWindows(t *testing.T) {
 	})
 }
 
-// Regresses the deadline-scope decision: Exec must not inherit the
-// interactive read deadline, or silent long commands time out before ctx.
+// TestTerminalPtyExecSilentLong regresses the deadline-scope decision: Exec must not inherit the interactive read deadline.
 func TestTerminalPtyExecSilentLong(t *testing.T) {
 	if testing.Short() {
 		t.Skip("170s exec — skipped under -short")
 	}
-	agentID := os.Getenv(ptyEnvLinuxAgent)
-	if agentID == "" {
-		t.Skipf("%s not set", ptyEnvLinuxAgent)
+	agentID, skip := pickAgentByOS(t, "Linux")
+	if skip != "" {
+		t.Skipf("exec long skipped: %s", skip)
 	}
 
 	cmd := exec.Command(ptyBinary(t), "agent", "exec", agentID,

--- a/api/testenv_test.go
+++ b/api/testenv_test.go
@@ -1,4 +1,4 @@
-//go:build integration || guest
+//go:build integration || guest || terminal_pty
 
 package api_test
 

--- a/api/types.go
+++ b/api/types.go
@@ -630,11 +630,15 @@ type BuildRef struct {
 }
 
 // APIError represents an error from TeamCity's REST API
+//
+//goland:noinspection GoNameStartsWithPackageName
 type APIError struct {
 	Message string `json:"message"`
 }
 
 // APIErrorResponse represents TeamCity's error response format
+//
+//goland:noinspection GoNameStartsWithPackageName
 type APIErrorResponse struct {
 	Errors []APIError `json:"errors"`
 }

--- a/internal/cmd/auth/pkce_test.go
+++ b/internal/cmd/auth/pkce_test.go
@@ -1,0 +1,61 @@
+package auth
+
+import (
+	"encoding/base64"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPkceCodeChallenge_RFC7636Vector pins the verifier→challenge derivation against the RFC 7636 §B worked example.
+func TestPkceCodeChallenge_RFC7636Vector(t *testing.T) {
+	t.Parallel()
+
+	const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	const want = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+	got := pkceCodeChallenge(verifier)
+	assert.Equal(t, want, got, "RFC 7636 §B test vector failed — PKCE is broken")
+}
+
+var verifierAlphabet = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+// TestGeneratePkceVerifier_RFC7636Constraints pins length (43 chars), alphabet ([A-Za-z0-9_-]), and uniqueness per RFC 7636 §4.1.
+func TestGeneratePkceVerifier_RFC7636Constraints(t *testing.T) {
+	t.Parallel()
+
+	const samples = 1000
+	seen := make(map[string]struct{}, samples)
+
+	for range samples {
+		v, err := generatePkceVerifier()
+		require.NoError(t, err)
+		assert.Len(t, v, 43, "verifier must be 43 chars (32 raw bytes, base64url no-padding)")
+		assert.True(t, verifierAlphabet.MatchString(v), "verifier %q has illegal chars", v)
+
+		raw, err := base64.RawURLEncoding.DecodeString(v)
+		require.NoError(t, err)
+		assert.Len(t, raw, 32)
+
+		_, dup := seen[v]
+		assert.False(t, dup, "duplicate verifier — randomness is broken")
+		seen[v] = struct{}{}
+	}
+}
+
+func TestDescribeScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("known scope → description + faint enum", func(t *testing.T) {
+		got := describeScope("VIEW_PROJECT")
+		assert.Contains(t, got, "View project")
+		assert.Contains(t, got, "VIEW_PROJECT")
+	})
+
+	t.Run("unknown scope → returns scope verbatim", func(t *testing.T) {
+		got := describeScope("CUSTOM_FUTURE_SCOPE_X")
+		assert.Equal(t, "CUSTOM_FUTURE_SCOPE_X", got)
+	})
+}

--- a/internal/cmd/job/tree.go
+++ b/internal/cmd/job/tree.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+//goland:noinspection GoUnnecessarilyExportedIdentifiers
 type JobTreeNode struct {
 	ID           string        `json:"id"`
 	Name         string        `json:"name"`

--- a/internal/cmd/param/param.go
+++ b/internal/cmd/param/param.go
@@ -11,6 +11,8 @@ import (
 )
 
 // ParamAPI defines the interface for parameter operations
+//
+//goland:noinspection GoNameStartsWithPackageName
 type ParamAPI struct {
 	List   func(client api.ClientInterface, id string) (*api.ParameterList, error)
 	Get    func(client api.ClientInterface, id, name string) (*api.Parameter, error)

--- a/internal/cmd/pipeline/validate_test.go
+++ b/internal/cmd/pipeline/validate_test.go
@@ -1,0 +1,156 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestFindLineNumber(t *testing.T) {
+	t.Parallel()
+
+	src := `version: v1.0
+jobs:
+  build:
+    steps:
+      - script: go build ./...
+  test:
+    needs: [build]
+    steps:
+      - script: go test ./...
+`
+	var root yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(src), &root))
+
+	// findLineNumber descends to the *value* node, so block-style YAML reports the line after the key.
+	cases := []struct {
+		path     string
+		wantLine int
+	}{
+		{"", 0},                    // empty path → 0
+		{"/version", 1},            // scalar value on the same line as its key
+		{"/jobs", 3},               // value starts at the first sub-key ("build:")
+		{"/jobs/build", 4},         // value starts at "steps:"
+		{"/jobs/build/steps", 5},   // sequence starts on the next line
+		{"/jobs/build/steps/0", 5}, // first sequence item
+		{"/jobs/test/needs/0", 7},  // inline-array element on key's line
+		{"/jobs/test/steps/0/script", 9},
+		{"/jobs/missing", 0}, // missing path: walk falls through; we only assert non-negative below
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			t.Parallel()
+			got := findLineNumber(&root, tc.path)
+			if tc.path == "/jobs/missing" {
+				assert.True(t, got >= 0)
+				return
+			}
+			assert.Equal(t, tc.wantLine, got)
+		})
+	}
+
+	t.Run("nil root", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, 0, findLineNumber(nil, "/anything"))
+	})
+}
+
+func TestConvertYAMLToJSON(t *testing.T) {
+	t.Parallel()
+
+	t.Run("string keys passthrough", func(t *testing.T) {
+		in := map[string]any{"k": "v"}
+		got := convertYAMLToJSON(in)
+		assert.Equal(t, map[string]any{"k": "v"}, got)
+	})
+
+	t.Run("integer keys stringified", func(t *testing.T) {
+		// jsonschema only accepts string keys, so map[any]any keys must stringify.
+		in := map[any]any{1: "one", "two": 2}
+		got := convertYAMLToJSON(in)
+		want := map[string]any{"1": "one", "two": 2}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("nested arrays and maps", func(t *testing.T) {
+		in := map[string]any{
+			"jobs": map[any]any{
+				"build": map[string]any{
+					"steps": []any{
+						map[any]any{"script": "go build"},
+					},
+				},
+			},
+		}
+		got := convertYAMLToJSON(in).(map[string]any)
+		jobs := got["jobs"].(map[string]any)
+		build := jobs["build"].(map[string]any)
+		steps := build["steps"].([]any)
+		assert.Equal(t, "go build", steps[0].(map[string]any)["script"])
+	})
+
+	t.Run("scalars unchanged", func(t *testing.T) {
+		assert.Equal(t, "x", convertYAMLToJSON("x"))
+		assert.Equal(t, 42, convertYAMLToJSON(42))
+		assert.Equal(t, true, convertYAMLToJSON(true))
+		assert.Equal(t, nil, convertYAMLToJSON(nil))
+	})
+}
+
+func TestValidateAgainstSchema(t *testing.T) {
+	t.Parallel()
+
+	// Tiny inline schema mirroring the real pipeline schema's top-level shape.
+	schema := []byte(`{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"type": "object",
+		"properties": {
+			"version": {"type": "string", "enum": ["v1.0"]},
+			"jobs":    {"type": "object"}
+		},
+		"required": ["version", "jobs"]
+	}`)
+
+	t.Run("valid doc → no errors", func(t *testing.T) {
+		t.Parallel()
+		doc := map[string]any{"version": "v1.0", "jobs": map[string]any{}}
+		errs, err := validateAgainstSchema(schema, doc)
+		require.NoError(t, err)
+		assert.Empty(t, errs)
+	})
+
+	t.Run("missing required → reported", func(t *testing.T) {
+		t.Parallel()
+		doc := map[string]any{"version": "v1.0"}
+		errs, err := validateAgainstSchema(schema, doc)
+		require.NoError(t, err)
+		require.NotEmpty(t, errs)
+		// Don't pin exact wording (jsonschema lib may rephrase); just check the field is mentioned.
+		assert.Contains(t, errs[0].message, "jobs")
+	})
+
+	t.Run("wrong enum → reported with path", func(t *testing.T) {
+		t.Parallel()
+		doc := map[string]any{"version": "v0.9", "jobs": map[string]any{}}
+		errs, err := validateAgainstSchema(schema, doc)
+		require.NoError(t, err)
+		require.NotEmpty(t, errs)
+		// At least one error should point at the version field via its JSON pointer.
+		var sawVersion bool
+		for _, e := range errs {
+			if e.path == "/version" {
+				sawVersion = true
+				break
+			}
+		}
+		assert.True(t, sawVersion, "expected an error with path /version, got %+v", errs)
+	})
+
+	t.Run("invalid schema → returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := validateAgainstSchema([]byte(`{not json`), map[string]any{})
+		assert.Error(t, err)
+	})
+}

--- a/internal/cmd/project/connection_create_github_app_manifest.go
+++ b/internal/cmd/project/connection_create_github_app_manifest.go
@@ -43,7 +43,7 @@ var defaultManifestPermissions = map[string]string{
 	"checks":        "write",
 }
 
-// defaultManifestEvents is empty: TeamCity polls VCS roots; webhooks need a public TeamCity URL we shouldn't assume.
+// defaultManifestEvents must stay []string{} (not nil) so the JSON manifest emits "default_events": [], not null. GitHub's manifest schema rejects null. Empty array is intentional: TeamCity polls VCS roots; webhooks need a public TeamCity URL we shouldn't assume.
 var defaultManifestEvents = []string{}
 
 // manifestCreds is the subset of GitHub's app-manifest conversion response we need.
@@ -193,8 +193,8 @@ func manifestSubmitURL(org string) string {
 
 // exchangeManifestCode trades the one-shot code for the new GitHub App's credentials.
 func exchangeManifestCode(ctx context.Context, code string) (*manifestCreds, error) {
-	url := fmt.Sprintf("%s/app-manifests/%s/conversions", strings.TrimSuffix(githubAPIHost, "/"), code)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	ghUrl := fmt.Sprintf("%s/app-manifests/%s/conversions", strings.TrimSuffix(githubAPIHost, "/"), code)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ghUrl, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/project/helpers_internal_test.go
+++ b/internal/cmd/project/helpers_internal_test.go
@@ -1,0 +1,121 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSSHURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		// Explicit ssh:// scheme.
+		{"ssh://git@github.com/org/repo", true},
+		{"ssh://example.com:2222/repo.git", true},
+		// SCP-style (user@host:path), no scheme.
+		{"git@github.com:org/repo.git", true},
+		{"jenkins@gerrit.example.com:project", true},
+		// HTTPS / HTTP — has :// but doesn't start with ssh://, even with @ in userinfo.
+		{"https://github.com/org/repo", false},
+		{"http://example.com/repo", false},
+		{"https://user@example.com/repo", false}, // @ in HTTPS userinfo: still not SSH
+		// Edge cases.
+		{"", false},
+		{"file:///tmp/repo", false},
+		{"plain.example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, isSSHURL(tc.url))
+		})
+	}
+}
+
+func TestInferAuthFromURL(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, authSSHKey, inferAuthFromURL("git@github.com:org/repo.git"))
+	assert.Equal(t, authSSHKey, inferAuthFromURL("ssh://example.com/repo"))
+	assert.Equal(t, authAnonymous, inferAuthFromURL("https://github.com/org/repo"))
+	assert.Equal(t, authAnonymous, inferAuthFromURL(""))
+}
+
+func TestBaseName(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in, want string
+	}{
+		{"foo", "foo"},
+		{"path/to/foo", "foo"},
+		{"path\\to\\foo", "foo"},    // Windows separator
+		{"path/to\\mixed", "mixed"}, // mixed separators take the last one
+		{"/abs/path/key", "key"},
+		{"./relative/key.pem", "key.pem"},
+		{"", ""},
+		{"trailing/", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, baseName(tc.in))
+		})
+	}
+}
+
+func TestParseValidationStats(t *testing.T) {
+	t.Parallel()
+
+	// Real DSL shape: target/generated-configs/<ProjectName>/{buildTypes,vcsRoots}/*.xml.
+	t.Run("missing target dir → empty", func(t *testing.T) {
+		t.Parallel()
+		assert.Empty(t, parseValidationStats(t.TempDir()))
+	})
+
+	t.Run("empty configs dir → empty (no projects)", func(t *testing.T) {
+		t.Parallel()
+		dsl := t.TempDir()
+		require.NoError(t, os.MkdirAll(filepath.Join(dsl, "target", "generated-configs"), 0700))
+		// projects=0 → function short-circuits to "" by design, regardless of buildTypes/vcsRoots.
+		assert.Empty(t, parseValidationStats(dsl))
+	})
+
+	t.Run("two projects with builds and vcs roots", func(t *testing.T) {
+		t.Parallel()
+		dsl := t.TempDir()
+		base := filepath.Join(dsl, "target", "generated-configs")
+
+		// Real shape: <project>/{project-config.xml, buildTypes/*.xml, vcsRoots/*.xml}
+		require.NoError(t, os.MkdirAll(filepath.Join(base, "MyApp", "buildTypes"), 0700))
+		require.NoError(t, os.MkdirAll(filepath.Join(base, "MyApp", "vcsRoots"), 0700))
+		require.NoError(t, os.MkdirAll(filepath.Join(base, "Infra", "buildTypes"), 0700))
+
+		require.NoError(t, os.WriteFile(filepath.Join(base, "MyApp", "buildTypes", "Build.xml"), []byte("<x/>"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(base, "MyApp", "buildTypes", "Test.xml"), []byte("<x/>"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(base, "MyApp", "vcsRoots", "MainRepo.xml"), []byte("<x/>"), 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(base, "Infra", "buildTypes", "Deploy.xml"), []byte("<x/>"), 0600))
+
+		got := parseValidationStats(dsl)
+		assert.Equal(t, "Projects: 2, Build configurations: 3, VCS roots: 1", got)
+	})
+
+	t.Run("projects with no vcs roots → omits VCS line", func(t *testing.T) {
+		t.Parallel()
+		dsl := t.TempDir()
+		base := filepath.Join(dsl, "target", "generated-configs")
+		require.NoError(t, os.MkdirAll(filepath.Join(base, "MyApp", "buildTypes"), 0700))
+		require.NoError(t, os.WriteFile(filepath.Join(base, "MyApp", "buildTypes", "Build.xml"), []byte("<x/>"), 0600))
+
+		got := parseValidationStats(dsl)
+		assert.Equal(t, "Projects: 1, Build configurations: 1", got)
+		assert.NotContains(t, got, "VCS roots", "VCS line should be suppressed when count is 0")
+	})
+}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -324,6 +324,7 @@ func runProjectTokenGet(f *cmdutil.Factory, projectID, token string) error {
 	return nil
 }
 
+//goland:noinspection GoUnnecessarilyExportedIdentifiers
 type ProjectTreeNode struct {
 	ID        string            `json:"id"`
 	Name      string            `json:"name"`

--- a/internal/cmd/run/tree.go
+++ b/internal/cmd/run/tree.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+//goland:noinspection GoUnnecessarilyExportedIdentifiers
 type RunTreeNode struct {
 	ID           int           `json:"id"`
 	Number       string        `json:"number,omitempty"`

--- a/internal/cmdtest/testutil.go
+++ b/internal/cmdtest/testutil.go
@@ -108,15 +108,6 @@ func JSON(w http.ResponseWriter, v any) {
 	}
 }
 
-// JSONStatus writes a JSON response with specified status code.
-func JSONStatus(w http.ResponseWriter, status int, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-}
-
 // Text writes a plain text response.
 func Text(w http.ResponseWriter, s string) {
 	w.Header().Set("Content-Type", "text/plain")

--- a/internal/cmdutil/cmdutil.go
+++ b/internal/cmdutil/cmdutil.go
@@ -7,7 +7,6 @@ import (
 )
 
 // SubcommandRequired is a RunE function for parent commands that require a subcommand.
-// It returns an error when no valid subcommand is provided.
-func SubcommandRequired(cmd *cobra.Command, args []string) error {
+func SubcommandRequired(cmd *cobra.Command, _ []string) error {
 	return fmt.Errorf("requires a subcommand\n\nRun '%s --help' for available commands", cmd.CommandPath())
 }

--- a/internal/cmdutil/deprecate.go
+++ b/internal/cmdutil/deprecate.go
@@ -19,6 +19,8 @@ func DeprecateFlag(cmd *cobra.Command, old, new, removeVersion string) {
 }
 
 // DeprecateCommand marks a command as deprecated with a consistent message format.
+//
+//goland:noinspection GoUnusedExportedFunction
 func DeprecateCommand(cmd *cobra.Command, new, removeVersion string) {
 	cmd.Deprecated = fmt.Sprintf("use %q instead (will be removed in %s)", new, removeVersion)
 }

--- a/internal/cmdutil/helpers_test.go
+++ b/internal/cmdutil/helpers_test.go
@@ -1,6 +1,10 @@
 package cmdutil
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -108,4 +112,180 @@ func TestWarnInsecureHTTP(t *testing.T) {
 	// Should not panic with env var set
 	t.Setenv("TC_INSECURE_SKIP_WARN", "1")
 	f.WarnInsecureHTTP("http://tc.example.com", "token")
+}
+
+func TestRequireNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in      string
+		wantErr bool
+	}{
+		{"hello", false},
+		{"  hello  ", false}, // trim leaves content
+		{"", true},
+		{"   ", true}, // whitespace-only rejected
+		{"\t\n", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			err := RequireNonEmpty(tc.in)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// fakeAgentClient stubs the agent-resolution surface only.
+type fakeAgentClient struct {
+	api.ClientInterface
+	byID   map[int]*api.Agent
+	byName map[string]*api.Agent
+}
+
+func (c *fakeAgentClient) GetAgent(id int) (*api.Agent, error) {
+	if a, ok := c.byID[id]; ok {
+		return a, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func (c *fakeAgentClient) GetAgentByName(name string) (*api.Agent, error) {
+	if a, ok := c.byName[name]; ok {
+		return a, nil
+	}
+	return nil, errors.New("not found")
+}
+
+func TestResolveAgent(t *testing.T) {
+	t.Parallel()
+	client := &fakeAgentClient{
+		byID:   map[int]*api.Agent{42: {ID: 42, Name: "linux-01"}},
+		byName: map[string]*api.Agent{"linux-01": {ID: 42, Name: "linux-01"}},
+	}
+
+	t.Run("numeric → GetAgent", func(t *testing.T) {
+		t.Parallel()
+		a, err := ResolveAgent(client, "42")
+		require.NoError(t, err)
+		assert.Equal(t, 42, a.ID)
+	})
+	t.Run("name → GetAgentByName", func(t *testing.T) {
+		t.Parallel()
+		a, err := ResolveAgent(client, "linux-01")
+		require.NoError(t, err)
+		assert.Equal(t, "linux-01", a.Name)
+	})
+	t.Run("ResolveAgentID returns id+name pair", func(t *testing.T) {
+		t.Parallel()
+		id, name, err := ResolveAgentID(client, "linux-01")
+		require.NoError(t, err)
+		assert.Equal(t, 42, id)
+		assert.Equal(t, "linux-01", name)
+	})
+	t.Run("unknown name → error", func(t *testing.T) {
+		t.Parallel()
+		_, err := ResolveAgent(client, "ghost")
+		assert.Error(t, err)
+	})
+	t.Run("ResolveAgentID propagates error", func(t *testing.T) {
+		t.Parallel()
+		_, _, err := ResolveAgentID(client, "ghost")
+		assert.Error(t, err)
+	})
+}
+
+func TestProbeGuestAccess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty url → false (no network call)", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, ProbeGuestAccess(context.Background(), ""))
+	})
+
+	t.Run("200 → true", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			// Minimal valid /app/rest/server JSON so GetServer decodes.
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"2025.7","versionMajor":2025,"versionMinor":7,"buildNumber":"1"}`))
+		}))
+		defer srv.Close()
+		assert.True(t, ProbeGuestAccess(context.Background(), srv.URL))
+	})
+
+	t.Run("401 → false", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+		assert.False(t, ProbeGuestAccess(context.Background(), srv.URL))
+	})
+
+	t.Run("dead address → false", func(t *testing.T) {
+		t.Parallel()
+		// Closed port; ProbeGuestAccess must return false without panicking.
+		assert.False(t, ProbeGuestAccess(context.Background(), "http://127.0.0.1:1"))
+	})
+}
+
+func TestNotAuthenticatedError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no keyring err", func(t *testing.T) {
+		t.Parallel()
+		err := NotAuthenticatedError(context.Background(), "", nil)
+		require.NotNil(t, err)
+		assert.Equal(t, "Not authenticated", err.Error())
+		assert.Contains(t, err.Suggestion(), "TEAMCITY_URL")
+	})
+
+	t.Run("with keyring err mentions it", func(t *testing.T) {
+		t.Parallel()
+		ke := errors.New("keychain locked")
+		err := NotAuthenticatedError(context.Background(), "", ke)
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "keyring")
+		assert.Contains(t, err.Error(), "keychain locked")
+	})
+
+	t.Run("guest-capable server adds guest hint", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"version":"2025.7","versionMajor":2025,"versionMinor":7,"buildNumber":"1"}`))
+		}))
+		defer srv.Close()
+
+		err := NotAuthenticatedError(context.Background(), srv.URL, nil)
+		require.NotNil(t, err)
+		assert.Contains(t, err.Suggestion(), "TEAMCITY_GUEST=1")
+	})
+}
+
+func TestDeprecateCommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "old"}
+	DeprecateCommand(cmd, "new", "v2.0.0")
+
+	assert.NotEmpty(t, cmd.Deprecated)
+	assert.Contains(t, cmd.Deprecated, "new")
+	assert.Contains(t, cmd.Deprecated, "v2.0.0")
+}
+
+func TestDeprecateFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().Bool("old", false, "old flag")
+	DeprecateFlag(cmd, "old", "new", "v2.0.0")
+
+	flag := cmd.Flag("old")
+	require.NotNil(t, flag)
+	assert.NotEmpty(t, flag.Deprecated, "flag should carry deprecation note")
+	assert.Contains(t, flag.Deprecated, "new")
+	assert.Contains(t, flag.Deprecated, "v2.0.0")
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -150,8 +150,8 @@ func keyringService(serverURL string) string {
 
 // GetServerURL resolves the target server from TEAMCITY_URL, then the configured default; never from DSL (avoids routing a stored token to an untrusted repo's .teamcity/pom.xml — opt in via `auth login`).
 func GetServerURL() string {
-	if url := os.Getenv(EnvServerURL); url != "" {
-		return NormalizeURL(url)
+	if serverUrl := os.Getenv(EnvServerURL); serverUrl != "" {
+		return NormalizeURL(serverUrl)
 	}
 	return cfg.DefaultServer
 }
@@ -278,8 +278,8 @@ func writeConfig() error {
 	w.Set("default_server", cfg.DefaultServer)
 
 	servers := make(map[string]any, len(cfg.Servers))
-	for url, sc := range cfg.Servers {
-		servers[url] = serverConfigToMap(sc)
+	for serverUrl, sc := range cfg.Servers {
+		servers[serverUrl] = serverConfigToMap(sc)
 	}
 	w.Set("servers", servers)
 	w.Set("aliases", cfg.Aliases)

--- a/internal/output/render_error_test.go
+++ b/internal/output/render_error_test.go
@@ -1,0 +1,273 @@
+package output_test
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+)
+
+// httpErr builds a typed api error via the real parser (only way to set the unexported Category).
+func httpErr(t *testing.T, status int, body string) error {
+	t.Helper()
+	resp := &http.Response{
+		StatusCode: status,
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+	return api.ErrorFromResponse(resp)
+}
+
+// permErr returns a *api.PermissionError with AuthSource set, routed via ErrorFromResponse so cat is populated.
+func permErr(t *testing.T, body string, src api.AuthSource) *api.PermissionError {
+	t.Helper()
+	var pe *api.PermissionError
+	ok := errors.As(httpErr(t, http.StatusForbidden, body), &pe)
+	require.True(t, ok, "expected *api.PermissionError")
+	pe.AuthSource = src
+	return pe
+}
+
+func notFoundErr(t *testing.T, message string) *api.NotFoundError {
+	t.Helper()
+	body := `{"errors":[{"message":` + jsonString(message) + `}]}`
+	var nf *api.NotFoundError
+	ok := errors.As(httpErr(t, http.StatusNotFound, body), &nf)
+	require.True(t, ok, "expected *api.NotFoundError")
+	return nf
+}
+
+func jsonString(s string) string {
+	// minimal JSON escape — we control inputs so this is enough.
+	return `"` + strings.ReplaceAll(strings.ReplaceAll(s, `\`, `\\`), `"`, `\"`) + `"`
+}
+
+// TestClassifyError_Categories pins the (code, tip) pair for each error class.
+func TestClassifyError_Categories(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		err      error
+		wantCode output.JSONErrorCode
+		wantTip  string // substring expected in tip; "" means no tip
+	}{
+		{
+			name:     "401 → auth re-login",
+			err:      httpErr(t, http.StatusUnauthorized, ""),
+			wantCode: output.ErrCodeAuth,
+			wantTip:  "teamcity auth login",
+		},
+		{
+			name:     "403 generic → broader permissions",
+			err:      httpErr(t, http.StatusForbidden, ""),
+			wantCode: output.ErrCodePermission,
+			wantTip:  "broader permissions",
+		},
+		{
+			name:     "404 with no resource → fallback tip",
+			err:      httpErr(t, http.StatusNotFound, ""),
+			wantCode: output.ErrCodeNotFound,
+			wantTip:  "teamcity",
+		},
+		{
+			name:     "read-only sentinel",
+			err:      api.ErrReadOnly,
+			wantCode: output.ErrCodeReadOnly,
+			wantTip:  "TEAMCITY_RO",
+		},
+		{
+			name:     "network error generic",
+			err:      &api.NetworkError{URL: "https://x", Cause: errors.New("dial tcp: timeout")},
+			wantCode: output.ErrCodeNetwork,
+			wantTip:  "network connection",
+		},
+		{
+			name:     "network error sandbox-blocked",
+			err:      &api.NetworkError{URL: "https://x", Cause: errors.New("dial tcp: Forbidden")},
+			wantCode: output.ErrCodeNetwork,
+			wantTip:  "sandbox",
+		},
+		{
+			name:     "validation with explicit tip",
+			err:      api.Validation("bad input", "Pass --foo instead"),
+			wantCode: output.ErrCodeValidation,
+			wantTip:  "Pass --foo instead",
+		},
+		{
+			name:     "non-typed error → internal",
+			err:      errors.New("something broke"),
+			wantCode: output.ErrCodeInternal,
+			wantTip:  "",
+		},
+		{
+			name:     "cobra-style 'unknown command' → validation, no tip",
+			err:      errors.New("unknown command \"foo\""),
+			wantCode: output.ErrCodeValidation,
+			wantTip:  "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			code, msg, tip := output.ClassifyError(tc.err)
+			assert.Equal(t, tc.wantCode, code, "code")
+			assert.NotEmpty(t, msg, "message must not be empty")
+			if tc.wantTip == "" {
+				assert.Empty(t, tip, "expected no tip")
+			} else {
+				assert.Contains(t, tip, tc.wantTip, "tip should contain %q", tc.wantTip)
+			}
+		})
+	}
+}
+
+// TestClassifyError_PermissionAuthSource pins the per-AuthSource branch in permissionTip.
+func TestClassifyError_PermissionAuthSource(t *testing.T) {
+	t.Parallel()
+
+	body := `{"errors":[{"message":"You do not have \"Run build\" permission in project My_Project"}]}`
+
+	cases := []struct {
+		src     api.AuthSource
+		wantTip string
+	}{
+		{api.AuthSourcePKCE, "permissions picker"},
+		{api.AuthSourceEnv, "TEAMCITY_TOKEN"},
+		{api.AuthSourceBuild, "Build-level credentials can't be widened"},
+		{api.AuthSourceGuest, "Guest access lacks"},
+		{api.AuthSourceManual, "Generate a new access token"},
+		{api.AuthSourceUnknown, "Generate a new access token"},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.src), func(t *testing.T) {
+			t.Parallel()
+			pe := permErr(t, body, tc.src)
+			_, _, tip := output.ClassifyError(pe)
+			assert.Contains(t, tip, tc.wantTip)
+			// Tip must include the enum (RUN_BUILD) so it matches the picker's "(ENUM)" suffix.
+			assert.Contains(t, tip, "RUN_BUILD")
+		})
+	}
+}
+
+// TestClassifyError_NotFoundCascade pins the order-dependent string-contains cascade in notFoundTip ("agent pool" must match before "agent").
+func TestClassifyError_NotFoundCascade(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		message string
+		wantTip string
+	}{
+		{"agent pool 'Default' not found", "teamcity pool list"},
+		{"No pool found by locator 'id:99'", "teamcity pool list"},
+		{"agent 'mac-01' not found", "teamcity agent list"},
+		{"project 'X' not found", "teamcity project list"},
+		{"build type 'Foo_Bar' not found", "teamcity job list"},
+		{"job 'Foo' not found", "teamcity job list"},
+		{"some other thing not found", "teamcity job list"}, // fallthrough
+	}
+	for _, tc := range cases {
+		t.Run(tc.message, func(t *testing.T) {
+			t.Parallel()
+			nf := notFoundErr(t, tc.message)
+			_, _, tip := output.ClassifyError(nf)
+			assert.Contains(t, tip, tc.wantTip)
+		})
+	}
+}
+
+// TestClassifyError_NotFoundResource pins the resource-driven tip shortcut (parsed Resource bypasses the message cascade).
+func TestClassifyError_NotFoundResource(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		resource string
+		want     string
+	}{
+		{"run", "teamcity run list"},
+		{"job", "teamcity job list"},
+		{"project", "teamcity project list"},
+		{"agent", "teamcity agent list"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.resource, func(t *testing.T) {
+			t.Parallel()
+			// Build via parser to populate Category, then override Resource/ID.
+			nf := notFoundErr(t, "placeholder not found")
+			nf.Resource = tc.resource
+			nf.ID = "x"
+			_, _, tip := output.ClassifyError(nf)
+			assert.Contains(t, tip, tc.want)
+		})
+	}
+}
+
+// TestClassifyError_InputErrors pins the prefix/substring list that classifies cobra error strings as validation.
+func TestClassifyError_InputErrors(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"unknown command \"foo\" for \"teamcity\"",
+		"unknown flag: --bogus",
+		"required flag(s) \"server\" not set",
+		"invalid argument \"x\" for --limit",
+		"invalid status: foo",
+		"accepts 1 arg(s), received 2",
+		"if any flags in the group [a b] are set none of the others can be",
+		"--limit must be > 0",
+		"unknown fields: extra_thing",
+		"foo: flag needs an argument",
+		"--a and --b are mutually exclusive",
+		"required (or use --no-input)",
+		"key 'foo' not found in configuration",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+			code, _, _ := output.ClassifyError(errors.New(in))
+			assert.Equal(t, output.ErrCodeValidation, code, "should classify as validation")
+		})
+	}
+
+	t.Run("not_input/internal", func(t *testing.T) {
+		t.Parallel()
+		code, _, _ := output.ClassifyError(errors.New("kaboom"))
+		assert.Equal(t, output.ErrCodeInternal, code)
+	})
+}
+
+// TestRenderError pins that RenderError appends a FormatTip line when a tip exists, else returns the original error.
+func TestRenderError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no tip → unchanged", func(t *testing.T) {
+		t.Parallel()
+		original := errors.New("kaboom")
+		rendered := output.RenderError(original)
+		assert.Equal(t, "kaboom", rendered.Error())
+	})
+
+	t.Run("with tip → appended", func(t *testing.T) {
+		t.Parallel()
+		rendered := output.RenderError(api.ErrReadOnly)
+		got := rendered.Error()
+		assert.Contains(t, got, "read-only mode")
+		assert.Contains(t, got, "Tip:")
+		assert.Contains(t, got, "TEAMCITY_RO")
+	})
+
+	t.Run("validation tip preserved", func(t *testing.T) {
+		t.Parallel()
+		rendered := output.RenderError(api.Validation("bad", "Use --baz"))
+		got := rendered.Error()
+		assert.Contains(t, got, "bad")
+		assert.Contains(t, got, "Use --baz")
+	})
+}

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -1,9 +1,13 @@
 package update
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsNewer(t *testing.T) {
@@ -29,4 +33,176 @@ func TestIsNewer(t *testing.T) {
 			assert.Equal(t, tt.want, IsNewer(tt.current, tt.latest))
 		})
 	}
+}
+
+func TestParseSemver(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in                  string
+		major, minor, patch int
+	}{
+		{"1.2.3", 1, 2, 3},
+		{"v1.2.3", 1, 2, 3},
+		{"v0.10.0", 0, 10, 0},
+		{"1.0.0-beta.1", 1, 0, 0}, // pre-release stripped
+		{"v2", 2, 0, 0},           // missing parts → zero
+		{"", 0, 0, 0},
+		{"dev", 0, 0, 0}, // non-numeric → zero
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			major, minor, pat := parseSemver(tc.in)
+			assert.Equal(t, tc.major, major, "major")
+			assert.Equal(t, tc.minor, minor, "minor")
+			assert.Equal(t, tc.patch, pat, "patch")
+		})
+	}
+}
+
+func TestLatestReleaseFromAPI(t *testing.T) {
+	const defaultURL = "https://api.github.com/repos/JetBrains/teamcity-cli/releases/latest"
+
+	t.Run("happy path", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "application/vnd.github+json", r.Header.Get("Accept"))
+			assert.Equal(t, "teamcity-cli", r.Header.Get("User-Agent"))
+			_, _ = w.Write([]byte(`{"tag_name":"v1.2.3","html_url":"https://github.com/x/y/releases/tag/v1.2.3"}`))
+		}))
+		defer srv.Close()
+
+		t.Cleanup(func() { latestReleaseAPIURL = defaultURL })
+		latestReleaseAPIURL = srv.URL
+
+		got, err := latestReleaseFromAPI(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "1.2.3", got.Version) // "v" prefix stripped
+		assert.Equal(t, "https://github.com/x/y/releases/tag/v1.2.3", got.URL)
+	})
+
+	t.Run("non-200 → error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden) // simulate rate limit
+		}))
+		defer srv.Close()
+		t.Cleanup(func() { latestReleaseAPIURL = defaultURL })
+		latestReleaseAPIURL = srv.URL
+
+		_, err := latestReleaseFromAPI(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "403")
+	})
+
+	t.Run("malformed JSON → error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{not json`))
+		}))
+		defer srv.Close()
+		t.Cleanup(func() { latestReleaseAPIURL = defaultURL })
+		latestReleaseAPIURL = srv.URL
+
+		_, err := latestReleaseFromAPI(context.Background())
+		assert.Error(t, err)
+	})
+}
+
+func TestLatestReleaseFromRedirect(t *testing.T) {
+	const defaultURL = "https://github.com/JetBrains/teamcity-cli/releases/latest"
+
+	t.Run("302 → version from Location", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodHead, r.Method)
+			w.Header().Set("Location", "https://github.com/JetBrains/teamcity-cli/releases/tag/v1.5.0")
+			w.WriteHeader(http.StatusFound)
+		}))
+		defer srv.Close()
+		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
+		latestReleaseRedirectURL = srv.URL
+
+		got, err := latestReleaseFromRedirect(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "1.5.0", got.Version)
+		assert.Equal(t, "https://github.com/JetBrains/teamcity-cli/releases/tag/v1.5.0", got.URL)
+	})
+
+	t.Run("301 also accepted", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Location", "https://example.com/releases/tag/v2.0.0")
+			w.WriteHeader(http.StatusMovedPermanently)
+		}))
+		defer srv.Close()
+		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
+		latestReleaseRedirectURL = srv.URL
+
+		got, err := latestReleaseFromRedirect(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, "2.0.0", got.Version)
+	})
+
+	t.Run("200 (no redirect) → error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
+		latestReleaseRedirectURL = srv.URL
+
+		_, err := latestReleaseFromRedirect(context.Background())
+		assert.Error(t, err)
+	})
+
+	t.Run("missing Location header → error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusFound)
+		}))
+		defer srv.Close()
+		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
+		latestReleaseRedirectURL = srv.URL
+
+		_, err := latestReleaseFromRedirect(context.Background())
+		assert.Error(t, err)
+	})
+}
+
+func TestLatestRelease_FallbackOnAPIFailure(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden) // simulate rate limit
+	}))
+	defer apiSrv.Close()
+	redirectSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", "https://github.com/x/y/releases/tag/v9.9.9")
+		w.WriteHeader(http.StatusFound)
+	}))
+	defer redirectSrv.Close()
+
+	origAPI, origRedirect := latestReleaseAPIURL, latestReleaseRedirectURL
+	t.Cleanup(func() { latestReleaseAPIURL, latestReleaseRedirectURL = origAPI, origRedirect })
+	latestReleaseAPIURL = apiSrv.URL
+	latestReleaseRedirectURL = redirectSrv.URL
+
+	got, err := LatestRelease(context.Background())
+	require.NoError(t, err, "fallback should rescue from API failure")
+	assert.Equal(t, "9.9.9", got.Version)
+}
+
+func TestLatestRelease_BothPathsFail(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer apiSrv.Close()
+	redirectSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer redirectSrv.Close()
+
+	origAPI, origRedirect := latestReleaseAPIURL, latestReleaseRedirectURL
+	t.Cleanup(func() { latestReleaseAPIURL, latestReleaseRedirectURL = origAPI, origRedirect })
+	latestReleaseAPIURL = apiSrv.URL
+	latestReleaseRedirectURL = redirectSrv.URL
+
+	_, err := LatestRelease(context.Background())
+	require.Error(t, err)
+	// Error must mention both failures, not just one.
+	assert.Contains(t, err.Error(), "fallback failed")
 }

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,176 @@
+package update
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setHomeForTest points os.UserHomeDir at dir on every platform: HOME for unix, USERPROFILE for Windows.
+func setHomeForTest(t *testing.T, dir string) {
+	t.Helper()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+}
+
+func TestIsCI(t *testing.T) {
+	// IsCI reads process env, so subtests can't t.Parallel.
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"all unset", map[string]string{"CI": "", "BUILD_NUMBER": "", "TEAMCITY_VERSION": ""}, false},
+		{"CI=true", map[string]string{"CI": "true", "BUILD_NUMBER": "", "TEAMCITY_VERSION": ""}, true},
+		{"BUILD_NUMBER set", map[string]string{"CI": "", "BUILD_NUMBER": "42", "TEAMCITY_VERSION": ""}, true},
+		{"TEAMCITY_VERSION set", map[string]string{"CI": "", "BUILD_NUMBER": "", "TEAMCITY_VERSION": "2025.7"}, true},
+		{"any non-empty wins", map[string]string{"CI": "false", "BUILD_NUMBER": "", "TEAMCITY_VERSION": ""}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			assert.Equal(t, tc.want, IsCI())
+		})
+	}
+}
+
+func TestStateIsStale(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cases := []struct {
+		name     string
+		last     time.Time
+		interval time.Duration
+		want     bool
+	}{
+		{"never checked → stale", time.Time{}, 24 * time.Hour, true},
+		{"just checked → fresh", now, 24 * time.Hour, false},
+		{"23h ago, 24h interval → fresh", now.Add(-23 * time.Hour), 24 * time.Hour, false},
+		{"25h ago, 24h interval → stale", now.Add(-25 * time.Hour), 24 * time.Hour, true},
+		{"future timestamp → fresh (clock skew safe)", now.Add(time.Hour), 24 * time.Hour, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			s := &State{LastCheckedAt: tc.last}
+			assert.Equal(t, tc.want, s.IsStale(tc.interval))
+		})
+	}
+}
+
+func TestLoadSaveState_RoundTrip(t *testing.T) {
+	// HOME→tempdir so stateFilePath writes under t.TempDir(), not real ~/.config/tc/.
+	home := t.TempDir()
+	setHomeForTest(t, home)
+
+	original := &State{
+		LastCheckedAt: time.Now().UTC().Truncate(time.Second), // truncate for JSON round-trip stability
+		LatestVersion: "1.2.3",
+		LatestURL:     "https://example.com/release",
+	}
+
+	SaveState(original)
+
+	// File must be under HOME and be 0600 readable. POSIX perm bits aren't
+	// meaningful on Windows, so we only assert the perm on unix-like systems.
+	want := filepath.Join(home, ".config", "tc", "update-check.json")
+	info, err := os.Stat(want)
+	require.NoError(t, err, "state file must exist at %s", want)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0600), info.Mode().Perm(), "file must be user-only")
+	}
+
+	// Reading back must restore every field.
+	got := LoadState()
+	assert.Equal(t, original.LastCheckedAt.Unix(), got.LastCheckedAt.Unix())
+	assert.Equal(t, original.LatestVersion, got.LatestVersion)
+	assert.Equal(t, original.LatestURL, got.LatestURL)
+}
+
+func TestLoadState_MissingFile(t *testing.T) {
+	setHomeForTest(t, t.TempDir())
+	got := LoadState()
+	require.NotNil(t, got)
+	assert.True(t, got.LastCheckedAt.IsZero(), "missing file → zero state")
+	assert.Empty(t, got.LatestVersion)
+}
+
+func TestLoadState_CorruptFile(t *testing.T) {
+	home := t.TempDir()
+	setHomeForTest(t, home)
+	dir := filepath.Join(home, ".config", "tc")
+	require.NoError(t, os.MkdirAll(dir, 0700))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "update-check.json"), []byte("{not json"), 0600))
+
+	got := LoadState()
+	require.NotNil(t, got, "corrupt JSON must not panic")
+	assert.True(t, got.LastCheckedAt.IsZero(), "corrupt file → zero state")
+}
+
+func TestSaveState_FileFormat(t *testing.T) {
+	home := t.TempDir()
+	setHomeForTest(t, home)
+
+	SaveState(&State{
+		LastCheckedAt: time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC),
+		LatestVersion: "v1.0.0",
+		LatestURL:     "https://github.com/JetBrains/teamcity-cli/releases/tag/v1.0.0",
+	})
+
+	data, err := os.ReadFile(filepath.Join(home, ".config", "tc", "update-check.json"))
+	require.NoError(t, err)
+
+	// Format pin: documented field names for old/new client compat.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Contains(t, parsed, "last_checked_at")
+	assert.Contains(t, parsed, "latest_version")
+	assert.Contains(t, parsed, "latest_url")
+}
+
+func TestPrintNotice(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	PrintNotice(&buf, "0.10.0", &ReleaseInfo{Version: "1.0.0", URL: "https://github.com/x/y/releases/v1.0.0"})
+
+	got := buf.String()
+	assert.Contains(t, got, "A new version is available")
+	assert.Contains(t, got, "v0.10.0")
+	assert.Contains(t, got, "v1.0.0")
+	assert.Contains(t, got, "teamcity update")
+}
+
+func TestCheck_CachedAndNotNewer(t *testing.T) {
+	// version.Version defaults to "dev" → parses as 0.0.0, so cached "0.0.0" is NOT newer → no notice.
+	setHomeForTest(t, t.TempDir())
+
+	SaveState(&State{
+		LastCheckedAt: time.Now(),
+		LatestVersion: "0.0.0",
+		LatestURL:     "https://example.com",
+	})
+
+	got := Check(t.Context())
+	assert.Nil(t, got, "cached version not newer → no notice")
+}
+
+func TestIsDisabled_EnvOverride(t *testing.T) {
+	// Only the truthy-env path is testable here; under `go test` stderr is never a TTY.
+	for _, v := range []string{"1", "true", "yes"} {
+		t.Run("TEAMCITY_NO_UPDATE="+v, func(t *testing.T) {
+			t.Setenv(EnvNoUpdateCheck, v)
+			assert.True(t, IsDisabled())
+		})
+	}
+}

--- a/teamcity.toml
+++ b/teamcity.toml
@@ -1,9 +1,9 @@
 [[server]]
-  url = "https://cli.teamcity.com"
-  project = "CLI"
-  job = "CLI_CiCd"
+url = 'https://cli.teamcity.com'
+project = 'CLI'
+job = 'CLI_CiCd'
 
 [[server]]
-  url = "https://teamcity-nightly.labs.intellij.net"
-  project = "TeamCity_TeamCityCLI"
-  jobs = ["TeamCity_TeamCityCLI_Release", "TeamCity_TeamCityCLI_SkillEval"]
+url = 'https://teamcity-nightly.labs.intellij.net'
+project = 'TeamCity_TeamCityCLI'
+jobs = ['TeamCity_TeamCityCLI_Release', 'TeamCity_TeamCityCLI_SkillEval']


### PR DESCRIPTION
## Summary

- Bumps merged coverage from ~65% → 76% (5 layers: unit, gallery, acceptance, guest, integration with Docker).
- Adds runtime API-drift detector + auto-discovering pty tests.
- Bulk linter cleanups across api/cmd/cmdutil packages (mostly mechanical).

## Changes

**Test additions**
- `test(api): add runtime drift detector for read endpoints` — `TestAPIDriftEndpoints` calls every read-only Client method against the live integration server. `TestAPIDriftAgentEndpoints` isolates agent-scoped endpoints. Build-tag widened to also fire under `terminal_pty`.
- `test(api): auto-discover agents in pty tests, drop TC_PTY_* env vars` — `pickAgentByOS` reads `teamcity.agent.os.family`. Windows skips cleanly when no Windows agent is connected.
- `test: pin error pipeline, pkce crypto, and pure-logic helpers` — 6 new test files + 2 extended ones covering `output/render_error`, `api/errors`, `pipeline/validate`, `auth/pkce` (RFC 7636 §B vector), `update` (state + HTTP fallback), `cmd/project` (URL classifiers), `cmdutil` (resolvers + probes).

**Cleanups**
- `chore: silence GoLand inspections, drop unused helpers` — `//goland:noinspection` directives across api/cmd packages, drop unused `JSONStatus`, normalize a regex.
- `refactor(config,project): rename net/url shadows, nil-init manifest events`
- `chore(link): reformat teamcity.toml` — TOML serializer style.
- `chore(api): drop section-header comments in ClientInterface`

## Design Decisions

**Drift sweep is shallow on purpose.** `TestAPIDrift` (existing) does deep field-level comparison against swagger; the new `TestAPIDriftEndpoints` only asserts `err == nil && result != nil`. Two layers, two responsibilities.

**PTY agent discovery has no env-var override.** All `TC_PTY_*` vars are gone — single source of truth via `TEAMCITY_URL/TOKEN` (set explicitly, via `.env`, or by testcontainers).

**Test comments held to one line.** Verbose preamble blocks and tautological annotations were deliberately stripped.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Acceptance tests pass (`just acceptance`)
- [x] Integration tests pass against testcontainers (Docker)
- [x] Guest-auth tests pass against cli.teamcity.com
- [x] Gallery test regenerates `docs/index.html` cleanly
- [x] PTY tests skip Windows cleanly when no Windows agent is connected
- [x] No new commands or flags — no `.txtar` updates needed
- [x] No `--json` output changes
- [x] No docs-visible behavior changes (besides a refreshed `teamcity.toml` format)