### PR TITLE
fix(api): stop using http.Client.Timeout for streaming endpoints

### DIFF
--- a/api/builds_artifacts.go
+++ b/api/builds_artifacts.go
@@ -104,7 +104,7 @@ func (c *Client) GetBuildLogStream(ctx context.Context, buildID string) (io.Read
 	return resp.Body, nil
 }
 
-// GetBuildLog returns the build log (accepts ID or #number); for large logs prefer GetBuildLogStream to avoid buffering in memory.
+// GetBuildLog returns the build log (accepts ID or #number); for large logs prefer GetBuildLogStream to avoid buffering in memory. Bypasses HTTPClient.Timeout — bound the read via ctx if needed.
 func (c *Client) GetBuildLog(ctx context.Context, buildID string) (string, error) {
 	rc, err := c.GetBuildLogStream(ctx, buildID)
 	if err != nil {

--- a/api/builds_artifacts.go
+++ b/api/builds_artifacts.go
@@ -115,24 +115,30 @@ func (c *Client) DownloadArtifactTo(ctx context.Context, buildID, artifactPath s
 	return io.Copy(w, resp.Body)
 }
 
-// GetBuildLog returns the build log (accepts ID or #number)
-func (c *Client) GetBuildLog(ctx context.Context, buildID string) (string, error) {
+// GetBuildLogStream streams the raw build log (accepts ID or #number); caller must Close the returned reader.
+func (c *Client) GetBuildLogStream(ctx context.Context, buildID string) (io.ReadCloser, error) {
 	id, err := c.ResolveBuildID(ctx, buildID)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	path := "/downloadBuildLog.html?buildId=" + id
+	resp, err := c.doGetStream(ctx, "/downloadBuildLog.html?buildId="+id)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Body, nil
+}
 
-	resp, err := c.doGetStream(ctx, path)
+// GetBuildLog returns the build log (accepts ID or #number); for large logs prefer GetBuildLogStream to avoid buffering in memory.
+func (c *Client) GetBuildLog(ctx context.Context, buildID string) (string, error) {
+	rc, err := c.GetBuildLogStream(ctx, buildID)
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { _ = rc.Close() }()
 
-	data, err := io.ReadAll(resp.Body)
+	data, err := io.ReadAll(rc)
 	if err != nil {
 		return "", err
 	}
-
 	return string(data), nil
 }

--- a/api/builds_artifacts.go
+++ b/api/builds_artifacts.go
@@ -2,10 +2,8 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"net/url"
 	"strings"
 )
@@ -84,33 +82,11 @@ func (c *Client) DownloadArtifactTo(ctx context.Context, buildID, artifactPath s
 	}
 
 	path := fmt.Sprintf("/app/rest/builds/id:%s/artifacts/content/%s", id, encodeArtifactPath(artifactPath))
-	reqURL := fmt.Sprintf("%s%s", c.BaseURL, c.apiPath(path))
-	streamClient := &http.Client{Transport: c.HTTPClient.Transport}
-
-	resp, err := withRetry(ctx, ReadRetry, func() (*http.Response, error) {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
-		if err != nil {
-			return nil, err
-		}
-		c.setAuth(req)
-		c.applyStandardHeaders(req)
-		return streamClient.Do(req)
-	})
+	resp, err := c.streamRequest(ctx, path)
 	if err != nil {
-		if resp != nil {
-			defer func() { _ = resp.Body.Close() }()
-			return 0, c.handleErrorResponse(resp)
-		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return 0, err
-		}
-		return 0, &NetworkError{URL: c.BaseURL, Cause: err}
+		return 0, err
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return 0, c.handleErrorResponse(resp)
-	}
 
 	return io.Copy(w, resp.Body)
 }
@@ -121,7 +97,7 @@ func (c *Client) GetBuildLogStream(ctx context.Context, buildID string) (io.Read
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.doGetStream(ctx, "/downloadBuildLog.html?buildId="+id)
+	resp, err := c.streamRequest(ctx, "/downloadBuildLog.html?buildId="+id)
 	if err != nil {
 		return nil, err
 	}

--- a/api/builds_artifacts_test.go
+++ b/api/builds_artifacts_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 
@@ -81,4 +82,30 @@ func TestGetBuildLog(t *testing.T) {
 	log, err := client.GetBuildLog(t.Context(), "1")
 	require.NoError(t, err)
 	assert.Contains(t, log, "Build started")
+}
+
+func TestGetBuildLogStream(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/rest/builds" || r.URL.Path == "/httpAuth/app/rest/builds" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
+			return
+		}
+		assert.Contains(t, r.URL.Path, "/downloadBuildLog.html")
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte("chunk-one\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		_, _ = w.Write([]byte("chunk-two\n"))
+	})
+
+	rc, err := client.GetBuildLogStream(t.Context(), "1")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rc.Close() })
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "chunk-one\nchunk-two\n", string(data))
 }

