### PR TITLE
docs(agents): codify lean code, one-line comments, and lean PR descriptions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,28 +1,32 @@
+<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->
+
 ## Summary
 
-<!-- What does this PR do? Link related issues with "Fixes #123" -->
+<!-- One paragraph. What does this PR do, and why? Link related issues with "Fixes #123". -->
 
 
 
 ## Changes
 
-<!-- Key changes, organized by area. Delete empty sections. -->
+<!-- Short bullet list of key changes; group by area if useful. Keep terse. -->
 
 -
 
 ## Design Decisions
 
-<!-- Explain non-obvious choices. Delete section if straightforward. -->
+<!-- Non-obvious choices and trade-offs. Write "Straightforward." if there are none. -->
 
 ## Example
 
-<!-- For CLI changes: show command + output. Delete if not applicable. -->
+<!-- For CLI changes: show command + output. Write "N/A — not user-visible." if not applicable. -->
 
 ```bash
 teamcity <command>
 ```
 
 ## Test Plan
+
+<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->
 
 - [ ] Unit tests pass (`just unit`)
 - [ ] Linter passes (`just lint`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,20 @@ just docs-generate  # regenerate CLI command reference
 just record-gifs <name>  # record GIF from docs/tapes/<name>.tape → docs/images/
 ```
 
+## Code style
+
+- **Start lean.** First draft is the bare minimum — the observable behavior plus the guards needed to make it correct. Don't pre-emptively add throttle files, `*_NO_*` env knobs, marker state, helper helpers, or "in case" escape hatches. Add them when a real signal asks for them.
+- **One-line comments by default.** Single-line godoc on exported symbols; only wrap when an invariant or trade-off truly needs the room.
+- **Reuse what's there before inventing.** Output goes through `internal/output` — tip strings live in `output/tips.go` and render via `output.FormatTip`; status messages via `output.Printer`. Search for an existing helper before adding a parallel path.
+- **Verify visible behavior before claiming done.** For runtime/UX changes, build (`just build`) and exercise the binary — the `verify` and `run` skills exist for this. Type-check passing ≠ feature works.
+
 ## Commits and PRs
 
 - Don't commit unless asked.
 - Conventional format: `feat(scope):`, `fix(scope):`, `refactor(scope):`.
-- **Always respect `.github/PULL_REQUEST_TEMPLATE.md` when opening a PR.** Read the
-  template before writing the body, fill in every section it defines (don't drop
-  any), and don't invent extra sections. If a section doesn't apply, say so
-  explicitly rather than silently omitting it.
+- **Subject line only by default.** Recent commits are single-line; push the *why* into the PR description, not the commit body. Add a body only when context genuinely won't fit anywhere else.
+- **Always respect `.github/PULL_REQUEST_TEMPLATE.md` when opening a PR.** Fill every section the template defines — its `<!-- Delete ... -->` hints are misleading, never drop a section. Write `N/A — <reason>` for sections that don't apply. Don't invent extra sections.
+- **PR descriptions stay lean.** Summary fits a paragraph; Changes is a short bullet list; no marketing copy, no restated diff. If Design Decisions has nothing non-obvious, write `Straightforward.` and move on.
 
 ## Terminology
 


### PR DESCRIPTION
## Summary

Codify three conventions that came out of #317: subject-line-only commits, one-line godoc comments, and lean PR descriptions. Also fix the PR template's `<!-- Delete ... -->` hints, which directly contradicted AGENTS.md's "fill every section" rule.

## Changes

- `AGENTS.md` — new **Code style** section (lean first, one-line comments, reuse `internal/output` helpers, verify visible behavior). Extended **Commits and PRs** with one-line subjects and lean-PR-description guidance.
- `.github/PULL_REQUEST_TEMPLATE.md` — replaced "Delete section if ..." comments with "write N/A — <reason>" guidance, added a header reminder that every section stays.

## Design Decisions

Straightforward.

## Example

N/A — not user-visible.

## Test Plan

- [x] Linter passes (`just lint`) — N/A, docs-only
- [ ] Unit tests pass (`just unit`) — N/A, docs-only
- [ ] Acceptance tests pass (`just acceptance`) — N/A, docs-only
- [ ] If adding a new command/flag: N/A
- [ ] If adding a data-producing command: N/A
- [ ] If modifying \`--json\` output: N/A
- [ ] If changing docs-visible behavior: N/A — these are contributor docs, not user docs