### PR TITLE
Ignore muted test failures when fetching failed tests

### DIFF
--- a/acceptance/testdata/run/run-tests.txtar
+++ b/acceptance/testdata/run/run-tests.txtar
@@ -14,6 +14,9 @@ stdout '"count"'
 exec teamcity run tests $BUILD_ID --failed --no-input
 ! stderr 'Error'
 
+exec teamcity run tests $BUILD_ID --muted --no-input
+! stderr 'Error'
+
 exec teamcity run tests $BUILD_ID --limit 5 --no-input
 ! stderr 'Error'
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -709,7 +709,7 @@ func TestGetBuildTests(T *testing.T) {
 		T.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			tests, err := client.GetBuildTests(t.Context(), buildID, tc.failedOnly, tc.limit)
+			tests, err := client.GetBuildTests(t.Context(), buildID, api.BuildTestsOptions{FailedOnly: tc.failedOnly, Limit: tc.limit})
 			if err != nil {
 				t.Logf("GetBuildTests: %v", err)
 				return

--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -199,34 +199,55 @@ func (c *Client) UploadDiffChanges(patch []byte, description string) (string, er
 	return strings.TrimSpace(string(resp.Body)), nil
 }
 
+// BuildTestsOptions controls test occurrence filtering for a build.
+type BuildTestsOptions struct {
+	FailedOnly bool
+	MutedOnly  bool
+	Limit      int
+}
+
 func (c *Client) GetBuildTests(ctx context.Context, buildID string, failedOnly bool, limit int) (*TestOccurrences, error) {
+	return c.GetBuildTestsWithOptions(ctx, buildID, BuildTestsOptions{FailedOnly: failedOnly, Limit: limit})
+}
+
+func (c *Client) GetBuildTestsWithOptions(ctx context.Context, buildID string, opts BuildTestsOptions) (*TestOccurrences, error) {
+	if opts.FailedOnly && opts.MutedOnly {
+		return nil, Validation("failedOnly and mutedOnly are mutually exclusive", "set only one test result filter")
+	}
+
 	id, err := c.ResolveBuildID(ctx, buildID)
 	if err != nil {
 		return nil, err
 	}
 
-	baseLocator := fmt.Sprintf("build:(id:%s)", id)
-	if failedOnly {
-		baseLocator += ",status:FAILURE"
+	baseLocator := NewLocator().AddLocator("build", NewLocator().Add("id", id))
+	if opts.FailedOnly || opts.MutedOnly {
+		baseLocator.AddUpper("status", "FAILURE")
+		if opts.FailedOnly {
+			baseLocator.Add("muted", "false")
+		} else {
+			baseLocator.Add("muted", "true")
+		}
 	}
 
-	summaryFields := "count,passed,failed,ignored"
-	summaryPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", url.QueryEscape(baseLocator), url.QueryEscape(summaryFields))
+	summaryFields := "count,passed,failed,ignored,muted"
+	summaryPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", baseLocator.Encode(), url.QueryEscape(summaryFields))
 
 	var summary TestOccurrences
 	if err := c.get(ctx, summaryPath, &summary); err != nil {
 		return nil, err
 	}
 
-	detailLocator := baseLocator
-	if limit > 0 {
-		detailLocator += fmt.Sprintf(",count:%d", limit)
+	detailLocator := NewLocator()
+	detailLocator.parts = append(detailLocator.parts, baseLocator.parts...)
+	if opts.Limit > 0 {
+		detailLocator.AddInt("count", opts.Limit)
 	} else {
-		detailLocator += fmt.Sprintf(",count:%d", summary.Count)
+		detailLocator.parts = append(detailLocator.parts, fmt.Sprintf("count:%d", summary.Count))
 	}
 
-	detailFields := "testOccurrence(id,name,status,duration,details,newFailure,firstFailed(build(id,number)))"
-	detailPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", url.QueryEscape(detailLocator), url.QueryEscape(detailFields))
+	detailFields := "testOccurrence(id,name,status,duration,details,newFailure,muted,firstFailed(build(id,number)))"
+	detailPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", detailLocator.Encode(), url.QueryEscape(detailFields))
 
 	var details TestOccurrences
 	if err := c.get(ctx, detailPath, &details); err != nil {
@@ -244,7 +265,7 @@ func (c *Client) GetBuildTestSummary(buildID string) (*TestOccurrences, error) {
 	}
 
 	locator := fmt.Sprintf("build:(id:%s)", id)
-	fields := "count,passed,failed,ignored"
+	fields := "count,passed,failed,ignored,muted"
 	path := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(fields))
 
 	var summary TestOccurrences

--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -206,11 +206,7 @@ type BuildTestsOptions struct {
 	Limit      int
 }
 
-func (c *Client) GetBuildTests(ctx context.Context, buildID string, failedOnly bool, limit int) (*TestOccurrences, error) {
-	return c.GetBuildTestsWithOptions(ctx, buildID, BuildTestsOptions{FailedOnly: failedOnly, Limit: limit})
-}
-
-func (c *Client) GetBuildTestsWithOptions(ctx context.Context, buildID string, opts BuildTestsOptions) (*TestOccurrences, error) {
+func (c *Client) GetBuildTests(ctx context.Context, buildID string, opts BuildTestsOptions) (*TestOccurrences, error) {
 	if opts.FailedOnly && opts.MutedOnly {
 		return nil, Validation("failedOnly and mutedOnly are mutually exclusive", "set only one test result filter")
 	}
@@ -220,34 +216,30 @@ func (c *Client) GetBuildTestsWithOptions(ctx context.Context, buildID string, o
 		return nil, err
 	}
 
-	baseLocator := NewLocator().AddLocator("build", NewLocator().Add("id", id))
-	if opts.FailedOnly || opts.MutedOnly {
-		baseLocator.AddUpper("status", "FAILURE")
-		if opts.FailedOnly {
-			baseLocator.Add("muted", "false")
-		} else {
-			baseLocator.Add("muted", "true")
-		}
+	locator := NewLocator().AddLocator("build", NewLocator().Add("id", id))
+	switch {
+	case opts.FailedOnly:
+		locator.AddUpper("status", "FAILURE").Add("muted", "false")
+	case opts.MutedOnly:
+		locator.AddUpper("status", "FAILURE").Add("muted", "true")
 	}
 
 	summaryFields := "count,passed,failed,ignored,muted"
-	summaryPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", baseLocator.Encode(), url.QueryEscape(summaryFields))
+	summaryPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(summaryFields))
 
 	var summary TestOccurrences
 	if err := c.get(ctx, summaryPath, &summary); err != nil {
 		return nil, err
 	}
 
-	detailLocator := NewLocator()
-	detailLocator.parts = append(detailLocator.parts, baseLocator.parts...)
-	if opts.Limit > 0 {
-		detailLocator.AddInt("count", opts.Limit)
-	} else {
-		detailLocator.parts = append(detailLocator.parts, fmt.Sprintf("count:%d", summary.Count))
+	count := opts.Limit
+	if count <= 0 {
+		count = summary.Count
 	}
+	locator.AddInt("count", count)
 
 	detailFields := "testOccurrence(id,name,status,duration,details,newFailure,muted,firstFailed(build(id,number)))"
-	detailPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", detailLocator.Encode(), url.QueryEscape(detailFields))
+	detailPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(detailFields))
 
 	var details TestOccurrences
 	if err := c.get(ctx, detailPath, &details); err != nil {

--- a/api/builds_metadata_test.go
+++ b/api/builds_metadata_test.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,30 +118,109 @@ func TestGetBuildChanges(t *testing.T) {
 
 func TestGetBuildTests(t *testing.T) {
 	t.Parallel()
-	callCount := 0
-	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/app/rest/builds" || r.URL.Path == "/httpAuth/app/rest/builds" {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
-			return
-		}
-		w.Header().Set("Content-Type", "application/json")
-		callCount++
-		if callCount <= 1 {
-			// Summary call
-			json.NewEncoder(w).Encode(TestOccurrences{Count: 2, Passed: 1, Failed: 1})
-		} else {
-			// Detail call
-			json.NewEncoder(w).Encode(TestOccurrences{
-				TestOccurrence: []TestOccurrence{{ID: "1", Name: "TestFoo", Status: "FAILURE"}},
+
+	cases := []struct {
+		name         string
+		call         func(context.Context, *Client) (*TestOccurrences, error)
+		wantLocators []string
+	}{
+		{
+			name: "all",
+			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
+				return c.GetBuildTests(ctx, "1", false, 10)
+			},
+			wantLocators: []string{
+				"build:(id:1)",
+				"build:(id:1),count:10",
+			},
+		},
+		{
+			name: "failed_only_excludes_muted",
+			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
+				return c.GetBuildTests(ctx, "1", true, 10)
+			},
+			wantLocators: []string{
+				"build:(id:1),status:FAILURE,muted:false",
+				"build:(id:1),status:FAILURE,muted:false,count:10",
+			},
+		},
+		{
+			name: "muted_only",
+			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
+				return c.GetBuildTestsWithOptions(ctx, "1", BuildTestsOptions{MutedOnly: true, Limit: 5})
+			},
+			wantLocators: []string{
+				"build:(id:1),status:FAILURE,muted:true",
+				"build:(id:1),status:FAILURE,muted:true,count:5",
+			},
+		},
+		{
+			name: "no_limit_uses_summary_count",
+			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
+				return c.GetBuildTests(ctx, "1", false, 0)
+			},
+			wantLocators: []string{
+				"build:(id:1)",
+				"build:(id:1),count:2",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var locators []string
+			var fields []string
+
+			client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.URL.Path != "/app/rest/testOccurrences" {
+					http.NotFound(w, r)
+					return
+				}
+
+				field := r.URL.Query().Get("fields")
+				mu.Lock()
+				locators = append(locators, r.URL.Query().Get("locator"))
+				fields = append(fields, field)
+				mu.Unlock()
+
+				if strings.Contains(field, "testOccurrence(") {
+					json.NewEncoder(w).Encode(TestOccurrences{
+						TestOccurrence: []TestOccurrence{{ID: "1", Name: "TestFoo", Status: "FAILURE", Muted: true}},
+					})
+					return
+				}
+				json.NewEncoder(w).Encode(TestOccurrences{Count: 2, Passed: 1, Failed: 1, Muted: 1})
 			})
-		}
+
+			tests, err := tc.call(t.Context(), client)
+			require.NoError(t, err)
+			assert.Equal(t, 1, tests.Failed)
+			assert.Equal(t, 1, tests.Muted)
+			require.Len(t, tests.TestOccurrence, 1)
+			assert.True(t, tests.TestOccurrence[0].Muted)
+
+			mu.Lock()
+			defer mu.Unlock()
+			assert.Equal(t, tc.wantLocators, locators)
+			assert.Equal(t, []string{
+				"count,passed,failed,ignored,muted",
+				"testOccurrence(id,name,status,duration,details,newFailure,muted,firstFailed(build(id,number)))",
+			}, fields)
+		})
+	}
+}
+
+func TestGetBuildTestsWithOptionsRejectsConflictingFilters(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
 	})
 
-	tests, err := client.GetBuildTests(t.Context(), "1", true, 10)
-	require.NoError(t, err)
-	assert.Equal(t, 1, tests.Failed)
-	assert.Len(t, tests.TestOccurrence, 1)
+	_, err := client.GetBuildTestsWithOptions(t.Context(), "1", BuildTestsOptions{FailedOnly: true, MutedOnly: true})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "mutually exclusive")
 }
 
 func TestGetBuildProblems(t *testing.T) {

--- a/api/builds_metadata_test.go
+++ b/api/builds_metadata_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -121,14 +120,12 @@ func TestGetBuildTests(t *testing.T) {
 
 	cases := []struct {
 		name         string
-		call         func(context.Context, *Client) (*TestOccurrences, error)
+		opts         BuildTestsOptions
 		wantLocators []string
 	}{
 		{
 			name: "all",
-			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
-				return c.GetBuildTests(ctx, "1", false, 10)
-			},
+			opts: BuildTestsOptions{Limit: 10},
 			wantLocators: []string{
 				"build:(id:1)",
 				"build:(id:1),count:10",
@@ -136,9 +133,7 @@ func TestGetBuildTests(t *testing.T) {
 		},
 		{
 			name: "failed_only_excludes_muted",
-			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
-				return c.GetBuildTests(ctx, "1", true, 10)
-			},
+			opts: BuildTestsOptions{FailedOnly: true, Limit: 10},
 			wantLocators: []string{
 				"build:(id:1),status:FAILURE,muted:false",
 				"build:(id:1),status:FAILURE,muted:false,count:10",
@@ -146,9 +141,7 @@ func TestGetBuildTests(t *testing.T) {
 		},
 		{
 			name: "muted_only",
-			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
-				return c.GetBuildTestsWithOptions(ctx, "1", BuildTestsOptions{MutedOnly: true, Limit: 5})
-			},
+			opts: BuildTestsOptions{MutedOnly: true, Limit: 5},
 			wantLocators: []string{
 				"build:(id:1),status:FAILURE,muted:true",
 				"build:(id:1),status:FAILURE,muted:true,count:5",
@@ -156,9 +149,7 @@ func TestGetBuildTests(t *testing.T) {
 		},
 		{
 			name: "no_limit_uses_summary_count",
-			call: func(ctx context.Context, c *Client) (*TestOccurrences, error) {
-				return c.GetBuildTests(ctx, "1", false, 0)
-			},
+			opts: BuildTestsOptions{},
 			wantLocators: []string{
 				"build:(id:1)",
 				"build:(id:1),count:2",
@@ -194,7 +185,7 @@ func TestGetBuildTests(t *testing.T) {
 				json.NewEncoder(w).Encode(TestOccurrences{Count: 2, Passed: 1, Failed: 1, Muted: 1})
 			})
 
-			tests, err := tc.call(t.Context(), client)
+			tests, err := client.GetBuildTests(t.Context(), "1", tc.opts)
 			require.NoError(t, err)
 			assert.Equal(t, 1, tests.Failed)
 			assert.Equal(t, 1, tests.Muted)
@@ -212,13 +203,13 @@ func TestGetBuildTests(t *testing.T) {
 	}
 }
 
-func TestGetBuildTestsWithOptionsRejectsConflictingFilters(t *testing.T) {
+func TestGetBuildTestsRejectsConflictingFilters(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected request: %s %s", r.Method, r.URL.String())
 	})
 
-	_, err := client.GetBuildTestsWithOptions(t.Context(), "1", BuildTestsOptions{FailedOnly: true, MutedOnly: true})
+	_, err := client.GetBuildTests(t.Context(), "1", BuildTestsOptions{FailedOnly: true, MutedOnly: true})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "mutually exclusive")
 }

--- a/api/drift_test.go
+++ b/api/drift_test.go
@@ -345,7 +345,7 @@ func TestAPIDriftEndpoints(t *testing.T) {
 		{"GetBuild", func() (any, error) { return client.GetBuild(t.Context(), buildID) }},
 		{"GetBuildChanges", func() (any, error) { return client.GetBuildChanges(t.Context(), buildID) }},
 		{"GetBuildTags", func() (any, error) { return client.GetBuildTags(buildID) }},
-		{"GetBuildTests", func() (any, error) { return client.GetBuildTests(t.Context(), buildID, false, 0) }},
+		{"GetBuildTests", func() (any, error) { return client.GetBuildTests(t.Context(), buildID, api.BuildTestsOptions{}) }},
 		{"GetBuildTestSummary", func() (any, error) { return client.GetBuildTestSummary(buildID) }},
 		{"GetBuildProblems", func() (any, error) { return client.GetBuildProblems(buildID) }},
 		{"GetBuildMessages", func() (any, error) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -60,7 +60,7 @@ type ClientInterface interface {
 	DeleteBuildComment(buildID string) error
 	GetBuildSnapshotDependencies(buildID string) (*BuildList, error)
 	GetBuildChanges(ctx context.Context, buildID string) (*ChangeList, error)
-	GetBuildTests(ctx context.Context, buildID string, failedOnly bool, limit int) (*TestOccurrences, error)
+	GetBuildTests(ctx context.Context, buildID string, opts BuildTestsOptions) (*TestOccurrences, error)
 	GetBuildTestSummary(buildID string) (*TestOccurrences, error)
 	GetBuildProblems(buildID string) (*ProblemOccurrences, error)
 	GetBuildResultingProperties(buildID string) (*ParameterList, error)

--- a/api/types.go
+++ b/api/types.go
@@ -343,6 +343,7 @@ type TestOccurrence struct {
 	Details    string `json:"details,omitempty"`
 	NewFailure bool   `json:"newFailure,omitempty"`
 	Ignored    bool   `json:"ignored,omitempty"`
+	Muted      bool   `json:"muted,omitempty"`
 	Href       string `json:"href,omitempty"`
 
 	FirstFailed *TestOccurrence `json:"firstFailed,omitempty"`
@@ -354,6 +355,7 @@ type TestOccurrences struct {
 	Passed         int              `json:"passed,omitempty"`
 	Failed         int              `json:"failed,omitempty"`
 	Ignored        int              `json:"ignored,omitempty"`
+	Muted          int              `json:"muted,omitempty"`
 	TestOccurrence []TestOccurrence `json:"testOccurrence"`
 }
 

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -998,10 +998,16 @@ teamcity run tests 12345
 teamcity run tests --job MyProject_Build
 ```
 
-Show only failed tests:
+Show only failed tests, excluding muted failures:
 
 ```Shell
 teamcity run tests 12345 --failed
+```
+
+Show only muted failed tests:
+
+```Shell
+teamcity run tests 12345 --muted
 ```
 
 <img src="run-tests.gif" alt="Viewing test results" border-effect="rounded"/>

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -121,9 +122,14 @@ func runRunChanges(f *cmdutil.Factory, runID string, opts *runChangesOptions) er
 
 type runTestsOptions struct {
 	failed bool
+	muted  bool
 	json   bool
 	limit  int
 	job    string
+}
+
+type buildTestsOptionsClient interface {
+	GetBuildTestsWithOptions(context.Context, string, api.BuildTestsOptions) (*api.TestOccurrences, error)
 }
 
 func newRunTestsCmd(f *cmdutil.Factory) *cobra.Command {
@@ -143,6 +149,7 @@ You can specify a run ID directly, or use --job to get the latest run's tests.`,
 		},
 		Example: `  teamcity run tests 12345
   teamcity run tests 12345 --failed
+  teamcity run tests 12345 --muted
   teamcity run tests --job Falcon_Build`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var runID string
@@ -156,10 +163,12 @@ You can specify a run ID directly, or use --job to get the latest run's tests.`,
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.failed, "failed", false, "Show only failed tests")
+	cmd.Flags().BoolVar(&opts.failed, "failed", false, "Show only failed tests, excluding muted")
+	cmd.Flags().BoolVar(&opts.muted, "muted", false, "Show only muted failed tests")
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 0, "Maximum number of items")
 	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Use this job's latest")
+	cmd.MarkFlagsMutuallyExclusive("failed", "muted")
 
 	return cmd
 }
@@ -182,7 +191,7 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
 
-	tests, err := client.GetBuildTests(f.Context(), runID, opts.failed, opts.limit)
+	tests, err := getRunTests(f.Context(), client, runID, opts)
 	if err != nil {
 		return fmt.Errorf("failed to get tests: %w", err)
 	}
@@ -192,7 +201,9 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	}
 
 	if tests.Count == 0 {
-		if opts.failed {
+		if opts.muted {
+			p.Success("No muted failed tests in this run")
+		} else if opts.failed {
 			p.Success("No failed tests in this run")
 		} else {
 			p.Info("No tests in this run")
@@ -200,7 +211,7 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		return nil
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "%s %s\n\n", output.Faint("View in browser:"), build.WebURL+"?buildTab=tests")
+	_, _ = fmt.Fprintf(p.Out, "%s %s\n\n", output.Faint("View in browser:"), runTestsBrowserURL(build.WebURL, opts))
 
 	var parts []string
 	if tests.Passed > 0 {
@@ -208,6 +219,9 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	}
 	if tests.Failed > 0 {
 		parts = append(parts, output.Red(fmt.Sprintf("%d failed", tests.Failed)))
+	}
+	if tests.Muted > 0 {
+		parts = append(parts, output.Faint(fmt.Sprintf("%d muted", tests.Muted)))
 	}
 	if tests.Ignored > 0 {
 		parts = append(parts, output.Faint(fmt.Sprintf("%d ignored", tests.Ignored)))
@@ -217,7 +231,11 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	for _, t := range tests.TestOccurrence {
 		switch t.Status {
 		case "FAILURE":
-			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Red("✗"), t.Name)
+			if t.Muted {
+				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("⊘"), t.Name)
+			} else {
+				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Red("✗"), t.Name)
+			}
 		case "SUCCESS":
 			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Green("✓"), t.Name)
 		default:
@@ -226,4 +244,33 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	}
 
 	return nil
+}
+
+func getRunTests(ctx context.Context, client api.ClientInterface, runID string, opts *runTestsOptions) (*api.TestOccurrences, error) {
+	if !opts.muted {
+		return client.GetBuildTests(ctx, runID, opts.failed, opts.limit)
+	}
+	testClient, ok := client.(buildTestsOptionsClient)
+	if !ok {
+		return nil, api.Validation("muted test filter unsupported", "use the standard TeamCity API client")
+	}
+	return testClient.GetBuildTestsWithOptions(ctx, runID, api.BuildTestsOptions{
+		MutedOnly: true,
+		Limit:     opts.limit,
+	})
+}
+
+func runTestsBrowserURL(webURL string, opts *runTestsOptions) string {
+	separator := "?"
+	if strings.Contains(webURL, "?") {
+		separator = "&"
+	}
+	link := webURL + separator + "buildTab=tests"
+	if opts.failed {
+		return link + "&status=failed"
+	}
+	if opts.muted {
+		return link + "&status=muted"
+	}
+	return link
 }

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -1,7 +1,6 @@
 package run
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -128,10 +127,6 @@ type runTestsOptions struct {
 	job    string
 }
 
-type buildTestsOptionsClient interface {
-	GetBuildTestsWithOptions(context.Context, string, api.BuildTestsOptions) (*api.TestOccurrences, error)
-}
-
 func newRunTestsCmd(f *cmdutil.Factory) *cobra.Command {
 	opts := &runTestsOptions{}
 
@@ -191,7 +186,11 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
 
-	tests, err := getRunTests(f.Context(), client, runID, opts)
+	tests, err := client.GetBuildTests(f.Context(), runID, api.BuildTestsOptions{
+		FailedOnly: opts.failed,
+		MutedOnly:  opts.muted,
+		Limit:      opts.limit,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to get tests: %w", err)
 	}
@@ -201,11 +200,12 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	}
 
 	if tests.Count == 0 {
-		if opts.muted {
+		switch {
+		case opts.muted:
 			p.Success("No muted failed tests in this run")
-		} else if opts.failed {
+		case opts.failed:
 			p.Success("No failed tests in this run")
-		} else {
+		default:
 			p.Info("No tests in this run")
 		}
 		return nil
@@ -244,20 +244,6 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	}
 
 	return nil
-}
-
-func getRunTests(ctx context.Context, client api.ClientInterface, runID string, opts *runTestsOptions) (*api.TestOccurrences, error) {
-	if !opts.muted {
-		return client.GetBuildTests(ctx, runID, opts.failed, opts.limit)
-	}
-	testClient, ok := client.(buildTestsOptionsClient)
-	if !ok {
-		return nil, api.Validation("muted test filter unsupported", "use the standard TeamCity API client")
-	}
-	return testClient.GetBuildTestsWithOptions(ctx, runID, api.BuildTestsOptions{
-		MutedOnly: true,
-		Limit:     opts.limit,
-	})
 }
 
 func runTestsBrowserURL(webURL string, opts *runTestsOptions) string {

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -282,7 +282,6 @@ func TestRunTests(T *testing.T) {
 
 	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID)
 	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID, "--failed")
-	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID, "--muted")
 	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID, "--json")
 }
 

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -282,7 +282,99 @@ func TestRunTests(T *testing.T) {
 
 	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID)
 	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID, "--failed")
