### PR TITLE
chore: prep 1.0 — analytics doc accuracy, supported versions, skill bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "TeamCity CLI tools for Claude Code - manage builds, jobs, queues, agents, and projects",
-    "version": "0.10.0"
+    "version": "1.0.0"
   },
   "plugins": [
     {
@@ -16,7 +16,7 @@
         "url": "https://github.com/JetBrains/teamcity-cli.git"
       },
       "description": "Agent skill for interacting with TeamCity CI/CD using the teamcity CLI. Enables Claude to explore builds, view logs, start jobs, manage queues, agents, and more.",
-      "version": "0.10.0",
+      "version": "1.0.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "teamcity-cli",
   "description": "Agent skill for interacting with TeamCity CI/CD using the teamcity CLI. Enables Claude to explore builds, view logs, start jobs, manage queues, agents, and more.",
-  "version": "0.10.0",
+  "version": "1.0.0",
   "author": {
     "name": "JetBrains"
   }

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     attributes:
       label: CLI Version
       description: Run `teamcity --version` to get this
-      placeholder: "v0.2.0"
+      placeholder: "v1.0.0"
     validations:
       required: true
 

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version  | Supported          |
 |----------|--------------------|
-| 0.x.x    | :white_check_mark: |
+| 1.x.x    | :white_check_mark: |
+| 0.x.x    | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -388,7 +388,7 @@ Chocolatey pushes can fail with `503 Service Unavailable` or other transient err
 
 1. Check out the release tag and build the package locally:
    ```sh
-   git checkout v0.9.0
+   git checkout v1.0.0
    ```
 
 2. Download the existing `.nupkg` for the previous version to use as a template:

--- a/docs/topics/teamcity-cli-analytics.md
+++ b/docs/topics/teamcity-cli-analytics.md
@@ -8,24 +8,40 @@
 
 </tip>
 
-TeamCity CLI sends anonymous usage data to JetBrains so we can see which commands matter to people, where things break, and where to spend our time next.
+TeamCity CLI sends anonymous usage statistics to JetBrains so we can see which commands matter to people, where things break, and where to spend our time next. Every value we send is constrained to a fixed enum or a numeric count – the CLI never transmits free-form strings, identifiers, or anything you typed.
 
 ## What we collect
 
-- The command you ran – for example, `run list`, `pipeline validate`, `agent term`.
-- Whether you used common flags like `--json`, `--watch`, or `--web`.
-- A salted hash of your TeamCity server URL, so we can count distinct servers without learning the URL.
-- A per-machine session ID.
-- OS, CLI version, terminal type, and whether the run was interactive or in CI.
+**Once per CLI invocation** (a "session" event):
+
+- CLI version, TeamCity server version (for example, `2026.1`), and server type – `cloud` or `on_prem`.
+- OS (`darwin`, `linux`, `windows`, `freebsd`, `other`) and CPU architecture (`amd64`, `arm64`, `386`, `other`).
+- The CI system the CLI is running inside, if any: `github_actions`, `gitlab`, `jenkins`, `circleci`, `buildkite`, `azure`, `travis`, `teamcity`, `other`, or `none`.
+- The AI coding agent that invoked the CLI, if any: `claude_code`, `junie`, `cursor`, `gemini_cli`, `codex`, `goose`, `augment`, `github_copilot`, `amp`, `windsurf`, `opencode`, `trae`, `roo`, `other`, or `none`.
+- How you authenticated: `keyring`, `env`, `build_properties`, `guest`, or `none` – never the token itself.
+- Whether the working directory has a `teamcity.toml` linked-project file (a boolean).
+- A randomly-generated session ID that rotates after 30 minutes of inactivity. The ID is hashed locally before it leaves your machine.
+
+**Once per command** (a "command" event):
+
+- The command you ran, mapped to a fixed enum: `run.list`, `pipeline.validate`, `agent.term`, and so on. Anything outside the enum collapses to `other`.
+- Whether `--json` was used.
+- Whether the command ran with git context (one of `--local-changes`, `--branch=@this`, `--revision=@head`).
+- Whether a `teamcity.toml` link file was used to resolve the project or job.
+- The total number of flags you set (count only – never the values).
+- Exit code (`0`, `1`, `2`), duration in milliseconds, and an error category if the command failed: `auth`, `permission`, `not_found`, `network`, `validation`, `read_only`, `internal`, or `none`.
+
+**For specific command groups** (build runs, agent sessions, pipeline operations, skill install/update, REST API calls, login, link) we record a handful of additional behavioral booleans and counts – for example, `is_personal` for `run start`, `error_count` for `pipeline validate`, `had_timeout` for `agent term`. The full, exact schema is committed in [`internal/analytics/scheme.go`](https://github.com/JetBrains/teamcity-cli/blob/main/internal/analytics/scheme.go).
 
 ## What we don't collect
 
 - Tokens, passwords, SSH keys, or anything stored in the keyring or `config.yml`.
-- Repository contents, build logs, or arguments you pass to commands.
-- Project, job, agent, or pipeline names and IDs.
-- Usernames, emails, hostnames, or IP addresses.
+- Your TeamCity server URL, hostname, or IP address. The URL is used only as a local cache key in `~/.config/tc/.analytics/server-info.json` so the CLI can remember which server version it last saw; the URL itself never leaves your machine.
+- Repository contents, build logs, build numbers, or arguments you pass to commands.
+- Project, job, build, agent, pipeline, VCS-root, pool, or connection names or IDs.
+- Usernames, emails, branch names, file paths, or commit SHAs.
 
-**Nothing we collect can be used to identify you, your organization, or your repositories.** Identifiers that could be sensitive – like the server URL – are hashed locally with a salt before they leave your machine, and we don't sell or share the data we receive.
+**Nothing we collect can be used to identify you, your organization, your servers, or your repositories.** Every value goes through a published enum or numeric validator before it leaves your machine – the CLI cannot accidentally exfiltrate strings.
 
 ## How to opt out
 

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: teamcity-cli
-version: 0.10.1
+version: 1.0.0
 description: Use when working with TeamCity CI/CD or when a user provides a TeamCity build URL — drives the `teamcity` CLI for builds, logs, jobs, queues, agents, pools, projects, and pipelines.
 ---
 


### PR DESCRIPTION
## Summary

Three small, independent 1.0-prep changes:

1. Rewrite [`teamcity-cli-analytics.md`](docs/topics/teamcity-cli-analytics.md) so it matches what `internal/analytics/scheme.go` actually emits.
2. Bump [`.github/SECURITY.md`](.github/SECURITY.md) supported versions to `1.x.x ✓` / `0.x.x ✗`.
3. Bump the skill manifest in [`skills/teamcity-cli/SKILL.md`](skills/teamcity-cli/SKILL.md) to `1.0.0`.

Companion docs sync at JetBrains/teamcity-documentation#568 carries the same analytics correction.

## Changes

### `docs(analytics)` — describe the actual fields the CLI emits

The existing page made claims the CLI doesn't actually keep:

- **"salted hash of your TeamCity server URL"** — the URL is only used as a local cache key in `~/.config/tc/.analytics/server-info.json` so the CLI can remember which version it last saw; nothing about the URL ever goes on the wire (verified in `server_info.go` and the `sessionGroup()` schema).
- **"common flags like `--json`, `--watch`, or `--web`"** — only `has_json` is tracked. Companion fields are `has_git_context` (set by `--local-changes`/`--branch=@this`/`--revision=@head`), `has_link_context` (whether a `teamcity.toml` was used), and `flag_count` (count, not values).
- **"terminal type, and whether the run was interactive or in CI"** — there is no `terminal_type` and no `is_interactive` field anywhere. CI is captured by `ci_system` only.

Two signals were sent but **not previously disclosed** — fixed now:

- `ai_agent` — the AI coding agent that invoked the CLI (full enum: `claude_code`, `junie`, `cursor`, `gemini_cli`, `codex`, `goose`, `augment`, `github_copilot`, `amp`, `windsurf`, `opencode`, `trae`, `roo`, `other`, `none`).
- `auth_source` — `keyring` / `env` / `build_properties` / `guest` / `none`.

Other corrections:

- Session ID was described as "per-machine" — actually rolls every 30 min of inactivity (`session.go: SessionWindow`), and is hashed locally before transmission.
- Restructured into per-invocation, per-command, and group-specific sections.
- Pointed at [`internal/analytics/scheme.go`](internal/analytics/scheme.go) as the canonical source of truth so future docs drift gets caught against committed code.

### `chore(security)` — supported versions

`.github/SECURITY.md` listed `0.x.x` as the only supported line. Added `1.x.x ✓` and demoted `0.x.x` to ✗ now that 1.0 is the support boundary.

### `chore(skill)` — bump skill manifest version

`skills/teamcity-cli/SKILL.md` had `version: 0.10.1` hardcoded. Bumped to `1.0.0` to match the upcoming release.

## Design Decisions

- The analytics page enumerates concrete enum values (CI systems, AI agents, error categories) rather than hand-waving with "and similar". For a privacy disclosure, transparency beats brevity — and these enums are short and stable.
- I kept the page free of any field that doesn't exist in `scheme.go`, so a single re-read of the schema is enough to verify the doc.
- Skill version follows the release tag (1.0.0), not an independent skill cadence — matches the existing convention at v0.10.1.
- SECURITY.md keeps the 0.x row visible (as `:x:`) rather than removing it, so users still see at a glance that 0.x is no longer supported.

## Example

No CLI behavior changes. To preview the analytics page:

```bash
just docs-build  # if available, otherwise read in any markdown previewer
```

## Test Plan

- [x] Unit tests pass (`just unit`) — 364 tests, ran clean during the 1.0 audit.
- [x] Linter passes (`just lint`) — 0 issues.
- [x] Acceptance tests pass (`just acceptance`) — 86 tests, 22 env-skipped.
- [ ] If adding a new command/flag: N/A (docs + version bumps only).
- [ ] If adding a data-producing command: N/A.
- [ ] If modifying `--json` output: N/A.
- [x] If changing docs-visible behavior: synced to `teamcity-documentation` PR #568.
