### PR TITLE
Committed, but non-pushed changes should be delivered to the personal build

### DIFF
--- a/internal/cmd/run/local_changes.go
+++ b/internal/cmd/run/local_changes.go
@@ -38,7 +38,13 @@ func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 				"Run this command from within a git repository, or use --local-changes <path> to specify a diff file",
 			)
 		}
-		patch, err := git.UncommittedDiff()
+
+		base := "HEAD"
+		if git.HasUpstream() {
+			base = "@{u}"
+		}
+
+		patch, err := git.WorkingTreeDiffFrom(base)
 		if err != nil {
 			return nil, api.Validation(
 				"failed to generate git diff",
@@ -47,7 +53,7 @@ func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 		}
 		if len(patch) == 0 {
 			return nil, api.Validation(
-				"no uncommitted changes found",
+				"no local changes found",
 				"Make some changes to your files before running a personal build, or use --local-changes <path> to specify a diff file",
 			)
 		}

--- a/internal/cmd/run/local_changes.go
+++ b/internal/cmd/run/local_changes.go
@@ -39,9 +39,12 @@ func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 			)
 		}
 
-		base := "HEAD"
-		if git.HasUpstream() {
-			base = "@{u}"
+		base, err := git.LocalChangesGitDiffBase()
+		if err != nil {
+			return nil, api.Validation(
+				fmt.Sprintf("failed to resolve merge base for local changes against upstream: %v", err),
+				"Computing the merge base with your upstream failed, check for conflicts and fix them then try again or pass a patch with --local-changes instead.",
+			)
 		}
 
 		patch, err := git.WorkingTreeDiffFrom(base)

--- a/internal/cmd/run/local_changes.go
+++ b/internal/cmd/run/local_changes.go
@@ -43,7 +43,7 @@ func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 		if err != nil {
 			return nil, api.Validation(
 				fmt.Sprintf("failed to resolve merge base for local changes against upstream: %v", err),
-				"Computing the merge base with your upstream failed, check for conflicts and fix them then try again or pass a patch with --local-changes instead.",
+				"Computing the merge base with your upstream failed, run git fetch, or pass a patch with --local-changes <path> instead.",
 			)
 		}
 

--- a/internal/cmd/run/local_changes_test.go
+++ b/internal/cmd/run/local_changes_test.go
@@ -94,6 +94,78 @@ func TestLoadLocalChanges(t *testing.T) {
 		assert.Contains(t, string(patch), "modified")
 	})
 