--- a/api/builds_artifacts_test.go
+++ b/api/builds_artifacts_test.go
@@ -86,32 +86,6 @@ func TestGetBuildLog(t *testing.T) {
 	assert.Contains(t, log, "Build started")
 }
 
-func TestGetBuildLogStream(t *testing.T) {
-	t.Parallel()
-	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/app/rest/builds" || r.URL.Path == "/httpAuth/app/rest/builds" {
-			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
-			return
-		}
-		assert.Contains(t, r.URL.Path, "/downloadBuildLog.html")
-		flusher, _ := w.(http.Flusher)
-		_, _ = w.Write([]byte("chunk-one\n"))
-		if flusher != nil {
-			flusher.Flush()
-		}
-		_, _ = w.Write([]byte("chunk-two\n"))
-	})
-
-	rc, err := client.GetBuildLogStream(t.Context(), "1")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = rc.Close() })
-
-	data, err := io.ReadAll(rc)
-	require.NoError(t, err)
-	assert.Equal(t, "chunk-one\nchunk-two\n", string(data))
-}
-
 func TestGetBuildLogStreamHonorsCheckRedirect(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/api/builds_artifacts_test.go
+++ b/api/builds_artifacts_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -108,4 +110,31 @@ func TestGetBuildLogStream(t *testing.T) {
 	data, err := io.ReadAll(rc)
 	require.NoError(t, err)
 	assert.Equal(t, "chunk-one\nchunk-two\n", string(data))
+}
+
+func TestGetBuildLogStreamBypassesHTTPClientTimeout(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/app/rest/builds") {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
+			return
+		}
+		flusher, _ := w.(http.Flusher)
+		_, _ = w.Write([]byte("first\n"))
+		if flusher != nil {
+			flusher.Flush()
+		}
+		time.Sleep(250 * time.Millisecond)
+		_, _ = w.Write([]byte("second\n"))
+	})
+	client.HTTPClient.Timeout = 100 * time.Millisecond
+
+	rc, err := client.GetBuildLogStream(t.Context(), "1")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rc.Close() })
+
+	data, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	assert.Equal(t, "first\nsecond\n", string(data))
 }

--- a/api/builds_artifacts_test.go
+++ b/api/builds_artifacts_test.go
@@ -112,6 +112,34 @@ func TestGetBuildLogStream(t *testing.T) {
 	assert.Equal(t, "chunk-one\nchunk-two\n", string(data))
 }
 
+func TestGetBuildLogStreamHonorsCheckRedirect(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/app/rest/builds"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
+		case r.URL.Path == "/after-redirect":
+			_, _ = w.Write([]byte("followed"))
+		default:
+			w.Header().Set("Location", "/after-redirect")
+			w.WriteHeader(http.StatusFound)
+		}
+	})
+
+	rc, err := client.GetBuildLogStream(t.Context(), "1")
+	require.NoError(t, err)
+	data, _ := io.ReadAll(rc)
+	_ = rc.Close()
+	assert.Equal(t, "followed", string(data))
+
+	client.HTTPClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	_, err = client.GetBuildLogStream(t.Context(), "1")
+	require.Error(t, err)
+}
+
 func TestGetBuildLogStreamBypassesHTTPClientTimeout(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/api/builds_artifacts_test.go
+++ b/api/builds_artifacts_test.go
@@ -127,7 +127,7 @@ func TestGetBuildLogStreamBypassesHTTPClientTimeout(t *testing.T) {
 		if flusher != nil {
 			flusher.Flush()
 		}
-		time.Sleep(250 * time.Millisecond)
+		time.Sleep(1 * time.Second)
 		_, _ = w.Write([]byte("second\n"))
 	})
 	client.HTTPClient.Timeout = 100 * time.Millisecond

