### PR TITLE
feat(skill): hint to install skill when used from an AI agent without it

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -131,6 +131,7 @@ func Execute(ctx context.Context) error {
 	if !f.JSONOutput && executedCmd != nil && jsonOutputEnabled(executedCmd) {
 		f.JSONOutput = true
 	}
+	maybePromoteSkillInstall(f, executedCmd, err)
 	if err != nil && isCategory(err, api.CatAuth) && !f.JSONOutput {
 		tryAutoReauth(f)
 	}

--- a/internal/cmd/skill_hint.go
+++ b/internal/cmd/skill_hint.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/tiulpin/instill"
+	"golang.org/x/term"
+)
+
+// maybePromoteSkillInstall nudges the user to install the teamcity-cli skill when running from a detected AI agent that lacks it.
+func maybePromoteSkillInstall(f *cmdutil.Factory, cmd *cobra.Command, runErr error) {
+	if f == nil || cmd == nil || runErr != nil || f.Quiet || f.JSONOutput || f.NoInput {
+		return
+	}
+	if p := cmd.Parent(); p != nil && p.Name() == "skill" {
+		return
+	}
+	errFile, ok := f.Printer.ErrOut.(*os.File)
+	if !ok || !term.IsTerminal(int(errFile.Fd())) {
+		return
+	}
+	r := instill.DetectRuntime()
+	if r == nil {
+		return
+	}
+	opts := instill.Options{Agents: []string{r.Name}, ProjectDir: "."}
+	for _, global := range []bool{true, false} {
+		opts.Global = global
+		if v, err := instill.InstalledVersion("teamcity-cli", opts); err != nil || v != "" {
+			return
+		}
+	}
+	_, _ = fmt.Fprintln(f.Printer.ErrOut, "\n"+output.FormatTip(output.TipInstallSkillFor(r.DisplayName)))
+}

--- a/internal/output/tips.go
+++ b/internal/output/tips.go
@@ -77,3 +77,11 @@ func TipRegisterGitHubApp(owner string) string {
 
 // TipDockerServiceAccount nudges users away from personal Docker passwords.
 const TipDockerServiceAccount = "Use a service account / robot user, not a personal password"
+
+// TipInstallSkillFor formats the promotion shown when an AI agent runtime is detected but the teamcity-cli skill isn't installed for it.
+func TipInstallSkillFor(agentDisplayName string) string {
+	return fmt.Sprintf("Install the TeamCity skill for %s — run %s",
+		Cyan(agentDisplayName),
+		Cyan(`"teamcity skill install"`),
+	)
+}


### PR DESCRIPTION
## Summary

Closes #282. When `teamcity` is launched *by an AI agent* (`instill.DetectRuntime()` — `AI_AGENT`, `CLAUDECODE`, `CURSOR_AGENT`, …) and the `teamcity-cli` skill isn't installed for that agent, print a one-line tip pointing at `teamcity skill install`. Self-clears once the skill is installed.

## Changes

- `internal/cmd/skill_hint.go` — new `maybePromoteSkillInstall`; gates on runtime detection + install check (project & global), suppressed for `--json`/`--quiet`/`--no-input`/non-TTY/errors/`teamcity skill ...`.
- `internal/cmd/root.go` — single call site in `Execute` after `f.JSONOutput` is finalized.
- `internal/output/tips.go` — `TipInstallSkillFor` joins the existing tip catalog.

## Design Decisions

No persistent state, no env-var kill switch — the hint disappears the moment the install-check passes, so there's nothing to throttle or unset.

## Example

```bash
$ AI_AGENT=claude-code teamcity run list
…run table…

Tip: Install the TeamCity skill for Claude Code — run "teamcity skill install"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A, no command/flag surface changed
- [ ] If adding a new command/flag: N/A
- [ ] If adding a data-producing command: N/A
- [ ] If modifying `--json` output: N/A
- [ ] If changing docs-visible behavior: N/A — runtime nudge, not part of documented surface