+	t.Run("git source behind upstream clean tree after fetch", func(t *testing.T) {
+		remoteDir := t.TempDir()
+		cmd := exec.Command("git", "init", "--bare", remoteDir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git init --bare: %s", out)
+
+		localDir := setupRepo(t)
+		gitDo(t, localDir, "remote", "add", "origin", remoteDir)
+		writeFile(t, localDir, "test.txt", "content")
+		gitDo(t, localDir, "add", ".")
+		gitDo(t, localDir, "commit", "-m", "initial")
+
+		branchOut, err := exec.Command("git", "-C", localDir, "symbolic-ref", "--short", "HEAD").Output()
+		require.NoError(t, err)
+		branch := strings.TrimSpace(string(branchOut))
+		gitDo(t, localDir, "push", "-u", "origin", branch)
+
+		otherDir := t.TempDir()
+		out, err = exec.Command("git", "clone", remoteDir, otherDir).CombinedOutput()
+		require.NoError(t, err, "git clone: %s", string(out))
+		writeFile(t, otherDir, "from_remote.txt", "added on remote")
+		gitDo(t, otherDir, "add", ".")
+		gitDo(t, otherDir, "commit", "-m", "remote ahead commit")
+		gitDo(t, otherDir, "push", "origin", branch)
+
+		gitDo(t, localDir, "fetch", "origin")
+		diffOut, err := exec.Command("git", "-C", localDir, "diff", "@{u}").CombinedOutput()
+		require.NoError(t, err)
+		require.NotEmpty(t, diffOut, "sanity: git diff @{u} must be non-empty when behind upstream (reverse patch)")
+
+		t.Chdir(localDir)
+		_, err = loadLocalChanges("git", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no local changes found")
+	})
+
+	t.Run("git source behind remote with local working tree changes", func(t *testing.T) {
+		remoteDir := t.TempDir()
+		cmd := exec.Command("git", "init", "--bare", remoteDir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git init --bare: %s", out)
+
+		localDir := setupRepo(t)
+		gitDo(t, localDir, "remote", "add", "origin", remoteDir)
+		writeFile(t, localDir, "test.txt", "content")
+		gitDo(t, localDir, "add", ".")
+		gitDo(t, localDir, "commit", "-m", "initial")
+
+		branchOut, err := exec.Command("git", "-C", localDir, "symbolic-ref", "--short", "HEAD").Output()
+		require.NoError(t, err)
+		branch := strings.TrimSpace(string(branchOut))
+		gitDo(t, localDir, "push", "-u", "origin", branch)
+
+		otherDir := t.TempDir()
+		out, err = exec.Command("git", "clone", remoteDir, otherDir).CombinedOutput()
+		require.NoError(t, err, "git clone: %s", string(out))
+		writeFile(t, otherDir, "from_remote.txt", "added on remote")
+		gitDo(t, otherDir, "add", ".")
+		gitDo(t, otherDir, "commit", "-m", "remote ahead commit")
+		gitDo(t, otherDir, "push", "origin", branch)
+
+		gitDo(t, localDir, "fetch", "origin")
+		writeFile(t, localDir, "test.txt", "local working tree edit")
+
+		t.Chdir(localDir)
+		patch, err := loadLocalChanges("git", nil)
+		require.NoError(t, err)
+		p := string(patch)
+		assert.Contains(t, p, "local working tree edit")
+		assert.NotContains(t, p, "from_remote.txt")
+	})
+
 	t.Run("git source not in repo", func(t *testing.T) {
 		t.Chdir(t.TempDir())
 		_, err := loadLocalChanges("git", nil)

--- a/internal/cmd/run/local_changes_test.go
+++ b/internal/cmd/run/local_changes_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,7 +64,34 @@ func TestLoadLocalChanges(t *testing.T) {
 
 		_, err := loadLocalChanges("git", nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "no uncommitted changes")
+		assert.Contains(t, err.Error(), "no local changes found")
+	})
+
+	t.Run("git source committed but not pushed", func(t *testing.T) {
+		remoteDir := t.TempDir()
+		cmd := exec.Command("git", "init", "--bare", remoteDir)
+		out, err := cmd.CombinedOutput()
+		require.NoError(t, err, "git init --bare: %s", out)
+
+		localDir := setupRepo(t)
+		gitDo(t, localDir, "remote", "add", "origin", remoteDir)
+		writeFile(t, localDir, "test.txt", "content")
+		gitDo(t, localDir, "add", ".")
+		gitDo(t, localDir, "commit", "-m", "initial")
+
+		branchOut, err := exec.Command("git", "-C", localDir, "symbolic-ref", "--short", "HEAD").Output()
+		require.NoError(t, err)
+		branch := strings.TrimSpace(string(branchOut))
+		gitDo(t, localDir, "push", "-u", "origin", branch)
+
+		writeFile(t, localDir, "test.txt", "modified")
+		gitDo(t, localDir, "add", ".")
+		gitDo(t, localDir, "commit", "-m", "unpushed change")
+
+		t.Chdir(localDir)
+		patch, err := loadLocalChanges("git", nil)
+		require.NoError(t, err)
+		assert.Contains(t, string(patch), "modified")
 	})
 
 	t.Run("git source not in repo", func(t *testing.T) {

--- a/internal/cmd/run/local_changes_test.go
+++ b/internal/cmd/run/local_changes_test.go
@@ -14,17 +14,8 @@ import (
 func setupRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	for _, args := range [][]string{
-		{"init"},
-		{"config", "user.email", "test@test.com"},
-		{"config", "user.name", "Test User"},
-		{"config", "commit.gpgsign", "false"},
-	} {
-		cmd := exec.Command("git", args...)
-		cmd.Dir = dir
-		out, err := cmd.CombinedOutput()
-		require.NoError(t, err, "git %v: %s", args, string(out))
-	}
+	gitDo(t, dir, "init")
+	configureGitIdentity(t, dir)
 	return dir
 }
 
@@ -34,6 +25,13 @@ func gitDo(t *testing.T, dir string, args ...string) {
 	cmd.Dir = dir
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "git %v: %s", args, string(out))
+}
+
+func configureGitIdentity(t *testing.T, dir string) {
+	t.Helper()
+	gitDo(t, dir, "config", "user.email", "test@test.com")
+	gitDo(t, dir, "config", "user.name", "Test User")
+	gitDo(t, dir, "config", "commit.gpgsign", "false")
 }
 
 func writeFile(t *testing.T, dir, name, content string) {
@@ -114,6 +112,7 @@ func TestLoadLocalChanges(t *testing.T) {
 		otherDir := t.TempDir()
 		out, err = exec.Command("git", "clone", remoteDir, otherDir).CombinedOutput()
 		require.NoError(t, err, "git clone: %s", string(out))
+		configureGitIdentity(t, otherDir)
 		writeFile(t, otherDir, "from_remote.txt", "added on remote")
 		gitDo(t, otherDir, "add", ".")
 		gitDo(t, otherDir, "commit", "-m", "remote ahead commit")
@@ -150,6 +149,7 @@ func TestLoadLocalChanges(t *testing.T) {
 		otherDir := t.TempDir()
 		out, err = exec.Command("git", "clone", remoteDir, otherDir).CombinedOutput()
 		require.NoError(t, err, "git clone: %s", string(out))
+		configureGitIdentity(t, otherDir)
 		writeFile(t, otherDir, "from_remote.txt", "added on remote")
 		gitDo(t, otherDir, "add", ".")
 		gitDo(t, otherDir, "commit", "-m", "remote ahead commit")

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -103,6 +103,11 @@ func BranchExistsOnRemote(branch string) bool {
 	return err == nil && strings.TrimSpace(string(out)) != ""
 }
 
+// HasUpstream reports whether the current branch has an upstream tracking branch configured.
+func HasUpstream() bool {
+	return exec.Command("git", "rev-parse", "--abbrev-ref", "@{u}").Run() == nil
+}
+
 // Push runs `git push -u <remote> <branch>` for the branch's configured remote.
 func Push(branch string) error {
 	remote := RemoteForBranch(branch)
@@ -147,6 +152,29 @@ func UncommittedDiff() ([]byte, error) {
 	out, err := exec.Command("git", "diff", "HEAD").Output()
 	if err != nil {
 		return nil, fmt.Errorf("git diff HEAD: %w", err)
+	}
+	return out, nil
+}
+
+// WorkingTreeDiffFrom returns `git diff <base>` output, including committed, staged,
+// unstaged, and untracked changes relative to base.
+func WorkingTreeDiffFrom(base string) ([]byte, error) {
+	untracked, err := UntrackedFiles()
+	if err != nil {
+		return nil, err
+	}
+	if len(untracked) > 0 {
+		addArgs := append([]string{"add", "-N", "--"}, untracked...)
+		if exec.Command("git", addArgs...).Run() == nil {
+			defer func() {
+				resetArgs := append([]string{"reset", "HEAD", "--"}, untracked...)
+				_ = exec.Command("git", resetArgs...).Run()
+			}()
+		}
+	}
+	out, err := exec.Command("git", "diff", base).Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff %s: %w", base, err)
 	}
 	return out, nil
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -108,6 +108,19 @@ func HasUpstream() bool {
 	return exec.Command("git", "rev-parse", "--abbrev-ref", "@{u}").Run() == nil
 }
 
+// LocalChangesGitDiffBase returns the ref to pass to WorkingTreeDiffFrom for --local-changes git.
+// With an upstream it uses merge-base(HEAD, @{u}), without an upstream it returns HEAD.
+func LocalChangesGitDiffBase() (string, error) {
+	if !HasUpstream() {
+		return "HEAD", nil
+	}
+	out, err := exec.Command("git", "merge-base", "HEAD", "@{u}").Output()
+	if err != nil {
+		return "", fmt.Errorf("git merge-base HEAD @{u}: %w", err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
 // Push runs `git push -u <remote> <branch>` for the branch's configured remote.
 func Push(branch string) error {
 	remote := RemoteForBranch(branch)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -147,28 +147,6 @@ func UntrackedFiles() ([]string, error) {
 	return strings.Split(s, "\n"), nil
 }
 
-// UncommittedDiff returns `git diff HEAD` output, including untracked files via a transient intent-to-add.
-func UncommittedDiff() ([]byte, error) {
-	untracked, err := UntrackedFiles()
-	if err != nil {
-		return nil, err
-	}
-	if len(untracked) > 0 {
-		addArgs := append([]string{"add", "-N", "--"}, untracked...)
-		if exec.Command("git", addArgs...).Run() == nil {
-			defer func() {
-				resetArgs := append([]string{"reset", "HEAD", "--"}, untracked...)
-				_ = exec.Command("git", resetArgs...).Run()
-			}()
-		}
-	}
-	out, err := exec.Command("git", "diff", "HEAD").Output()
-	if err != nil {
-		return nil, fmt.Errorf("git diff HEAD: %w", err)
-	}
-	return out, nil
-}
-
 // WorkingTreeDiffFrom returns `git diff <base>` output, including committed, staged,
 // unstaged, and untracked changes relative to base.
 func WorkingTreeDiffFrom(base string) ([]byte, error) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -198,47 +198,6 @@ func TestUntrackedFiles(t *testing.T) {
 	})
 }
 
-func TestUncommittedDiff(t *testing.T) {
-	t.Run("no changes", func(t *testing.T) {
-		dir := setupRepo(t)
-		t.Chdir(dir)
-		writeFile(t, dir, "test.txt", "content")
-		runGit(t, dir, "add", ".")
-		runGit(t, dir, "commit", "-m", "initial")
-
-		diff, err := UncommittedDiff()
-		require.NoError(t, err)
-		assert.Empty(t, diff)
-	})
-
-	t.Run("modified file", func(t *testing.T) {
-		dir := setupRepo(t)
-		t.Chdir(dir)
-		writeFile(t, dir, "test.txt", "content")
-		runGit(t, dir, "add", ".")
-		runGit(t, dir, "commit", "-m", "initial")
-		writeFile(t, dir, "test.txt", "modified")
-
-		diff, err := UncommittedDiff()
-		require.NoError(t, err)
-		assert.Contains(t, string(diff), "modified")
-	})
-
-	t.Run("includes untracked", func(t *testing.T) {
-		dir := setupRepo(t)
-		t.Chdir(dir)
-		writeFile(t, dir, "seed.txt", "seed")
-		runGit(t, dir, "add", ".")
-		runGit(t, dir, "commit", "-m", "initial")
-		writeFile(t, dir, "new.txt", "fresh content")
-
-		diff, err := UncommittedDiff()
-		require.NoError(t, err)
-		assert.Contains(t, string(diff), "new.txt")
-		assert.Contains(t, string(diff), "fresh content")
-	})
-}
-
 func TestCanonicalURL(t *testing.T) {
 	cases := []struct {
 		in, want string

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -169,7 +169,7 @@ teamcity run watch <run-id> --json
 
 > **Kotlin DSL caveat:** `--local-changes` does **not** include changes to Kotlin DSL (`.teamcity/`). Always push Kotlin DSL changes to the remote before running the build.
 
-**Run build with uncommitted git changes:**
+**Run build with local git changes:**
 ```bash
 teamcity run start <job-id> --local-changes
 ```


### PR DESCRIPTION
## Summary

Fixes #284
Personal builds now include committed-but-not-pushed changes, not just uncommitted ones. Previously, --local-changes git only diffed against HEAD, so any commits made locally but not yet pushed to the remote were silently excluded from the patch sent to TeamCity. Now, when the current branch has an upstream tracking branch, the diff is computed against merge-base(HEAD, @{u}) instead, capturing all unpushed commits as well as any working tree changes and dealing with them when you are behind upstream. Branches without an upstream still use HEAD.

## Changes
`internal/git/git.go`
- Added `HasUpstream()` to detect whether the current branch has a configured upstream tracking branch.
- Added `WorkingTreeDiffFrom(base)` to diff the full working tree (including committed, staged, unstaged, and untracked changes) from an arbitrary base ref. Untracked files are temporarily intent-to-added so they appear in the diff, then reset afterward.
- Added `LocalChangesGitDiffBase()` — HEAD if no upstream, otherwise merge-base(HEAD, @{u}); errors surface merge-base failures to the CLI.

`internal/cmd/run/local_changes.go`
- `loadLocalChanges` resolves the diff base via LocalChangesGitDiffBase(), then WorkingTreeDiffFrom(base).
- Updated the empty-patch error message from "no uncommitted changes found" to "no local changes found" to match the broader scope.

`internal/cmd/run/local_changes_test.go`
- Added test case covering the committed-but-not-pushed scenario: sets up a bare remote, pushes an initial commit to establish tracking, makes an unpushed commit, and asserts the patch includes the new content.
- Updated the existing empty-diff test assertion to match the new error message.
- Added test case covering the behind upstream, clean tree after fetch case: expects no patch (no local changes found)
- Added test case covering behind upstream with working tree edits → patch reflects only local edits

## Design Decisions

The diff base is chosen dynamically at runtime: merge-base(HEAD, @{u}) when a tracking branch exists, HEAD otherwise. This means branches that have never been pushed (no upstream configured) still use HEAD as the base, which preserves the previous behavior for those cases and avoids erroring out on detached HEADs or untracked local branches.
Untracked files are temporarily staged with git add -N (intent-to-add) so git diff <base> picks them up, then immediately reset. This avoids permanently modifying the index.

## Example

```
# Committed a change locally but haven't pushed yet
git commit -m "WIP: my change"
teamcity run MyBuildConfig --local-changes git
# → patch now includes the unpushed commit diff
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