+	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID, "--muted")
 	cmdtest.RunCmdWithFactory(T, f, "run", "tests", testBuildID, "--json")
+}
+
+func TestRunTestsFailedAndMutedFilters(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	installRunTestsFilterHandler(ts)
+
+	failed := cmdtest.CaptureOutput(T, ts.Factory, "run", "tests", testBuildID, "--failed")
+	assert.Contains(T, failed, "PlainFailure")
+	assert.NotContains(T, failed, "MutedFailure")
+	assert.Contains(T, failed, "TESTS: 1 failed")
+	assert.Contains(T, failed, "buildTab=tests&status=failed")
+
+	muted := cmdtest.CaptureOutput(T, ts.Factory, "run", "tests", testBuildID, "--muted")
+	assert.Contains(T, muted, "MutedFailure")
+	assert.NotContains(T, muted, "PlainFailure")
+	assert.Contains(T, muted, "TESTS: 1 muted")
+	assert.Contains(T, muted, "buildTab=tests&status=muted")
+}
+
+func TestRunTestsAllLabelsMutedOccurrences(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	installRunTestsFilterHandler(ts)
+
+	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "tests", testBuildID)
+	assert.Contains(T, got, "PlainFailure")
+	assert.Contains(T, got, "MutedFailure")
+	assert.Contains(T, got, "TESTS: 1 passed, 1 failed, 1 muted, 1 ignored")
+}
+
+func TestRunTestsMutedJSON(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	installRunTestsFilterHandler(ts)
+
+	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "tests", testBuildID, "--muted", "--json")
+	var tests api.TestOccurrences
+	require.NoError(T, json.Unmarshal([]byte(got), &tests))
+	assert.Equal(T, 1, tests.Muted)
+	require.Len(T, tests.TestOccurrence, 1)
+	assert.True(T, tests.TestOccurrence[0].Muted)
+}
+
+func TestRunTestsFailedAndMutedAreMutuallyExclusive(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+
+	err := cmdtest.CaptureErr(T, ts.Factory, "run", "tests", testBuildID, "--failed", "--muted")
+	assert.Contains(T, err.Error(), "failed")
+	assert.Contains(T, err.Error(), "muted")
+}
+
+func installRunTestsFilterHandler(ts *cmdtest.TestServer) {
+	ts.Handle("GET /app/rest/testOccurrences", func(w http.ResponseWriter, r *http.Request) {
+		locator := r.URL.Query().Get("locator")
+		fields := r.URL.Query().Get("fields")
+		detail := strings.Contains(fields, "testOccurrence(")
+
+		switch {
+		case strings.Contains(locator, "muted:false"):
+			if detail {
+				cmdtest.JSON(w, api.TestOccurrences{
+					TestOccurrence: []api.TestOccurrence{
+						{ID: "failed", Name: "PlainFailure", Status: "FAILURE"},
+					},
+				})
+				return
+			}
+			cmdtest.JSON(w, api.TestOccurrences{Count: 1, Failed: 1})
+		case strings.Contains(locator, "muted:true"):
+			if detail {
+				cmdtest.JSON(w, api.TestOccurrences{
+					TestOccurrence: []api.TestOccurrence{
+						{ID: "muted", Name: "MutedFailure", Status: "FAILURE", Muted: true},
+					},
+				})
+				return
+			}
+			cmdtest.JSON(w, api.TestOccurrences{Count: 1, Muted: 1})
+		default:
+			if detail {
+				cmdtest.JSON(w, api.TestOccurrences{
+					TestOccurrence: []api.TestOccurrence{
+						{ID: "passed", Name: "PassingTest", Status: "SUCCESS"},
+						{ID: "failed", Name: "PlainFailure", Status: "FAILURE"},
+						{ID: "muted", Name: "MutedFailure", Status: "FAILURE", Muted: true},
+						{ID: "ignored", Name: "IgnoredTest", Status: "IGNORED"},
+					},
+				})
+				return
+			}
+			cmdtest.JSON(w, api.TestOccurrences{Count: 4, Passed: 1, Failed: 1, Muted: 1, Ignored: 1})
+		}
+	})
 }
 
 func TestRunListWithAtMe(T *testing.T) {

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -161,7 +161,7 @@ func fetchBuildData(ctx context.Context, client api.ClientInterface, id string, 
 		return buildData{}, fmt.Errorf("#%s: %w", id, err)
 	}
 	d := buildData{build: b}
-	if d.tests, err = client.GetBuildTests(ctx, id, true, 0); err != nil {
+	if d.tests, err = client.GetBuildTests(ctx, id, api.BuildTestsOptions{FailedOnly: true}); err != nil {
 		p.Warn("Could not fetch tests for #%s: %v", id, err)
 	}
 	if d.testSummary, err = client.GetBuildTestSummary(id); err != nil {

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -511,7 +511,7 @@ func runLogFailed(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 			summary.Problems = problems.ProblemOccurrence
 		}
 		if build.Status != "SUCCESS" {
-			if tests, err := client.GetBuildTests(f.Context(), runID, true, 0); err == nil {
+			if tests, err := client.GetBuildTests(f.Context(), runID, api.BuildTestsOptions{FailedOnly: true}); err == nil {
 				summary.Tests = tests
 			}
 		}

--- a/internal/cmdutil/failure.go
+++ b/internal/cmdutil/failure.go
@@ -24,7 +24,7 @@ func PrintFailureSummary(ctx context.Context, p *output.Printer, client api.Clie
 	var testsErr error
 	var tests *api.TestOccurrences
 
-	tests, testsErr = client.GetBuildTests(ctx, buildID, true, maxFailedTestsToShow)
+	tests, testsErr = client.GetBuildTests(ctx, buildID, api.BuildTestsOptions{FailedOnly: true, Limit: maxFailedTestsToShow})
 	if testsErr != nil {
 		p.Debug("Failed to fetch tests: %v", testsErr)
 	} else if tests.Failed > 0 {

--- a/internal/cmdutil/failure_summary_test.go
+++ b/internal/cmdutil/failure_summary_test.go
@@ -6,14 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // failureSummaryFixture sets up a mock server returning the given tests and problems,
@@ -94,37 +92,6 @@ func TestPrintFailureSummary(t *testing.T) {
 			"",
 		)
 		assert.Contains(t, out, "3 tests failed")
-	})
-
-	t.Run("failed test request excludes muted failures", func(t *testing.T) {
-		var mu sync.Mutex
-		var locators []string
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			switch {
-			case strings.HasPrefix(r.URL.Path, "/app/rest/testOccurrences"):
-				mu.Lock()
-				locators = append(locators, r.URL.Query().Get("locator"))
-				mu.Unlock()
-				json.NewEncoder(w).Encode(api.TestOccurrences{Count: 0, Failed: 0})
-			case strings.HasPrefix(r.URL.Path, "/app/rest/problemOccurrences"):
-				json.NewEncoder(w).Encode(api.ProblemOccurrences{})
-			default:
-				http.NotFound(w, r)
-			}
-		}))
-		t.Cleanup(ts.Close)
-
-		var buf bytes.Buffer
-		p := &output.Printer{Out: &buf, ErrOut: &buf}
-		client := api.NewClient(ts.URL, "test")
-		PrintFailureSummary(t.Context(), p, client, "123", "42", "https://tc/build/123", "")
-
-		mu.Lock()
-		defer mu.Unlock()
-		require.Len(t, locators, 2)
-		assert.Equal(t, "build:(id:123),status:FAILURE,muted:false", locators[0])
-		assert.Equal(t, "build:(id:123),status:FAILURE,muted:false,count:10", locators[1])
 	})
 
 	t.Run("muted failures do not create failed tests section", func(t *testing.T) {

--- a/internal/cmdutil/failure_summary_test.go
+++ b/internal/cmdutil/failure_summary_test.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // failureSummaryFixture sets up a mock server returning the given tests and problems,
@@ -92,6 +94,50 @@ func TestPrintFailureSummary(t *testing.T) {
 			"",
 		)
 		assert.Contains(t, out, "3 tests failed")
+	})
+
+	t.Run("failed test request excludes muted failures", func(t *testing.T) {
+		var mu sync.Mutex
+		var locators []string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch {
+			case strings.HasPrefix(r.URL.Path, "/app/rest/testOccurrences"):
+				mu.Lock()
+				locators = append(locators, r.URL.Query().Get("locator"))
+				mu.Unlock()
+				json.NewEncoder(w).Encode(api.TestOccurrences{Count: 0, Failed: 0})
+			case strings.HasPrefix(r.URL.Path, "/app/rest/problemOccurrences"):
+				json.NewEncoder(w).Encode(api.ProblemOccurrences{})
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(ts.Close)
+
+		var buf bytes.Buffer
+		p := &output.Printer{Out: &buf, ErrOut: &buf}
+		client := api.NewClient(ts.URL, "test")
+		PrintFailureSummary(t.Context(), p, client, "123", "42", "https://tc/build/123", "")
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, locators, 2)
+		assert.Equal(t, "build:(id:123),status:FAILURE,muted:false", locators[0])
+		assert.Equal(t, "build:(id:123),status:FAILURE,muted:false,count:10", locators[1])
+	})
+
+	t.Run("muted failures do not create failed tests section", func(t *testing.T) {
+		out := failureSummaryFixture(t,
+			api.TestOccurrences{
+				Count: 1, Failed: 0, Muted: 1,
+				TestOccurrence: []api.TestOccurrence{{Name: "MutedBroken", Status: "FAILURE", Muted: true}},
+			},
+			api.ProblemOccurrences{},
+			"",
+		)
+		assert.NotContains(t, out, "Failed tests")
+		assert.NotContains(t, out, "MutedBroken")
 	})
 
 	t.Run("overflow shows remaining count", func(t *testing.T) {

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -123,7 +123,8 @@ Shows all branches and all build states (including canceled, personal, composite
 
 ### Flags for `teamcity run tests`
 
-- `--failed` - Show only failed tests
+- `--failed` - Show only failed tests, excluding muted failures
+- `--muted` - Show only muted failed tests
 - `-j, --job <id>` - Get tests for latest run of this job
 - `--json` - Output as JSON
 - `-n, --limit <n>` - Maximum number of tests to show


### PR DESCRIPTION
This change addresses the #295 issue by:
1. Excluding muted test failures from `teamcity run tests --failed` by default.
2. Introducing `--muted` flag to fetch muted failures. For simplicity `--muted` and `--failed` are considered mutually exclusive.

### Example output

#### Before

The output contains 24 entries mixing failed and muted tests.

```
/teamcity run tests --failed 939138670

TESTS: 15 failed

✗ com.jetbrains.tbe.uitests.e2e.ai.AmazonBedrockTestConnectionTestsBatch1.test connection of working amazon bedrock config
✗ com.jetbrains.tbe.uitests.e2e.profiles.ProfilePageTests.Create profile with Dev Environment filter on plugin rules
✗ com.jetbrains.tbe.uitests.e2e.routing.RoutingTest.visit third-party-licenses page
✗ com.jetbrains.tbe.uitests.e2e.ai.AmazonBedrockTestConnectionTestsBatch2.test connection of working amazon bedrock config
✗ com.jetbrains.tbe.uitests.e2e.ai.AzureOpenAITestConnectionTestsBatch2GPT5.test connection of working azure open ai config
✗ com.jetbrains.tbe.server.lv.test.LicenseVaultFlowTest.testPublicApiLicensesReport
✗ com.jetbrains.tbe.server.cwm.tests.CodeWithMeLicenseIntegrationTest.cwm should be enabled by main claims and trial in the past
✗ com.jetbrains.tbe.server.license.CloudLicenseActivationIntegrationTest.valid cloud license suspended via BAD response updates server state
✗ com.jetbrains.tbe.uitests.e2e.user.UserAuditLogsPageTest.filter by event type works as expected
✗ com.jetbrains.tbe.uitests.e2e.user.UserAuditLogsPageTest.creating user results in created event
✗ com.jetbrains.tbe.uitests.e2e.user.UserAuditLogsPageTest.editing user results in update event
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.impersonate by email should be case-insensitive
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest: impersonate returns impersonated user authentication(String, String): com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.impersonate returns impersonated user authentication([2] "X-IDES-USER-EMAIL", "test@example.com")
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.impersonate throws exception when user is not found by email
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.subject is preferred over email
✗ com.jetbrains.tbe.server.usergroups.UserGroupControllerTest.check audit logs
✗ com.jetbrains.tbe.server.security.UserAuditLogsControllerTest.creating user results in user audit log
✗ com.jetbrains.tbe.server.security.UserAuditLogsControllerTest.get user returns only user state updates
✗ com.jetbrains.tbe.server.security.UserAuditLogsControllerTest.list user audit logs supports type filter
✗ com.jetbrains.tbe.server.security.idp.BasicIdPUserImportServiceTest.user was removed from their only group and deactivated after updating from IdP
✗ com.jetbrains.tbe.server.bulk.BulkImportServiceTest.users that are in state and TBE should stay
✗ com.jetbrains.tbe.server.tools.UserTest.unassign profile EXPECT lastModifiedDate field is changed
✗ com.jetbrains.tbe.uitests.uber.AutoInstallIDEUberTest.auto-installed tools compatibility test
✗ com.jetbrains.tbe.uitests.uber.UberTestExample.check TBE-TBA-IDE configuration chain
```

#### After

`--failed` includes 15 failed tests entries:
```
bin/teamcity run tests --failed 939138670

TESTS: 15 failed

✗ com.jetbrains.tbe.uitests.e2e.user.UserAuditLogsPageTest.filter by event type works as expected
✗ com.jetbrains.tbe.uitests.e2e.user.UserAuditLogsPageTest.creating user results in created event
✗ com.jetbrains.tbe.uitests.e2e.user.UserAuditLogsPageTest.editing user results in update event
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.impersonate by email should be case-insensitive
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest: impersonate returns impersonated user authentication(String, String): com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.impersonate returns impersonated user authentication([2] "X-IDES-USER-EMAIL", "test@example.com")
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.impersonate throws exception when user is not found by email
✗ com.jetbrains.tbe.server.security.UserAuthImpersonatorTest.subject is preferred over email
✗ com.jetbrains.tbe.server.usergroups.UserGroupControllerTest.check audit logs
✗ com.jetbrains.tbe.server.security.UserAuditLogsControllerTest.creating user results in user audit log
✗ com.jetbrains.tbe.server.security.UserAuditLogsControllerTest.get user returns only user state updates
✗ com.jetbrains.tbe.server.security.UserAuditLogsControllerTest.list user audit logs supports type filter
✗ com.jetbrains.tbe.server.security.idp.BasicIdPUserImportServiceTest.user was removed from their only group and deactivated after updating from IdP
✗ com.jetbrains.tbe.server.bulk.BulkImportServiceTest.users that are in state and TBE should stay
✗ com.jetbrains.tbe.server.tools.UserTest.unassign profile EXPECT lastModifiedDate field is changed
✗ com.jetbrains.tbe.uitests.uber.AutoInstallIDEUberTest.auto-installed tools compatibility test
```

`--muted` includes 9 muted tests entries:
```
bin/teamcity run tests --muted 939138670

TESTS: 9 muted

⊘ com.jetbrains.tbe.uitests.e2e.ai.AmazonBedrockTestConnectionTestsBatch1.test connection of working amazon bedrock config
⊘ com.jetbrains.tbe.uitests.e2e.profiles.ProfilePageTests.Create profile with Dev Environment filter on plugin rules
⊘ com.jetbrains.tbe.uitests.e2e.routing.RoutingTest.visit third-party-licenses page
⊘ com.jetbrains.tbe.uitests.e2e.ai.AmazonBedrockTestConnectionTestsBatch2.test connection of working amazon bedrock config
⊘ com.jetbrains.tbe.uitests.e2e.ai.AzureOpenAITestConnectionTestsBatch2GPT5.test connection of working azure open ai config
⊘ com.jetbrains.tbe.server.lv.test.LicenseVaultFlowTest.testPublicApiLicensesReport
⊘ com.jetbrains.tbe.server.cwm.tests.CodeWithMeLicenseIntegrationTest.cwm should be enabled by main claims and trial in the past
⊘ com.jetbrains.tbe.server.license.CloudLicenseActivationIntegrationTest.valid cloud license suspended via BAD response updates server state
⊘ com.jetbrains.tbe.uitests.uber.UberTestExample.check TBE-TBA-IDE configuration chain
```

## Summary

<!-- What does this PR do? Link related issues with "Fixes #123" -->



## Changes

<!-- Key changes, organized by area. Delete empty sections. -->

-

## Design Decisions

<!-- Explain non-obvious choices. Delete section if straightforward. -->

## Example

<!-- For CLI changes: show command + output. Delete if not applicable. -->

```bash
teamcity <command>
```

## Test Plan

- [ ] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only)
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
