### PR TITLE
fix(analytics): classify tc api HTTP errors instead of bucketing as internal

### DIFF
--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -193,7 +193,7 @@ func (c *Client) UploadDiffChanges(patch []byte, description string) (string, er
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", errorFromBody(resp.StatusCode, resp.Body)
+		return "", ErrorFromBody(resp.StatusCode, resp.Body)
 	}
 
 	return strings.TrimSpace(string(resp.Body)), nil

--- a/api/errors.go
+++ b/api/errors.go
@@ -1,10 +1,10 @@
 package api
 
 import (
-	"cmp"
 	"errors"
 	"fmt"
 	"strings"
+	"unicode/utf8"
 )
 
 // Category classifies user-facing errors for UI rendering and JSON output.
@@ -33,24 +33,26 @@ type Wire struct {
 
 // HTTPError covers HTTP-derived errors without extra structured fields (401, generic 4xx/5xx).
 type HTTPError struct {
-	Status int
-	Wire   Wire
-	cat    Category
+	Status  int
+	Wire    Wire
+	rawBody []byte // surfaced only when Wire has no message — preserves diagnostic detail from proxy HTML / oversized text
+	cat     Category
 }
 
 func (e *HTTPError) Error() string {
 	if e.Wire.Message != "" {
 		return e.Wire.Message
 	}
+	snippet := bodySnippet(e.rawBody)
 	switch e.cat {
 	case CatAuth:
-		return "authentication failed: invalid or expired credentials"
+		return joinSnippet("authentication failed: invalid or expired credentials", snippet)
 	case CatPermission:
-		return "permission denied"
+		return joinSnippet("permission denied", snippet)
 	case CatNotFound:
-		return "resource not found"
+		return joinSnippet("resource not found", snippet)
 	}
-	return fmt.Sprintf("server returned %d", e.Status)
+	return joinSnippet(fmt.Sprintf("server returned %d", e.Status), snippet)
 }
 
 func (e *HTTPError) Category() Category { return e.cat }
@@ -70,7 +72,10 @@ func (e *PermissionError) Error() string {
 	case e.Permission != "":
 		return fmt.Sprintf("missing %q permission", e.Permission)
 	}
-	return cmp.Or(e.Wire.Message, "permission denied")
+	if e.Wire.Message != "" {
+		return e.Wire.Message
+	}
+	return joinSnippet("permission denied", bodySnippet(e.rawBody))
 }
 
 // NotFoundError is returned for HTTP 404 responses.
@@ -84,7 +89,10 @@ func (e *NotFoundError) Error() string {
 	if e.Resource != "" && e.ID != "" {
 		return fmt.Sprintf("%s %q not found", e.Resource, e.ID)
 	}
-	return cmp.Or(e.Wire.Message, "resource not found")
+	if e.Wire.Message != "" {
+		return e.Wire.Message
+	}
+	return joinSnippet("resource not found", bodySnippet(e.rawBody))
 }
 
 // NetworkError wraps transport-level failures (DNS, connect, TLS, timeout).
@@ -142,6 +150,38 @@ func (readOnlyError) Category() Category { return CatReadOnly }
 
 // ErrReadOnly is returned when a non-GET request is attempted in read-only mode.
 var ErrReadOnly UserError = readOnlyError{}