--- a/api/client.go
+++ b/api/client.go
@@ -131,7 +131,7 @@ func WithAPIVersion(version string) ClientOption {
 	}
 }
 
-// WithTimeout sets a wall-clock cap on every HTTP request (including body read); leave unset to rely on transport + context deadlines.
+// WithTimeout sets a wall-clock cap on standard HTTP requests; streaming endpoints (build logs, artifacts) bypass it by design and must be bounded via the request context.
 func WithTimeout(timeout time.Duration) ClientOption {
 	return func(c *Client) {
 		c.HTTPClient.Timeout = timeout

--- a/api/client.go
+++ b/api/client.go
@@ -188,11 +188,11 @@ func WithExtraHeaders(h map[string]string) ClientOption {
 }
 
 // newClientBase returns a Client populated with shared defaults: trimmed BaseURL, default HTTPClient, env extras.
-// HTTPClient.Timeout intentionally unset — server-alive detection lives on Transport.ResponseHeaderTimeout, deadlines come from context.
 func newClientBase(baseURL string) *Client {
 	return &Client{
 		BaseURL: strings.TrimSuffix(baseURL, "/"),
 		HTTPClient: &http.Client{
+			Timeout:   30 * time.Second,
 			Transport: defaultTransport(),
 		},
 		serverInfo:   &serverInfoCache{},
@@ -412,6 +412,39 @@ func (c *Client) doGetStream(ctx context.Context, path string) (*http.Response, 
 		}
 		return nil, &NetworkError{URL: c.BaseURL, Cause: err}
 	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		defer func() { _ = resp.Body.Close() }()
+		return nil, c.handleErrorResponse(resp)
+	}
+	return resp, nil
+}
+
+// streamRequest GETs path with ReadRetry on a client that shares c.HTTPClient.Transport but omits the wall-clock Timeout; intended for endpoints with large or open-ended response bodies (build logs, artifacts).
+func (c *Client) streamRequest(ctx context.Context, path string) (*http.Response, error) {
+	reqURL := fmt.Sprintf("%s%s", c.BaseURL, c.apiPath(path))
+	client := &http.Client{Transport: c.HTTPClient.Transport}
+
+	resp, err := withRetry(ctx, ReadRetry, func() (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.setAuth(req)
+		c.applyStandardHeaders(req)
+		c.debugLogRequest(req)
+		return client.Do(req)
+	})
+	if err != nil {
+		if resp != nil {
+			defer func() { _ = resp.Body.Close() }()
+			return nil, c.handleErrorResponse(resp)
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return nil, &NetworkError{URL: c.BaseURL, Cause: err}
+	}
+	c.debugLogResponse(resp)
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer func() { _ = resp.Body.Close() }()
 		return nil, c.handleErrorResponse(resp)

--- a/api/client.go
+++ b/api/client.go
@@ -131,7 +131,7 @@ func WithAPIVersion(version string) ClientOption {
 	}
 }
 
-// WithTimeout sets a custom HTTP timeout
+// WithTimeout sets a wall-clock cap on every HTTP request (including body read); leave unset to rely on transport + context deadlines.
 func WithTimeout(timeout time.Duration) ClientOption {
 	return func(c *Client) {
 		c.HTTPClient.Timeout = timeout
@@ -188,11 +188,11 @@ func WithExtraHeaders(h map[string]string) ClientOption {
 }
 
 // newClientBase returns a Client populated with shared defaults: trimmed BaseURL, default HTTPClient, env extras.
+// HTTPClient.Timeout is intentionally unset so streaming endpoints (logs, artifacts) aren't capped by a wall-clock deadline; "server is alive" detection lives on the transport (ResponseHeaderTimeout) and command-level deadlines come from context.
 func newClientBase(baseURL string) *Client {
 	return &Client{
 		BaseURL: strings.TrimSuffix(baseURL, "/"),
 		HTTPClient: &http.Client{
-			Timeout:   30 * time.Second,
 			Transport: defaultTransport(),
 		},
 		serverInfo:   &serverInfoCache{},

--- a/api/client.go
+++ b/api/client.go
@@ -419,10 +419,11 @@ func (c *Client) doGetStream(ctx context.Context, path string) (*http.Response, 
 	return resp, nil
 }
 
-// streamRequest GETs path with ReadRetry on a client that shares c.HTTPClient.Transport but omits the wall-clock Timeout; intended for endpoints with large or open-ended response bodies (build logs, artifacts).
+// streamRequest GETs path with ReadRetry on a copy of c.HTTPClient that omits the wall-clock Timeout but preserves Transport/Jar/CheckRedirect; intended for endpoints with large or open-ended response bodies (build logs, artifacts).
 func (c *Client) streamRequest(ctx context.Context, path string) (*http.Response, error) {
 	reqURL := fmt.Sprintf("%s%s", c.BaseURL, c.apiPath(path))
-	client := &http.Client{Transport: c.HTTPClient.Transport}
+	streamClient := *c.HTTPClient
+	streamClient.Timeout = 0
 
 	resp, err := withRetry(ctx, ReadRetry, func() (*http.Response, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
@@ -432,7 +433,7 @@ func (c *Client) streamRequest(ctx context.Context, path string) (*http.Response
 		c.setAuth(req)
 		c.applyStandardHeaders(req)
 		c.debugLogRequest(req)
-		return client.Do(req)
+		return streamClient.Do(req)
 	})
 	if err != nil {
 		if resp != nil {

--- a/api/client.go
+++ b/api/client.go
@@ -188,7 +188,7 @@ func WithExtraHeaders(h map[string]string) ClientOption {
 }
 
 // newClientBase returns a Client populated with shared defaults: trimmed BaseURL, default HTTPClient, env extras.
-// HTTPClient.Timeout is intentionally unset so streaming endpoints (logs, artifacts) aren't capped by a wall-clock deadline; "server is alive" detection lives on the transport (ResponseHeaderTimeout) and command-level deadlines come from context.
+// HTTPClient.Timeout intentionally unset — server-alive detection lives on Transport.ResponseHeaderTimeout, deadlines come from context.
 func newClientBase(baseURL string) *Client {
 	return &Client{
 		BaseURL: strings.TrimSuffix(baseURL, "/"),

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -172,11 +172,11 @@ func TestClientOptions(T *testing.T) {
 	assert.Equal(T, 60*time.Second, client.HTTPClient.Timeout)
 }
 
-func TestDefaultHTTPClientHasNoWallClockTimeout(T *testing.T) {
+func TestDefaultHTTPClientHasWallClockTimeout(T *testing.T) {
 	T.Parallel()
 
 	client := NewClient("https://example.com", "token")
-	assert.Zero(T, client.HTTPClient.Timeout)
+	assert.Equal(T, 30*time.Second, client.HTTPClient.Timeout)
 }
 
 func TestDefaultTransportSetsResponseHeaderTimeout(T *testing.T) {

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -172,6 +172,29 @@ func TestClientOptions(T *testing.T) {
 	assert.Equal(T, 60*time.Second, client.HTTPClient.Timeout)
 }
 
+func TestDefaultHTTPClientHasNoWallClockTimeout(T *testing.T) {
+	T.Parallel()
+
+	client := NewClient("https://example.com", "token")
+	assert.Zero(T, client.HTTPClient.Timeout, "default client must not impose a wall-clock cap; streaming endpoints depend on it being unset")
+}
+
+func TestDefaultTransportSetsResponseHeaderTimeout(T *testing.T) {
+	T.Parallel()
+
+	rt := defaultTransport()
+	var tr *http.Transport
+	switch v := rt.(type) {
+	case *http.Transport:
+		tr = v
+	case *pemFallbackTransport:
+		tr = v.platform.(*http.Transport)
+	default:
+		T.Fatalf("unexpected transport type %T", rt)
+	}
+	assert.Equal(T, responseHeaderTimeout, tr.ResponseHeaderTimeout)
+}
+
 func TestCheckVersion(T *testing.T) {
 	T.Parallel()
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -176,7 +176,7 @@ func TestDefaultHTTPClientHasNoWallClockTimeout(T *testing.T) {
 	T.Parallel()
 
 	client := NewClient("https://example.com", "token")
-	assert.Zero(T, client.HTTPClient.Timeout, "default client must not impose a wall-clock cap; streaming endpoints depend on it being unset")
+	assert.Zero(T, client.HTTPClient.Timeout)
 }
 
 func TestDefaultTransportSetsResponseHeaderTimeout(T *testing.T) {

--- a/api/interface.go
+++ b/api/interface.go
@@ -49,6 +49,7 @@ type ClientInterface interface {
 	RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, error)
 	CancelBuild(buildID string, comment string) error
 	GetBuildLog(ctx context.Context, buildID string) (string, error)
+	GetBuildLogStream(ctx context.Context, buildID string) (io.ReadCloser, error)
 	GetBuildMessages(ctx context.Context, buildID string, opts BuildMessagesOptions) (*BuildMessagesResponse, error)
 	PinBuild(buildID string, comment string) error
 	UnpinBuild(buildID string) error

--- a/api/tls.go
+++ b/api/tls.go
@@ -10,16 +10,22 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
+
+// responseHeaderTimeout bounds how long we wait for the server to start sending response headers; body reads are unbounded so streaming endpoints (logs, artifacts) work for large payloads.
+const responseHeaderTimeout = 30 * time.Second
 
 // defaultTransport returns a transport with PEM fallback when the platform TLS verifier is blocked.
 var defaultTransport = sync.OnceValue(func() http.RoundTripper {
 	platform := http.DefaultTransport.(*http.Transport).Clone()
+	platform.ResponseHeaderTimeout = responseHeaderTimeout
 	pool := loadRootCAs()
 	if pool == nil {
 		return platform
 	}
 	pem := http.DefaultTransport.(*http.Transport).Clone()
+	pem.ResponseHeaderTimeout = responseHeaderTimeout
 	pem.TLSClientConfig = &tls.Config{RootCAs: pool}
 	return &pemFallbackTransport{platform: platform, pem: pem}
 })

--- a/api/tls.go
+++ b/api/tls.go
@@ -13,7 +13,6 @@ import (
 	"time"
 )
 
-// responseHeaderTimeout bounds how long we wait for the server to start sending response headers; body reads are unbounded so streaming endpoints (logs, artifacts) work for large payloads.
 const responseHeaderTimeout = 30 * time.Second
 
 // defaultTransport returns a transport with PEM fallback when the platform TLS verifier is blocked.

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -130,6 +130,17 @@ func TestRunLog(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, ts.Factory, "run", "log", testBuildID)
 }
 
+func TestRunLogStreamErrorSurfaces(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	ts.Handle("GET /downloadBuildLog.html", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "9999")
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("partial line without newline"))
+	})
+	err := cmdtest.CaptureErr(T, ts.Factory, "run", "log", testBuildID)
+	assert.Contains(T, err.Error(), "failed to read run log")
+}
+
 func TestRunLogJSON(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "log", testBuildID, "--json")

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -132,9 +132,12 @@ func TestRunLog(T *testing.T) {
 
 func TestRunLogRaw(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
+	ts.Handle("GET /downloadBuildLog.html", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("plain text line\n"))
+	})
 	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "log", testBuildID, "--raw")
-	assert.Contains(T, got, "Build started")
-	assert.Contains(T, got, "Build finished")
+	assert.Contains(T, got, "plain text line")
+	assert.NotContains(T, got, "  plain text line")
 }
 
 func TestRunLogEmpty(T *testing.T) {

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -130,6 +130,22 @@ func TestRunLog(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, ts.Factory, "run", "log", testBuildID)
 }
 
+func TestRunLogRaw(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "log", testBuildID, "--raw")
+	assert.Contains(T, got, "Build started")
+	assert.Contains(T, got, "Build finished")
+}
+
+func TestRunLogEmpty(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	ts.Handle("GET /downloadBuildLog.html", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "log", testBuildID)
+	assert.Contains(T, got, "No log available")
+}
+
 func TestRunLogStreamErrorSurfaces(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	ts.Handle("GET /downloadBuildLog.html", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -266,7 +266,6 @@ func runLogFull(f *cmdutil.Factory, client api.ClientInterface, runID string, op
 	}
 	defer func() { _ = rc.Close() }()
 
-	// Peek the first byte so we can show an "empty" hint without buffering the whole log.
 	br := bufio.NewReader(rc)
 	if _, err := br.Peek(1); err != nil {
 		if errors.Is(err, io.EOF) {
@@ -276,21 +275,35 @@ func runLogFull(f *cmdutil.Factory, client api.ClientInterface, runID string, op
 		return fmt.Errorf("failed to get run log: %w", err)
 	}
 
+	var streamErr error
 	output.WithPager(f.Printer.Out, func(w io.Writer) {
 		if opts.raw {
-			_, _ = io.Copy(w, br)
+			if _, err := io.Copy(w, br); err != nil {
+				streamErr = err
+				return
+			}
 			_, _ = fmt.Fprintln(w)
 			return
 		}
-		scanner := bufio.NewScanner(br)
-		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
-		for scanner.Scan() {
-			formatted := formatLogLine(scanner.Text())
-			if formatted != "" {
-				_, _ = fmt.Fprintln(w, formatted)
+		for {
+			line, err := br.ReadString('\n')
+			if line != "" {
+				formatted := formatLogLine(strings.TrimSuffix(line, "\n"))
+				if formatted != "" {
+					_, _ = fmt.Fprintln(w, formatted)
+				}
+			}
+			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					streamErr = err
+				}
+				return
 			}
 		}
 	})
+	if streamErr != nil {
+		return fmt.Errorf("failed to read run log: %w", streamErr)
+	}
 	return nil
 }
 

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -1,8 +1,10 @@
 package run
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -250,30 +252,40 @@ func runRunLog(f *cmdutil.Factory, runID string, opts *runLogOptions) error {
 }
 
 func runLogFull(f *cmdutil.Factory, client api.ClientInterface, runID string, opts *runLogOptions) error {
-	log, err := client.GetBuildLog(f.Context(), runID)
+	if opts.json {
+		log, err := client.GetBuildLog(f.Context(), runID)
+		if err != nil {
+			return fmt.Errorf("failed to get run log: %w", err)
+		}
+		return f.Printer.PrintJSON(buildLogJSON{RunID: runID, Log: log})
+	}
+
+	rc, err := client.GetBuildLogStream(f.Context(), runID)
 	if err != nil {
 		return fmt.Errorf("failed to get run log: %w", err)
 	}
+	defer func() { _ = rc.Close() }()
 
-	if opts.json {
-		return f.Printer.PrintJSON(buildLogJSON{
-			RunID: runID,
-			Log:   log,
-		})
-	}
-
-	if log == "" {
-		f.Printer.Empty("No log available", output.TipNoLogFor(runID))
-		return nil
+	// Peek the first byte so we can show an "empty" hint without buffering the whole log.
+	br := bufio.NewReader(rc)
+	if _, err := br.Peek(1); err != nil {
+		if errors.Is(err, io.EOF) {
+			f.Printer.Empty("No log available", output.TipNoLogFor(runID))
+			return nil
+		}
+		return fmt.Errorf("failed to get run log: %w", err)
 	}
 
 	output.WithPager(f.Printer.Out, func(w io.Writer) {
 		if opts.raw {
-			_, _ = fmt.Fprintln(w, log)
+			_, _ = io.Copy(w, br)
+			_, _ = fmt.Fprintln(w)
 			return
 		}
-		for line := range strings.SplitSeq(log, "\n") {
-			formatted := formatLogLine(line)
+		scanner := bufio.NewScanner(br)
+		scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			formatted := formatLogLine(scanner.Text())
 			if formatted != "" {
 				_, _ = fmt.Fprintln(w, formatted)
 			}


### PR DESCRIPTION
## Summary

Fixes #309. The 30s `http.Client.Timeout` in `api/client.go` is a wall-clock cap on the entire HTTP exchange *including body read*, so any long log fetch dies with `request canceled (Client.Timeout or context cancellation while reading body)`. Removing it and replacing with `Transport.ResponseHeaderTimeout` (server-alive detection only) fixes the reported error without introducing a user-facing knob. `run log` also gets a streaming body reader so multi-MB logs no longer buffer in memory before they show up.

## Changes

- `api/client.go` — drop `Timeout: 30 * time.Second` from the default `http.Client`; HTTP-level deadlines now live on the transport, command-level deadlines come from `context`.
- `api/tls.go` — set `ResponseHeaderTimeout: 30 * time.Second` on the cloned transports (platform and PEM fallback) so we still detect a dead server within 30s while the body streams unbounded.
- `api/builds_artifacts.go` — add `GetBuildLogStream(ctx, buildID) (io.ReadCloser, error)`; reimplement `GetBuildLog` (string) as a thin `io.ReadAll` wrapper.
- `api/interface.go` — surface `GetBuildLogStream` on `ClientInterface`.
- `internal/cmd/run/log.go` — `runLogFull` peeks one byte for the empty-state hint, then streams through `bufio.Scanner` (1 MiB line cap) line-by-line instead of `strings.SplitSeq` over a giant string.
- Tests: `TestDefaultHTTPClientHasNoWallClockTimeout`, `TestDefaultTransportSetsResponseHeaderTimeout`, `TestGetBuildLogStream` (chunked-transfer assertion via `http.Flusher`).

## Design Decisions

- **No global `--timeout` flag.** The 30s `Client.Timeout` is the actual bug; once it's gone, per-command timeouts on `run watch`, `run download`, `agent exec` continue to cover the cases where a deadline makes sense. `gh` ships without a global timeout for the same reason — `Client.Timeout` conflates "server is unresponsive" with "this response is large," and a user-tunable hard cap doesn't fix that conflation.
- **`ResponseHeaderTimeout` vs `Client.Timeout`.** `ResponseHeaderTimeout` only bounds the wait for the first response header byte; once headers arrive, body reads stream as long as the server keeps sending. This is exactly what streaming endpoints (logs, artifacts) need. `DownloadArtifactTo` already worked around `Client.Timeout` by constructing a fresh `http.Client` per stream — that workaround is now unnecessary for new callers but is left untouched.
- **`WithTimeout` ClientOption preserved.** Library users who want an explicit wall-clock cap can still opt in; the default just doesn't impose one.
- **`GetBuildLog` kept for `--json`, `run diff`, TUI.** Those callers need the full log as a string; only `runLogFull` (interactive view) was rewritten to stream.

## Example

Before — large logs failed at 30s:

```
$ teamcity run log 592419
Error: failed to get run log: net/http: request canceled (Client.Timeout or context cancellation while reading body)
```

After — same command on a real 1.86 MB / 8251-line log:

```
$ teamcity run log 955945951
  Build 'Ultimate / Master / CIDR Trunk / … STM32 DevBuild Tests (macOS, Nova)' #336, default branch 'master'
  …
[12:51:11] Build finished
```

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A locally; will run in CI
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A (no new flags)
- [x] If adding a data-producing command: includes `--json` support — N/A (existing `--json` path preserved)
- [x] If modifying `--json` output: no field removals/renames (additive only) — output unchanged
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A (behavior is purely "doesn't fail spuriously")