### PR TITLE
fix(api): teamcity api --input drops body on PUT/POST

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -86,6 +86,10 @@ func (c *Client) debugLogRequest(req *http.Request) {
 	}
 	c.debugLog("> %s %s", req.Method, req.URL.String())
 	c.debugLogHeaders(">", req.Header)
+	// req.ContentLength isn't in req.Header — log it separately so --verbose shows body size.
+	if req.ContentLength > 0 {
+		c.debugLog("> Content-Length: %d", req.ContentLength)
+	}
 }
 
 func (c *Client) debugLogResponse(resp *http.Response) {

--- a/api/client.go
+++ b/api/client.go
@@ -539,10 +539,9 @@ func (c *Client) RawRequest(ctx context.Context, method, path string, body io.Re
 		return nil, err
 	}
 
-	// TeamCity returns 406 when it can only produce XML for an error but the client
-	// requested JSON. Retry with Accept: */* to get the real error.
-	if resp.StatusCode == http.StatusNotAcceptable {
-		resp, err = c.doRawRequest(ctx, method, path, body, headers, "*/*")
+	// Retry only when there's no body — an io.Reader is single-shot and would resend empty.
+	if resp.StatusCode == http.StatusNotAcceptable && body == nil {
+		resp, err = c.doRawRequest(ctx, method, path, nil, headers, "*/*")
 		if err != nil {
 			return nil, err
 		}

--- a/api/client.go
+++ b/api/client.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"runtime"
 	"sort"
@@ -532,6 +533,16 @@ type RawResponse struct {
 	Body       []byte
 }
 
+func hasHeader(headers map[string]string, name string) bool {
+	canonical := http.CanonicalHeaderKey(name)
+	for k := range headers {
+		if http.CanonicalHeaderKey(k) == canonical {
+			return true
+		}
+	}
+	return false
+}
+
 // RawRequest performs a raw HTTP request and returns the response without parsing.
 func (c *Client) RawRequest(ctx context.Context, method, path string, body io.Reader, headers map[string]string) (*RawResponse, error) {
 	if c.ReadOnly && method != "GET" {
@@ -572,6 +583,14 @@ func (c *Client) doRawRequest(ctx context.Context, method, path string, body io.
 	// Per-request headers run last so callers can override Accept / Content-Type / extras.
 	for k, v := range headers {
 		req.Header.Set(k, v)
+	}
+
+	// Non-JSON bodies default to Accept: */* — JSON-only servers would 406 on the response.
+	if body != nil && !hasHeader(headers, "Accept") {
+		mediaType, _, _ := mime.ParseMediaType(req.Header.Get("Content-Type"))
+		if mediaType != "application/json" {
+			req.Header.Set("Accept", "*/*")
+		}
 	}
 
 	c.debugLogRequest(req)

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -643,6 +643,42 @@ func TestDebugLogging(T *testing.T) {
 	})
 }
 
+func TestRawRequestAcceptDefaultForNonJSONBody(T *testing.T) {
+	T.Parallel()
+
+	tests := []struct {
+		name       string
+		method     string
+		body       io.Reader
+		headers    map[string]string
+		wantAccept string
+	}{
+		{"PUT with text/plain body → */*", "PUT", bytes.NewReader([]byte("x")), map[string]string{"Content-Type": "text/plain"}, "*/*"},
+		{"POST with XML body → */*", "POST", bytes.NewReader([]byte("<x/>")), map[string]string{"Content-Type": "application/xml"}, "*/*"},
+		{"PUT with JSON body keeps application/json", "PUT", bytes.NewReader([]byte("{}")), map[string]string{"Content-Type": "application/json"}, "application/json"},
+		{"PUT with JSON body + charset param keeps application/json", "PUT", bytes.NewReader([]byte("{}")), map[string]string{"Content-Type": "application/json; charset=utf-8"}, "application/json"},
+		{"user-set Accept wins over default", "PUT", bytes.NewReader([]byte("x")), map[string]string{"Content-Type": "text/plain", "Accept": "application/xml"}, "application/xml"},
+		{"user-set Accept wins (lowercase key)", "PUT", bytes.NewReader([]byte("x")), map[string]string{"Content-Type": "text/plain", "accept": "application/xml"}, "application/xml"},
+		{"GET (no body) keeps application/json default", "GET", nil, nil, "application/json"},
+	}
+
+	for _, tc := range tests {
+		T.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotAccept string
+			client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				gotAccept = r.Header.Get("Accept")
+				w.WriteHeader(http.StatusOK)
+			})
+
+			_, err := client.RawRequest(T.Context(), tc.method, "/app/rest/x", tc.body, tc.headers)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAccept, gotAccept)
+		})
+	}
+}
+
 func TestRawRequestNoRetryOn406WithBody(T *testing.T) {
 	T.Parallel()
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -611,6 +611,24 @@ func TestDebugLogging(T *testing.T) {
 		assert.Contains(t, captured, "> Authorization: [REDACTED]")
 		assert.Contains(t, captured, "< HTTP/1.1 200 OK")
 		assert.NotContains(t, captured, "test-token")
+		assert.NotContains(t, captured, "> Content-Length", "no request Content-Length on body-less GET")
+	})
+
+	T.Run("logs Content-Length when request has a body", func(t *testing.T) {
+		t.Parallel()
+
+		var buf bytes.Buffer
+		client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		client.DebugFunc = func(format string, args ...any) {
+			fmt.Fprintf(&buf, format+"\n", args...)
+		}
+
+		_, _ = client.RawRequest(T.Context(), "PUT", "/api/test",
+			bytes.NewReader([]byte("hello world")), nil)
+
+		assert.Contains(t, buf.String(), "> Content-Length: 11")
 	})
 
 	T.Run("silent when DebugFunc not set", func(t *testing.T) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -625,6 +625,27 @@ func TestDebugLogging(T *testing.T) {
 	})
 }
 