+
+// joinSnippet appends a body-snippet diagnostic to base when one is available.
+func joinSnippet(base, snippet string) string {
+	if snippet == "" {
+		return base
+	}
+	return base + ": " + snippet
+}
+
+// bodySnippet returns a single-line, control-stripped excerpt of body (≤512 bytes), or "" if there is nothing useful to show.
+func bodySnippet(body []byte) string {
+	s := strings.TrimSpace(string(body))
+	if s == "" {
+		return ""
+	}
+	s = strings.Join(strings.Fields(s), " ")
+	s = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, s)
+	const max = 512
+	if len(s) > max {
+		cut := max
+		for cut > 0 && !utf8.RuneStart(s[cut]) {
+			cut--
+		}
+		s = s[:cut] + "..."
+	}
+	return s
+}
 
 // IsSandboxBlocked reports whether a sandbox is blocking outbound network access.
 func IsSandboxBlocked(err error) bool {

--- a/api/errors_parse.go
+++ b/api/errors_parse.go
@@ -39,10 +39,17 @@ func ErrorFromResponse(resp *http.Response) error {
 	return ErrorFromBody(resp.StatusCode, body)
 }
 
+// maxStoredRawBody caps the body retained on HTTPError; the rendered snippet is ≤512 bytes.
+const maxStoredRawBody = 1024
+
 // ErrorFromBody classifies a non-2xx status + body into a typed UserError; pure for ease of testing.
 func ErrorFromBody(status int, body []byte) error {
 	w := parseWire(body)
 	base := HTTPError{Status: status, Wire: w}
+	if w.Message == "" && len(body) > 0 {
+		n := min(len(body), maxStoredRawBody)
+		base.rawBody = body[:n]
+	}
 
 	switch status {
 	case http.StatusUnauthorized:

--- a/api/errors_parse.go
+++ b/api/errors_parse.go
@@ -36,11 +36,11 @@ var (
 // ErrorFromResponse reads a non-2xx body (capped at maxErrorBody) and returns the typed error.
 func ErrorFromResponse(resp *http.Response) error {
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
-	return errorFromBody(resp.StatusCode, body)
+	return ErrorFromBody(resp.StatusCode, body)
 }
 
-// errorFromBody is a pure function for ease of testing.
-func errorFromBody(status int, body []byte) error {
+// ErrorFromBody classifies a non-2xx status + body into a typed UserError; pure for ease of testing.
+func ErrorFromBody(status int, body []byte) error {
 	w := parseWire(body)
 	base := HTTPError{Status: status, Wire: w}
 

--- a/api/errors_parse_test.go
+++ b/api/errors_parse_test.go
@@ -124,7 +124,7 @@ func TestErrorFromBody(T *testing.T) {
 
 	T.Run("401 → HTTPError with auth category", func(t *testing.T) {
 		t.Parallel()
-		err := errorFromBody(http.StatusUnauthorized, nil)
+		err := ErrorFromBody(http.StatusUnauthorized, nil)
 		he, ok := errors.AsType[*HTTPError](err)
 		require.True(t, ok)
 		assert.Equal(t, CatAuth, he.Category())
@@ -135,7 +135,7 @@ func TestErrorFromBody(T *testing.T) {
 		t.Parallel()
 		// Real server output: project id is single-quoted in the body.
 		body := []byte(`{"errors":[{"message":"You do not have \"Comment build\" permission in project with internal id: 'MyProj'"}]}`)
-		err := errorFromBody(http.StatusForbidden, body)
+		err := ErrorFromBody(http.StatusForbidden, body)
 		pe, ok := errors.AsType[*PermissionError](err)
 		require.True(t, ok)
 		assert.Equal(t, CatPermission, pe.Category())
@@ -147,7 +147,7 @@ func TestErrorFromBody(T *testing.T) {
 	T.Run("403 without parseable permission falls back to wire message", func(t *testing.T) {
 		t.Parallel()
 		body := []byte(`{"errors":[{"message":"Access denied."}]}`)
-		err := errorFromBody(http.StatusForbidden, body)
+		err := ErrorFromBody(http.StatusForbidden, body)
 		pe, ok := errors.AsType[*PermissionError](err)
 		require.True(t, ok)
 		assert.Empty(t, pe.Permission)
@@ -157,7 +157,7 @@ func TestErrorFromBody(T *testing.T) {
 	T.Run("404 with locator parsed", func(t *testing.T) {
 		t.Parallel()
 		body := []byte(`{"errors":[{"message":"No build types found by locator 'Sandbox_Demo'."}]}`)
-		err := errorFromBody(http.StatusNotFound, body)
+		err := ErrorFromBody(http.StatusNotFound, body)
 		nf, ok := errors.AsType[*NotFoundError](err)
 		require.True(t, ok)
 		assert.Equal(t, "job", nf.Resource)
@@ -168,7 +168,7 @@ func TestErrorFromBody(T *testing.T) {
 	T.Run("500 falls back to wire message", func(t *testing.T) {
 		t.Parallel()
 		body := []byte(`{"errors":[{"message":"database down"}]}`)
-		err := errorFromBody(http.StatusInternalServerError, body)
+		err := ErrorFromBody(http.StatusInternalServerError, body)
 		he, ok := errors.AsType[*HTTPError](err)
 		require.True(t, ok)
 		assert.Equal(t, CatInternal, he.Category())

--- a/api/errors_parse_test.go
+++ b/api/errors_parse_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -173,6 +174,41 @@ func TestErrorFromBody(T *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, CatInternal, he.Category())
 		assert.Equal(t, "database down", err.Error())
+	})
+
+	T.Run("502 with HTML body surfaces snippet", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`<html><head><title>502 Bad Gateway</title></head><body><h1>502 Bad Gateway</h1><hr>nginx/1.18.0</body></html>`)
+		err := ErrorFromBody(http.StatusBadGateway, body)
+		he, ok := errors.AsType[*HTTPError](err)
+		require.True(t, ok)
+		assert.Equal(t, CatInternal, he.Category())
+		msg := err.Error()
+		assert.Contains(t, msg, "server returned 502")
+		assert.Contains(t, msg, "502 Bad Gateway")
+		assert.Contains(t, msg, "nginx/1.18.0")
+	})
+
+	T.Run("oversized plain-text body is single-lined and truncated", func(t *testing.T) {
+		t.Parallel()
+		body := bytes.Repeat([]byte("xxxxxxxxxx\n"), 400)
+		err := ErrorFromBody(http.StatusInternalServerError, body)
+		msg := err.Error()
+		assert.True(t, strings.HasPrefix(msg, "server returned 500: "))
+		assert.True(t, strings.HasSuffix(msg, "..."), "truncated snippet should end with ellipsis")
+		assert.NotContains(t, msg, "\n", "snippet must be single-line")
+		assert.Less(t, len(msg), 700, "snippet must be bounded so it doesn't flood the terminal")
+	})
+
+	T.Run("403 with unparseable proxy body surfaces snippet", func(t *testing.T) {
+		t.Parallel()
+		body := []byte(`<html><body>Blocked by WAF rule 4242</body></html>`)
+		err := ErrorFromBody(http.StatusForbidden, body)
+		pe, ok := errors.AsType[*PermissionError](err)
+		require.True(t, ok)
+		msg := pe.Error()
+		assert.Contains(t, msg, "permission denied")
+		assert.Contains(t, msg, "WAF rule 4242")
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.42.0
-	github.com/tiulpin/instill v0.0.0-20260409102126-21f299ecb245
+	github.com/tiulpin/instill v0.0.0-20260521174322-b563ba2627d7
 	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/term v0.42.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,8 @@ github.com/testcontainers/testcontainers-go v0.42.0 h1:He3IhTzTZOygSXLJPMX7n44Xt
 github.com/testcontainers/testcontainers-go v0.42.0/go.mod h1:vZjdY1YmUA1qEForxOIOazfsrdyORJAbhi0bp8plN30=
 github.com/tiulpin/instill v0.0.0-20260409102126-21f299ecb245 h1:GDY9EUD9I7wzMjqx0L21hDlDg1j/RX374081jItBCqc=
 github.com/tiulpin/instill v0.0.0-20260409102126-21f299ecb245/go.mod h1:OxdrM9ElyAp2nLawA1UpPHWVscyOqfsI0+2mZnwEjIU=
+github.com/tiulpin/instill v0.0.0-20260521174322-b563ba2627d7 h1:0XLg2d4I8MPX7a1xQ5QsAFkbP3aEjXIygn74QCMUjtk=
+github.com/tiulpin/instill v0.0.0-20260521174322-b563ba2627d7/go.mod h1:OxdrM9ElyAp2nLawA1UpPHWVscyOqfsI0+2mZnwEjIU=
 github.com/tiulpin/termbook v0.0.0-20260418144716-4da9f77fcd23 h1:l29Z25hirqfjtM2q2ngi1APaxw9XEIIG6oeQU92OEGA=
 github.com/tiulpin/termbook v0.0.0-20260418144716-4da9f77fcd23/go.mod h1:FsYSe+6mgO8oPtycK1ux6z/JVJFpjnpzZWqRb6OFYcc=
 github.com/tklauser/go-sysconf v0.3.16 h1:frioLaCQSsF5Cy1jgRBrzr6t502KIIwQ0MArYICU0nA=

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -270,10 +270,7 @@ func outputAPIResponse(p *output.Printer, body []byte, statusCode int, respHeade
 		if opts.raw && len(body) > 0 {
 			_, _ = fmt.Fprint(p.Out, string(body))
 		}
-		if msg := api.ExtractErrorMessage(body); msg != "" {
-			return fmt.Errorf("%d %s — %s", statusCode, http.StatusText(statusCode), msg)
-		}
-		return fmt.Errorf("request failed with status %d", statusCode)
+		return api.ErrorFromBody(statusCode, body)
 	}
 
 	if len(body) > 0 {
@@ -310,10 +307,7 @@ func fetchAllPages(ctx context.Context, client api.ClientInterface, endpoint str
 		lastStatus = resp.StatusCode
 
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			if len(resp.Body) > 0 {
-				return nil, lastStatus, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, string(resp.Body))
-			}
-			return nil, lastStatus, fmt.Errorf("request failed with status %d", resp.StatusCode)
+			return nil, lastStatus, api.ErrorFromBody(resp.StatusCode, resp.Body)
 		}
 
 		pages = append(pages, resp.Body)

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -192,7 +192,8 @@ func TestAPICommandErrorResponse(T *testing.T) {
 
 	err := rootCmd.Execute()
 	require.Error(T, err, "expected error for 404 response")
-	assert.Contains(T, err.Error(), "404")
+	var nf *api.NotFoundError
+	assert.ErrorAs(T, err, &nf, "404 should classify as NotFoundError")
 }
 
 func TestAPICommandXMLErrorResponse(T *testing.T) {
@@ -210,7 +211,9 @@ func TestAPICommandXMLErrorResponse(T *testing.T) {
 
 	err := rootCmd.Execute()
 	require.Error(T, err, "expected error for 404 response")
-	assert.Contains(T, err.Error(), "404")
+	var nf *api.NotFoundError
+	assert.ErrorAs(T, err, &nf, "404 should classify as NotFoundError")
+	assert.Contains(T, err.Error(), "snapshot-dependencies", "wire message should be preserved")
 }
 
 func TestAPICommand406RetriesWithWildcardAccept(T *testing.T) {
@@ -237,7 +240,8 @@ func TestAPICommand406RetriesWithWildcardAccept(T *testing.T) {
 
 	err := rootCmd.Execute()
 	require.Error(T, err)
-	assert.Contains(T, err.Error(), "404")
+	var nf *api.NotFoundError
+	assert.ErrorAs(T, err, &nf, "404 should classify as NotFoundError")
 	assert.Equal(T, 2, requestCount)
 }
 

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -384,6 +384,38 @@ func TestAPICommandPaginate(T *testing.T) {
 	assert.Equal(T, 2, pageNum, "request count")
 }
 
+func TestAPICommandPaginatePreservesProxyErrorBody(T *testing.T) {
+	pageNum := 0
+	setupMockServerForAPI(T, func(w http.ResponseWriter, r *http.Request) {
+		pageNum++
+		if pageNum == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"count":    1,
+				"nextHref": "/app/rest/builds?start=2",
+				"build":    []map[string]int{{"id": 1}},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`<html><head><title>502 Bad Gateway</title></head><body>nginx/1.18.0</body></html>`))
+	})
+
+	var out bytes.Buffer
+	rootCmd := createTestRootCmd()
+	rootCmd.SetArgs([]string{"api", "/app/rest/builds", "--paginate"})
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+
+	err := rootCmd.Execute()
+	require.Error(T, err)
+	msg := err.Error()
+	assert.Contains(T, msg, "502", "status code must be present")
+	assert.Contains(T, msg, "Bad Gateway", "body snippet must surface the actual server message")
+	assert.Contains(T, msg, "nginx/1.18.0", "body snippet must preserve diagnostic detail (proxy version)")
+}
+
 func TestAPICommandPaginateNoNextHref(T *testing.T) {
 	requestCount := 0
 	setupMockServerForAPI(T, func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Route `tc api` HTTP failures through the typed `api.UserError` classifier so analytics' `error_type` reflects the actual category (`auth` / `permission` / `not_found`) instead of bucketing every `tc api` failure as `internal`.

## Changes

- Rename `errorFromBody` → `ErrorFromBody` in `api/errors_parse.go`; update internal callers and tests.
- `internal/cmd/api/api.go`: replace five ad-hoc `fmt.Errorf("status %d ...")` returns with two `api.ErrorFromBody(status, body)` calls in `outputAPIResponse` and `fetchAllPages`.
- Command-layer tests assert on the typed error (`*api.NotFoundError`) instead of the literal `"404"` substring.

## Design Decisions

The typed classifier already exists and is used by `client.handleErrorResponse` + `UploadDiffChanges`. Reusing it removes a parallel error-formatting path in `cmd/api/api.go` and brings `tc api` UX in line with typed commands (`tc job list`, etc.): same tips, same auto-reauth hint on 401, same wire-message format.

Trade-off: `PermissionError` loses `AuthSource` context (only stamped by `client.handleErrorResponse`), so 403s get the generic permission tip. Easy follow-up if it matters.

No analytics schema change — uses existing `error_type` enum values.

## Example

`tc api app/rest/builds/id:nonsense` now classifies as `not_found` instead of `internal`, matching how typed commands already classify the same failure.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- N/A: not adding a new command/flag
- N/A: not adding a data-producing command
- N/A: not modifying `--json` output
- N/A: no docs-visible behavior change