### PR TITLE
fix(project): scope picker to writeable permission roots and drop archived

### DIFF
--- a/api/permissions.go
+++ b/api/permissions.go
@@ -37,3 +37,6 @@ var permissionByDescription = func() map[string]string {
 func PermissionEnum(description string) string {
 	return permissionByDescription[description]
 }
+
+// PermissionEditProject is the locator-form value for `userPermission:(permission:<name>,...)` (lowercase).
+const PermissionEditProject = "edit_project"

--- a/api/projects.go
+++ b/api/projects.go
@@ -15,6 +15,10 @@ type ProjectsOptions struct {
 	Parent string
 	Limit  int
 	Fields []string
+	// Permission, when set, restricts results to projects where the current user holds it (e.g. PermissionEditProject).
+	Permission string
+	// ExcludeArchived, when true, drops archived projects (which can't accept new features).
+	ExcludeArchived bool
 }
 
 // GetProjects returns a list of projects, automatically following pagination.
@@ -22,6 +26,14 @@ func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
 	locator := NewLocator().
 		Add("parentProject", opts.Parent).
 		AddIntDefault("count", opts.Limit, 30)
+	if opts.Permission != "" {
+		locator.AddLocator("userPermission", NewLocator().
+			Add("permission", opts.Permission).
+			Add("user", "current"))
+	}
+	if opts.ExcludeArchived {
+		locator.Add("archived", "false")
+	}
 
 	fields := opts.Fields
 	if len(fields) == 0 {

--- a/api/projects_test.go
+++ b/api/projects_test.go
@@ -6,12 +6,35 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestGetProjectsLocator(t *testing.T) {
+	t.Parallel()
+
+	var captured string
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		captured = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(ProjectList{Count: 0})
+	})
+
+	_, err := client.GetProjects(ProjectsOptions{
+		Permission:      PermissionEditProject,
+		ExcludeArchived: true,
+		Limit:           100,
+	})
+	require.NoError(t, err)
+
+	decoded, err := url.QueryUnescape(captured)
+	require.NoError(t, err)
+	assert.Contains(t, decoded, "userPermission:(permission:edit_project,user:current)")
+	assert.Contains(t, decoded, "archived:false")
+}
 
 func TestGetVersionedSettingsStatus(T *testing.T) {
 	T.Parallel()

--- a/internal/cmd/project/connection_authorize.go
+++ b/internal/cmd/project/connection_authorize.go
@@ -63,7 +63,7 @@ func runConnectionAuthorize(f *cmdutil.Factory, opts *connectionAuthorizeOptions
 	if err != nil {
 		return err
 	}
-	projectID, err := resolveProject(f, opts.project)
+	projectID, err := resolveProject(f, opts.project, api.PermissionEditProject)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/project/connection_create.go
+++ b/internal/cmd/project/connection_create.go
@@ -101,7 +101,7 @@ func runConnectionCreateGitHubApp(f *cmdutil.Factory, opts *githubAppOptions) er
 	}
 
 	interactive := f.IsInteractive()
-	projectID, err := resolveProject(f, opts.project)
+	projectID, err := resolveProject(f, opts.project, api.PermissionEditProject)
 	if err != nil {
 		return err
 	}
@@ -322,7 +322,7 @@ func runConnectionCreateDocker(f *cmdutil.Factory, opts *dockerOptions) error {
 	interactive := f.IsInteractive()
 
 	if interactive {
-		err := runInteractiveForm(f, &opts.project,
+		err := runInteractiveForm(f, &opts.project, api.PermissionEditProject,
 			formField{title: "Connection name", value: &opts.name},
 			formField{title: "Registry URL", description: "e.g. https://ghcr.io", value: &opts.url, validate: validateRegistryURL},
 			formField{title: "Username", value: &opts.username},

--- a/internal/cmd/project/connection_delete.go
+++ b/internal/cmd/project/connection_delete.go
@@ -3,6 +3,7 @@ package project
 import (
 	"fmt"
 
+	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/spf13/cobra"
@@ -44,7 +45,7 @@ func runConnectionDelete(f *cmdutil.Factory, opts *connectionDeleteOptions, id s
 		return err
 	}
 
-	projectID, err := resolveProject(f, opts.project)
+	projectID, err := resolveProject(f, opts.project, api.PermissionEditProject)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/project/helpers_internal_test.go
+++ b/internal/cmd/project/helpers_internal_test.go
@@ -5,9 +5,27 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPermissionRoots(t *testing.T) {
+	t.Parallel()
+
+	// A is a root; B and C inherit via A. D is a separate root (parent not in set).
+	got := permissionRoots([]api.Project{
+		{ID: "A", ParentProjectID: "_Root"},
+		{ID: "B", ParentProjectID: "A"},
+		{ID: "C", ParentProjectID: "B"},
+		{ID: "D", ParentProjectID: "Other"},
+	})
+	ids := make([]string, 0, len(got))
+	for _, p := range got {
+		ids = append(ids, p.ID)
+	}
+	assert.Equal(t, []string{"A", "D"}, ids)
+}
 
 func TestIsSSHURL(t *testing.T) {
 	t.Parallel()

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -14,9 +14,14 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/charmbracelet/huh"
+	"github.com/dustin/go-humanize"
+	"github.com/dustin/go-humanize/english"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
+
+// pickerVisibleRows is the viewport size for the project picker; extras scroll.
+const pickerVisibleRows = 10
 
 func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -535,18 +540,24 @@ func newProjectSettingsCmd(f *cmdutil.Factory) *cobra.Command {
 	return newSettingsCmd(f)
 }
 
-// projectPickerOptions fetches all visible projects and returns huh picker options, or nil on failure.
-func projectPickerOptions(f *cmdutil.Factory) []huh.Option[string] {
+// projectPickerOptions fetches projects the user can act on, then collapses to permission roots so the picker isn't drowned by inherited descendants.
+func projectPickerOptions(f *cmdutil.Factory, permission string) []huh.Option[string] {
 	client, err := f.Client()
 	if err != nil {
 		return nil
 	}
-	list, err := client.GetProjects(api.ProjectsOptions{Limit: 10000})
+	list, err := client.GetProjects(api.ProjectsOptions{
+		Limit:           10000,
+		Fields:          []string{"id", "name", "parentProjectId"},
+		Permission:      permission,
+		ExcludeArchived: true,
+	})
 	if err != nil || len(list.Projects) == 0 {
 		return nil
 	}
-	options := make([]huh.Option[string], len(list.Projects))
-	for i, p := range list.Projects {
+	roots := permissionRoots(list.Projects)
+	options := make([]huh.Option[string], len(roots))
+	for i, p := range roots {
 		label := p.ID
 		if p.Name != "" && p.Name != p.ID {
 			label = p.ID + " — " + p.Name
@@ -554,6 +565,30 @@ func projectPickerOptions(f *cmdutil.Factory) []huh.Option[string] {
 		options[i] = huh.Option[string]{Key: label, Value: p.ID}
 	}
 	return options
+}
+
+// permissionRoots keeps only projects whose parent is not also in the set; descendants inherit the permission via the kept root.
+func permissionRoots(projects []api.Project) []api.Project {
+	inSet := make(map[string]bool, len(projects))
+	for _, p := range projects {
+		inSet[p.ID] = true
+	}
+	out := make([]api.Project, 0, len(projects))
+	for _, p := range projects {
+		if !inSet[p.ParentProjectID] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// pickerDescription renders the count below the picker title; appends a filter hint when the list overflows the viewport.
+func pickerDescription(total int) string {
+	desc := fmt.Sprintf("%s %s", humanize.Comma(int64(total)), english.PluralWord(total, "project", ""))
+	if total > pickerVisibleRows {
+		desc += " · type to filter"
+	}
+	return desc
 }
 
 // formField describes one text input for runInteractiveForm. Validate defaults to cmdutil.RequireNonEmpty.
@@ -565,32 +600,34 @@ type formField struct {
 }
 
 // resolveProject returns project if non-empty; otherwise runs the project picker (interactive) or errors (non-interactive).
-func resolveProject(f *cmdutil.Factory, project string) (string, error) {
+func resolveProject(f *cmdutil.Factory, project, permission string) (string, error) {
 	if project != "" {
 		return project, nil
 	}
 	if !f.IsInteractive() {
 		return "", api.RequiredFlag("project")
 	}
-	if err := runInteractiveForm(f, &project); err != nil {
+	if err := runInteractiveForm(f, &project, permission); err != nil {
 		return "", err
 	}
 	return project, nil
 }
 
-// runInteractiveForm prompts for project (picker, with text-input fallback) and the given fields in a single huh form
-// so Shift+Tab navigates between them. Fields whose value is already non-empty are skipped; the rest are validated
-// (cmdutil.RequireNonEmpty by default) so the form will not exit with empty values. Each prompted field is echoed
-// to scrollback after the form completes.
-func runInteractiveForm(f *cmdutil.Factory, project *string, fields ...formField) error {
+// runInteractiveForm prompts for project (picker scoped to permission, with text-input fallback) and the given fields in a single huh form so Shift+Tab navigates between them.
+func runInteractiveForm(f *cmdutil.Factory, project *string, permission string, fields ...formField) error {
 	var groups []*huh.Group
 
 	needsProject := *project == ""
 	var pickerOptions []huh.Option[string]
 	if needsProject {
-		pickerOptions = projectPickerOptions(f)
+		pickerOptions = projectPickerOptions(f, permission)
 		if pickerOptions != nil {
-			sel := huh.NewSelect[string]().Title("Project").Options(pickerOptions...).Value(project)
+			sel := huh.NewSelect[string]().
+				Title("Project").
+				Description(pickerDescription(len(pickerOptions))).
+				Options(pickerOptions...).
+				Height(pickerVisibleRows).
+				Value(project)
 			if len(pickerOptions) >= 5 {
 				sel.Filtering(true)
 			}

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -138,7 +138,7 @@ func runSSHUpload(f *cmdutil.Factory, filePath string, opts *sshUploadOptions) e
 		return fmt.Errorf("failed to read key file: %w", err)
 	}
 
-	projectID, err := resolveProject(f, opts.project)
+	projectID, err := resolveProject(f, opts.project, api.PermissionEditProject)
 	if err != nil {
 		return err
 	}
@@ -200,7 +200,7 @@ func runSSHGenerate(f *cmdutil.Factory, opts *sshGenerateOptions) error {
 	}
 
 	if f.IsInteractive() {
-		if err := runInteractiveForm(f, &opts.project, formField{title: "Key name", value: &opts.name}); err != nil {
+		if err := runInteractiveForm(f, &opts.project, api.PermissionEditProject, formField{title: "Key name", value: &opts.name}); err != nil {
 			return err
 		}
 	}
@@ -258,7 +258,7 @@ func runSSHDelete(f *cmdutil.Factory, name string, opts *sshDeleteOptions) error
 		return err
 	}
 
-	projectID, err := resolveProject(f, opts.project)
+	projectID, err := resolveProject(f, opts.project, api.PermissionEditProject)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -319,7 +319,7 @@ func runVcsCreate(f *cmdutil.Factory, opts *vcsCreateOptions) error {
 	interactive := f.IsInteractive()
 
 	if interactive {
-		if err := runInteractiveForm(f, &opts.project, formField{title: "Repository URL", value: &opts.repoURL}); err != nil {
+		if err := runInteractiveForm(f, &opts.project, api.PermissionEditProject, formField{title: "Repository URL", value: &opts.repoURL}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
## Summary

The interactive project picker fetched all visible projects (42,705 / 18.7 MiB / ~2.4 s on this server) and dumped every entry into huh's filter. This narrows it to projects the user can act on, collapses inherited descendants, and drops archived projects.

## Changes

- `api.ProjectsOptions` gains `Permission` (e.g. `PermissionEditProject`) and `ExcludeArchived`; the locator adds `userPermission:(permission:<v>,user:current)` and `archived:false` when set.
- New constant `api.PermissionEditProject = "edit_project"`.
- `projectPickerOptions` fetches `id, name, parentProjectId` only; new `permissionRoots` keeps projects whose parent is not in the edit set, since descendants inherit access.
- Picker uses `huh.Select` with `Height(10)` (extras scroll) and a description like `"4 projects"` / `"1,234 projects · type to filter"`.
- `resolveProject` and `runInteractiveForm` take a permission; the eight write call sites (`connection authorize/create×2/delete`, `vcs create`, `ssh add/upload/delete/generate`) pass `api.PermissionEditProject`.

## Design Decisions

**Permission roots, not the full edit set.** Project features inherit to descendants, so the highest writeable project is the right place to define them. Showing 1,998 leaf entries (the original complaint) is noise; users who need a leaf can pass `-p <id>`.

**No filter for `teamcity.ui.settings.readOnly`.** Probed against the live server: the parameter that drives the UI's "Editing disabled" banner on VCS-managed projects isn't surfaced via REST in any filterable form (direct GET → 404; the `parameter:` locator dimension only matches own parameters). Walking inheritance per candidate still wouldn't see it. Decision: trust the role model, drop archived, accept that overridable UI soft-locks can still appear.

## Example

```
$ teamcity project connection create docker

? Project
  4 projects
> Grazie                          — JetBrains AI
  StaticAnalysis                  — Qodana (Static Analysis)
  Sandbox_TeamCityUi              — TeamCity UI1
  ijplatform_master_Plugins_Grazi — Grazie
```

Measured fetch on `buildserver.labs.intellij.net`:

| variant | time | payload | entries |
|---|---|---|---|
| baseline | 2.36 s | 18.7 MiB | 42,705 |
| permission + trimmed fields + archived:false | **0.28 s** | **0.25 MiB** | 1,998 (→ 4 after root collapse) |

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — CI will exercise
- [x] No new command/flag
- [x] No `--json` output changes
- [x] No docs-visible behavior change (picker is interactive-only)