+func TestRawRequestNoRetryOn406WithBody(T *testing.T) {
+	T.Parallel()
+
+	var attempts int
+	var receivedBody string
+	client := setupTestServer(T, func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		buf, _ := io.ReadAll(r.Body)
+		receivedBody = string(buf)
+		w.WriteHeader(http.StatusNotAcceptable)
+	})
+
+	resp, err := client.RawRequest(T.Context(), "PUT", "/app/rest/x",
+		bytes.NewReader([]byte("hello world")),
+		map[string]string{"Content-Type": "text/plain"})
+	require.NoError(T, err)
+	assert.Equal(T, 1, attempts, "body-bearing 406 must not retry — second attempt would send empty body")
+	assert.Equal(T, "hello world", receivedBody, "first attempt must carry the body")
+	assert.Equal(T, http.StatusNotAcceptable, resp.StatusCode, "406 should propagate")
+}
+
 func TestApproveQueuedBuild(T *testing.T) {
 	T.Parallel()
 


### PR DESCRIPTION
## Summary

Fixes silent body-drop in \`teamcity api --input\` on PUT/POST and the related false-failure for text/plain endpoints. Closes #310. Reported by @wuservices.

## Changes

- \`fix(api): skip 406 retry on body-bearing requests in RawRequest\` — the retry re-used a consumed \`io.Reader\` and sent empty on the second attempt; restrict it to body-less requests.
- \`fix(api): log Content-Length in verbose request debug output\` — \`req.ContentLength\` isn't part of \`req.Header\`, so \`--verbose\` previously hid body size and made the bug invisible.
- \`fix(api): default Accept to */* for non-JSON request bodies\` — endpoints like \`/parameters/script.content\` and \`/comment\` produce text/plain. The CLI's \`Accept: application/json\` default caused TeamCity to 406 the response (the write succeeded server-side, but the user saw \"failed\"). Now matches \`curl\` for non-JSON bodies; explicit user Accept still wins.

## Design Decisions

- Don't buffer the body to enable replay. The original \`io.Reader\` contract streams; buffering would block on long-lived/pipe-driven readers and hold the payload in memory. Skipping the retry also eliminates the duplicate-write risk for non-idempotent methods (POST/PATCH) for free.
- Only auto-switch Accept when \`Content-Type\` is non-JSON. JSON POSTs and body-less GETs are unchanged, so callers parsing JSON responses are unaffected.

## Example

```bash
$ echo "new content" > body.txt
$ teamcity api --verbose -X PUT -H "Content-Type: text/plain" --input body.txt \\
    '/app/rest/buildTypes/MyBuild/steps/step1/parameters/script.content'
[debug] > PUT https://server/app/rest/buildTypes/MyBuild/steps/step1/parameters/script.content
[debug] > Accept: */*
[debug] > Content-Type: text/plain
[debug] > Content-Length: 12
[debug] < HTTP/1.1 200 OK
new content
```

## Test Plan

- [x] Unit tests pass (\`go test ./...\`)
- [x] Linter passes (\`just lint\`)
- [ ] Acceptance tests — N/A, no \`api\` acceptance fixtures touched
- [x] New command/flag — N/A
- [x] Data-producing command — N/A
- [x] \`--json\` output — N/A
- [x] Docs-visible behavior — N/A, fixes documented behavior

Regression tests: \`TestRawRequestNoRetryOn406WithBody\`, \`TestDebugLogging/logs_Content-Length_when_request_has_a_body\` plus a negative GET assertion, and \`TestRawRequestAcceptDefaultForNonJSONBody\` (6 subtests covering text/plain, XML, JSON, user override w/ both casings, and body-less GET).