### PR TITLE
fix(project): require -p for write commands and unify interactive prompts

### DIFF
--- a/api/testenv_test.go
+++ b/api/testenv_test.go
@@ -17,8 +17,8 @@ import (
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
-	"github.com/moby/moby/api/types/container"
 	"github.com/joho/godotenv"
+	"github.com/moby/moby/api/types/container"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"
 	"github.com/testcontainers/testcontainers-go/wait"

--- a/internal/cmd/project/connection.go
+++ b/internal/cmd/project/connection.go
@@ -63,8 +63,7 @@ func newConnectionListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *connectionListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	projectID := cmp.Or(opts.project, "_Root")
-	features, err := client.GetProjectConnections(projectID)
+	features, err := client.GetProjectConnections(cmp.Or(opts.project, "_Root"))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/project/connection_authorize.go
+++ b/internal/cmd/project/connection_authorize.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"cmp"
 	"fmt"
 	"net/url"
 
@@ -52,7 +51,7 @@ Connection types that don't have a per-user OAuth flow (Docker, AWS) error out.`
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
@@ -64,7 +63,10 @@ func runConnectionAuthorize(f *cmdutil.Factory, opts *connectionAuthorizeOptions
 	if err != nil {
 		return err
 	}
-	projectID := cmp.Or(opts.project, "_Root")
+	projectID, err := resolveProject(f, opts.project)
+	if err != nil {
+		return err
+	}
 
 	providerType, err := lookupConnectionProviderType(client, projectID, id)
 	if err != nil {

--- a/internal/cmd/project/connection_create.go
+++ b/internal/cmd/project/connection_create.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"cmp"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -75,7 +76,7 @@ automatically. Use --no-manifest to enter existing credentials manually.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 	cmd.Flags().StringVar(&opts.name, "name", "", "Connection display name in TeamCity (default: \"GitHub App\")")
 	cmd.Flags().StringVar(&opts.appName, "app-name", "", "GitHub App name; must be globally unique on github.com (default: TC <project>@<host>)")
 	cmd.Flags().StringVar(&opts.owner, "owner", "", "GitHub organization (interactive: posts the manifest under this org)")
@@ -99,8 +100,11 @@ func runConnectionCreateGitHubApp(f *cmdutil.Factory, opts *githubAppOptions) er
 		return err
 	}
 
-	projectID := cmp.Or(opts.project, "_Root")
 	interactive := f.IsInteractive()
+	projectID, err := resolveProject(f, opts.project)
+	if err != nil {
+		return err
+	}
 	useManifest := interactive && !opts.noManifest && opts.appID == ""
 
 	name, err := resolveGitHubAppName(f, opts.name, interactive)
@@ -297,7 +301,7 @@ over a personal account.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 	cmd.Flags().StringVar(&opts.name, "name", "", "Display name")
 	cmd.Flags().StringVar(&opts.url, "url", "", "Registry URL (e.g. https://ghcr.io)")
 	cmd.Flags().StringVar(&opts.username, "username", "", "Registry username")
@@ -315,16 +319,19 @@ func runConnectionCreateDocker(f *cmdutil.Factory, opts *dockerOptions) error {
 		return err
 	}
 
-	projectID := cmp.Or(opts.project, "_Root")
 	interactive := f.IsInteractive()
 
-	if err := promptIfEmpty(f, &opts.name, "Connection name", "", interactive, "name"); err != nil {
-		return err
+	if interactive {
+		err := runInteractiveForm(f, &opts.project,
+			formField{title: "Connection name", value: &opts.name},
+			formField{title: "Registry URL", description: "e.g. https://ghcr.io", value: &opts.url, validate: validateRegistryURL},
+			formField{title: "Username", value: &opts.username},
+		)
+		if err != nil {
+			return err
+		}
 	}
-	if err := promptIfEmpty(f, &opts.url, "Registry URL", "e.g. https://ghcr.io", interactive, "url"); err != nil {
-		return err
-	}
-	if err := promptIfEmpty(f, &opts.username, "Username", "", interactive, "username"); err != nil {
+	if err := validateDockerOptions(opts); err != nil {
 		return err
 	}
 
@@ -346,24 +353,43 @@ func runConnectionCreateDocker(f *cmdutil.Factory, opts *dockerOptions) error {
 		},
 	}
 
-	created, err := client.CreateProjectFeature(projectID, feat)
+	created, err := client.CreateProjectFeature(opts.project, feat)
 	if err != nil {
 		return fmt.Errorf("failed to create connection: %w", err)
 	}
 
-	f.Printer.Success("Created connection %q (%s) in project %s", opts.name, created.ID, projectID)
+	f.Printer.Success("Created connection %q (%s) in project %s", opts.name, created.ID, opts.project)
 	f.Printer.Tip("%s", output.TipDockerServiceAccount)
 	return nil
 }
 
-func promptIfEmpty(f *cmdutil.Factory, value *string, title, description string, interactive bool, flagName string) error {
-	if *value != "" {
-		return nil
+func validateDockerOptions(opts *dockerOptions) error {
+	if opts.project == "" {
+		return api.RequiredFlag("project")
 	}
-	if !interactive {
-		return api.RequiredFlag(flagName)
+	if opts.name == "" {
+		return api.RequiredFlag("name")
 	}
-	return cmdutil.PromptString(f.Printer, title, description, value)
+	if opts.url == "" {
+		return api.RequiredFlag("url")
+	}
+	if err := validateRegistryURL(opts.url); err != nil {
+		return api.Validation(err.Error(), "e.g. --url https://ghcr.io")
+	}
+	if opts.username == "" {
+		return api.RequiredFlag("username")
+	}
+	return nil
+}
+
+func validateRegistryURL(s string) error {
+	if err := cmdutil.RequireNonEmpty(s); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(s, "https://") && !strings.HasPrefix(s, "http://") {
+		return errors.New("must start with https:// or http://")
+	}
+	return nil
 }
 
 func resolveSecret(f *cmdutil.Factory, value string, stdin, interactive bool, label, flagName string) (string, error) {

--- a/internal/cmd/project/connection_delete.go
+++ b/internal/cmd/project/connection_delete.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"cmp"
 	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -31,7 +30,7 @@ The id is the one shown in the first column of 'connection list'.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Skip confirmation")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
@@ -45,7 +44,10 @@ func runConnectionDelete(f *cmdutil.Factory, opts *connectionDeleteOptions, id s
 		return err
 	}
 
-	projectID := cmp.Or(opts.project, "_Root")
+	projectID, err := resolveProject(f, opts.project)
+	if err != nil {
+		return err
+	}
 
 	if !opts.force && f.IsInteractive() {
 		confirm := false

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/charmbracelet/huh"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -532,6 +533,115 @@ func resolveHiddenProjects(client api.ClientInterface, known map[string]*api.Pro
 
 func newProjectSettingsCmd(f *cmdutil.Factory) *cobra.Command {
 	return newSettingsCmd(f)
+}
+
+// projectPickerOptions fetches all visible projects and returns huh picker options, or nil on failure.
+func projectPickerOptions(f *cmdutil.Factory) []huh.Option[string] {
+	client, err := f.Client()
+	if err != nil {
+		return nil
+	}
+	list, err := client.GetProjects(api.ProjectsOptions{Limit: 10000})
+	if err != nil || len(list.Projects) == 0 {
+		return nil
+	}
+	options := make([]huh.Option[string], len(list.Projects))
+	for i, p := range list.Projects {
+		label := p.ID
+		if p.Name != "" && p.Name != p.ID {
+			label = p.ID + " — " + p.Name
+		}
+		options[i] = huh.Option[string]{Key: label, Value: p.ID}
+	}
+	return options
+}
+
+// formField describes one text input for runInteractiveForm. Validate defaults to cmdutil.RequireNonEmpty.
+type formField struct {
+	title       string
+	description string
+	value       *string
+	validate    func(string) error
+}
+
+// resolveProject returns project if non-empty; otherwise runs the project picker (interactive) or errors (non-interactive).
+func resolveProject(f *cmdutil.Factory, project string) (string, error) {
+	if project != "" {
+		return project, nil
+	}
+	if !f.IsInteractive() {
+		return "", api.RequiredFlag("project")
+	}
+	if err := runInteractiveForm(f, &project); err != nil {
+		return "", err
+	}
+	return project, nil
+}
+
+// runInteractiveForm prompts for project (picker, with text-input fallback) and the given fields in a single huh form
+// so Shift+Tab navigates between them. Fields whose value is already non-empty are skipped; the rest are validated
+// (cmdutil.RequireNonEmpty by default) so the form will not exit with empty values. Each prompted field is echoed
+// to scrollback after the form completes.
+func runInteractiveForm(f *cmdutil.Factory, project *string, fields ...formField) error {
+	var groups []*huh.Group
+
+	needsProject := *project == ""
+	var pickerOptions []huh.Option[string]
+	if needsProject {
+		pickerOptions = projectPickerOptions(f)
+		if pickerOptions != nil {
+			sel := huh.NewSelect[string]().Title("Project").Options(pickerOptions...).Value(project)
+			if len(pickerOptions) >= 5 {
+				sel.Filtering(true)
+			}
+			groups = append(groups, huh.NewGroup(sel))
+		} else {
+			groups = append(groups, huh.NewGroup(huh.NewInput().Title("Project ID").Prompt("").Validate(cmdutil.RequireNonEmpty).Value(project)))
+		}
+	}
+
+	var prompted []formField
+	var huhFields []huh.Field
+	for _, fld := range fields {
+		if *fld.value != "" {
+			continue
+		}
+		validate := fld.validate
+		if validate == nil {
+			validate = cmdutil.RequireNonEmpty
+		}
+		in := huh.NewInput().Prompt("").Title(fld.title).Validate(validate).Value(fld.value)
+		if fld.description != "" {
+			in.Description(fld.description)
+		}
+		huhFields = append(huhFields, in)
+		prompted = append(prompted, fld)
+	}
+	if len(huhFields) > 0 {
+		groups = append(groups, huh.NewGroup(huhFields...))
+	}
+
+	if len(groups) == 0 {
+		return nil
+	}
+	if err := cmdutil.RunForm(groups...); err != nil {
+		return err
+	}
+
+	if needsProject {
+		label := *project
+		for _, o := range pickerOptions {
+			if o.Value == *project {
+				label = o.Key
+				break
+			}
+		}
+		_, _ = fmt.Fprintf(f.Printer.Out, "Project: %s\n", output.Cyan(label))
+	}
+	for _, fld := range prompted {
+		_, _ = fmt.Fprintf(f.Printer.Out, "%s: %s\n", fld.title, output.Cyan(*fld.value))
+	}
+	return nil
 }
 
 // firstArgComplete applies fn only to args[0]; later positionals get no completions.

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -49,7 +49,7 @@ func newSSHListCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"ls"},
 		Example: `  teamcity project ssh list
   teamcity project ssh list --project MyProject
-  teamcity project ssh list --json
+  teamcity project ssh list --project MyProject --json
   teamcity project ssh list --plain`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.SSHKeyFields, opts.fetch)
@@ -65,8 +65,7 @@ func newSSHListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *sshListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	projectID := cmp.Or(opts.project, "_Root")
-	keys, err := client.GetSSHKeys(projectID)
+	keys, err := client.GetSSHKeys(cmp.Or(opts.project, "_Root"))
 	if err != nil {
 		return nil, err
 	}
@@ -112,7 +111,7 @@ func newSSHUploadCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upload <file>",
 		Short: "Upload an SSH private key",
-		Example: `  teamcity project ssh upload ~/.ssh/id_ed25519
+		Example: `  teamcity project ssh upload ~/.ssh/id_ed25519 --project MyProject
   teamcity project ssh upload key.pem --name my-deploy-key --project MyProject`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -120,7 +119,7 @@ func newSSHUploadCmd(f *cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 	cmd.Flags().StringVar(&opts.name, "name", "", "Key name (default: filename)")
 
 	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
@@ -139,7 +138,10 @@ func runSSHUpload(f *cmdutil.Factory, filePath string, opts *sshUploadOptions) e
 		return fmt.Errorf("failed to read key file: %w", err)
 	}
 
-	projectID := cmp.Or(opts.project, "_Root")
+	projectID, err := resolveProject(f, opts.project)
+	if err != nil {
+		return err
+	}
 	name := opts.name
 	if name == "" {
 		name = baseName(filePath)
@@ -174,14 +176,14 @@ func newSSHGenerateCmd(f *cmdutil.Factory) *cobra.Command {
 		Use:   "generate",
 		Short: "Generate an SSH key pair",
 		Long:  `Generate an SSH key pair in TeamCity and print the public key.`,
-		Example: `  teamcity project ssh generate --name deploy-key
+		Example: `  teamcity project ssh generate --name deploy-key --project MyProject
   teamcity project ssh generate --name deploy-key --type rsa --project MyProject`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSSHGenerate(f, opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 	cmd.Flags().StringVar(&opts.name, "name", "", "Key name (required)")
 	cmd.Flags().StringVar(&opts.keyType, "type", "ed25519", "Key type: ed25519 or rsa")
 
@@ -197,24 +199,24 @@ func runSSHGenerate(f *cmdutil.Factory, opts *sshGenerateOptions) error {
 		return err
 	}
 
-	projectID := cmp.Or(opts.project, "_Root")
-	name := opts.name
-
-	if name == "" {
-		if !f.IsInteractive() {
-			return api.RequiredFlag("name")
-		}
-		if err := cmdutil.PromptString(f.Printer, "Key name", "", &name); err != nil {
+	if f.IsInteractive() {
+		if err := runInteractiveForm(f, &opts.project, formField{title: "Key name", value: &opts.name}); err != nil {
 			return err
 		}
 	}
+	if opts.project == "" {
+		return api.RequiredFlag("project")
+	}
+	if opts.name == "" {
+		return api.RequiredFlag("name")
+	}
 
-	key, err := client.GenerateSSHKey(projectID, name, opts.keyType)
+	key, err := client.GenerateSSHKey(opts.project, opts.name, opts.keyType)
 	if err != nil {
 		return fmt.Errorf("failed to generate SSH key: %w", err)
 	}
 
-	f.Printer.Success("Generated SSH key %q in project %s", key.Name, projectID)
+	f.Printer.Success("Generated SSH key %q in project %s", key.Name, opts.project)
 	_, _ = fmt.Fprintln(f.Printer.Out)
 	_, _ = fmt.Fprintln(f.Printer.Out, key.PublicKey)
 	return nil
@@ -233,14 +235,14 @@ func newSSHDeleteCmd(f *cmdutil.Factory) *cobra.Command {
 		Short:   "Delete an SSH key",
 		Aliases: []string{"rm"},
 		Args:    cobra.ExactArgs(1),
-		Example: `  teamcity project ssh delete my-deploy-key
-  teamcity project ssh delete my-deploy-key --yes`,
+		Example: `  teamcity project ssh delete my-deploy-key --project MyProject
+  teamcity project ssh delete my-deploy-key --project MyProject --yes`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSSHDelete(f, args[0], opts)
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 	cmd.Flags().BoolVarP(&opts.yes, "yes", "y", false, "Skip confirmation prompt")
 	cmd.Flags().BoolVarP(&opts.yes, "force", "f", false, "")
 	cmdutil.DeprecateFlag(cmd, "force", "yes", "v1.0.0")
@@ -256,7 +258,10 @@ func runSSHDelete(f *cmdutil.Factory, name string, opts *sshDeleteOptions) error
 		return err
 	}
 
-	projectID := cmp.Or(opts.project, "_Root")
+	projectID, err := resolveProject(f, opts.project)
+	if err != nil {
+		return err
+	}
 
 	if !opts.yes && f.IsInteractive() {
 		var confirm bool

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -73,9 +73,8 @@ func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *vcsListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	project := cmp.Or(opts.project, "_Root")
 	roots, err := client.GetVcsRoots(api.VcsRootsOptions{
-		Project: project,
+		Project: cmp.Or(opts.project, "_Root"),
 		Limit:   opts.Limit,
 		Fields:  fields,
 	})
@@ -290,7 +289,7 @@ Tests the connection before creating unless --no-test is specified.`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID")
 	cmd.Flags().StringVar(&opts.repoURL, "url", "", "Repository URL")
 	cmd.Flags().StringVar(&opts.name, "name", "", "Display name (auto-generated from URL if omitted)")
 	cmd.Flags().StringVar(&opts.branch, "branch", "refs/heads/main", "Default branch")
@@ -317,18 +316,22 @@ func runVcsCreate(f *cmdutil.Factory, opts *vcsCreateOptions) error {
 		return err
 	}
 
-	projectID := cmp.Or(opts.project, "_Root")
 	interactive := f.IsInteractive()
 
-	repoURL := opts.repoURL
-	if repoURL == "" {
-		if !interactive {
-			return api.RequiredFlag("url")
-		}
-		if err := cmdutil.PromptString(f.Printer, "Repository URL", "", &repoURL); err != nil {
+	if interactive {
+		if err := runInteractiveForm(f, &opts.project, formField{title: "Repository URL", value: &opts.repoURL}); err != nil {
 			return err
 		}
 	}
+	if opts.project == "" {
+		return api.RequiredFlag("project")
+	}
+	if opts.repoURL == "" {
+		return api.RequiredFlag("url")
+	}
+
+	projectID := opts.project
+	repoURL := opts.repoURL
 
 	name := opts.name
 	if name == "" {

--- a/internal/cmd/project/vcs_test.go
+++ b/internal/cmd/project/vcs_test.go
@@ -101,6 +101,7 @@ func TestVcsCreateNoTest(T *testing.T) {
 	f := ts.Factory
 
 	out := cmdtest.CaptureOutput(T, f, "project", "vcs", "create",
+		"--project", "TestProject",
 		"--url", "https://github.com/org/repo.git",
 		"--auth", "anonymous",
 		"--no-test",
@@ -113,7 +114,7 @@ func TestVcsCreateMissingURL(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	f := ts.Factory
 
-	cmdtest.RunCmdWithFactoryExpectErr(T, f, "url", "project", "vcs", "create", "--auth", "anonymous")
+	cmdtest.RunCmdWithFactoryExpectErr(T, f, "url", "project", "vcs", "create", "--project", "TestProject", "--auth", "anonymous")
 }
 
 func TestVcsTest(T *testing.T) {


### PR DESCRIPTION
## Summary

Fixes what @sugdyzhekov reported: project-scoped **write** commands silently used `_Root` when `-p` was omitted, creating resources in the wrong project. Non-admins also hit a cryptic 403 since `_Root` requires server admin.

## Changes

- **Write commands** (`connection create/delete`, `ssh generate/upload/delete`, `vcs create`): `-p` is now required. Interactive mode shows a filterable project picker; non-interactive (`--no-input`, CI) returns a clear error.
- **Read commands** (`connection list`, `ssh list`, `vcs list`): `_Root` default is preserved — no script breakage.
- **Single-form interactive UX**: project picker + per-command fields run in one `huh.Form` with Shift+Tab back-navigation. Picker falls back to a text input within the same form when project listing fails (transient errors no longer abort the wizard).
- **Validators on every prompt**: `Connection name`, `Username`, `Key name`, `Repository URL` reject empty/whitespace at entry time; `Registry URL` enforces `http(s)://` scheme. No more wizard-then-fail.
- **Helpers consolidated**: `runInteractiveForm(f, &project, formField...)` is the single entry point for project + write-form prompts. `resolveProject` delegates to it. Per-command `prompt*Fields` wrappers are gone.

## Design Decisions

- **Reads vs writes treated differently** because risk profiles differ: a list defaulting to `_Root` is non-destructive and useful for browsing; a create/delete silently targeting `_Root` is an invisible footgun.
- **Final validation runs in both modes**: `validateDockerOptions` is invoked after the form too, so a pre-set bad value (e.g. `--url ghcr.io` without a scheme) doesn't slip past the wizard.
- **No client-side credential testing**: the obvious server endpoint (`/repo/registry-test-connection.html`) is a UI-form path that requires fetching the server's RSA public key and PKCS#1-encrypting `secure:` properties — that's the browser's job, not a CLI's. Kept out of scope; should be revisited when there's a proper REST endpoint that doesn't require the web-form handshake.

## Example

```bash
# Before: silently creates in _Root
teamcity project connection create docker --name GHCR --url https://ghcr.io --username org --stdin

# After (interactive): one form, Shift+Tab navigates back, every field validated at entry
teamcity project connection create docker
# → filterable project list → Connection name → Registry URL → Username → Password
# → ✓ Created connection "GHCR" (PROJECT_EXT_55) in project Backend

# After (non-interactive): clear error
teamcity project connection create docker --no-input
# Error: --project is required in non-interactive mode
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [x] If adding a new command/flag: existing acceptance/unit tests already pass `-p` explicitly; no new flags
- [ ] If adding a data-producing command: includes `--json` support — n/a
- [ ] If modifying `--json` output: no field removals/renames (additive only) — n/a
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — n/a
