### PR TITLE
fix: use ASCII fallbacks for Unicode symbols on Windows

### DIFF
--- a/internal/analytics/validate.go
+++ b/internal/analytics/validate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	fus "github.com/JetBrains/fus-reporting-api-go"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 )
 
 // SchemeFinding is a single client-side-validation diagnostic against a sample event.
@@ -23,7 +24,7 @@ func (f SchemeFinding) String() string {
 	if f.Field != "" {
 		loc += "." + f.Field
 	}
-	return loc + " → " + f.Got
+	return loc + " " + output.Arrow + " " + f.Got
 }
 
 // SampleEvents returns one canonical event per (group, event_id) covering every declared field.

--- a/internal/cmd/agent/agent_jobs.go
+++ b/internal/cmd/agent/agent_jobs.go
@@ -137,7 +137,7 @@ func showIncompatibleJobs(p *output.Printer, client api.ClientInterface, agentID
 		if c.Reasons != nil && len(c.Reasons.Reasons) > 0 {
 			_, _ = fmt.Fprintf(p.Out, "  Reasons:\n")
 			for _, reason := range c.Reasons.Reasons {
-				_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red("•"), reason)
+				_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red(output.Bullet), reason)
 			}
 		}
 		_, _ = fmt.Fprintln(p.Out)

--- a/internal/cmd/agent/terminal.go
+++ b/internal/cmd/agent/terminal.go
@@ -166,7 +166,7 @@ func connectToAgent(f *cmdutil.Factory, ctx context.Context, nameOrID string, sh
 		return nil, err
 	}
 
-	_, _ = fmt.Fprintf(f.Printer.Out, "%s %s\n", output.Green("✓"), agentURL)
+	_, _ = fmt.Fprintf(f.Printer.Out, "%s %s\n", output.Green(output.Success), agentURL)
 
 	return conn, nil
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -130,7 +130,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 				switch {
 				case detected != "":
 					_, _ = fmt.Fprintf(p.Out, "%s Detected server from %s/pom.xml\n",
-						output.Green("✓"), config.DetectTeamCityDir())
+						output.Green(output.Success), config.DetectTeamCityDir())
 					serverURL = detected
 					detected = ""
 				case savedDefault != "":
@@ -152,7 +152,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 		p.Progress("Checking %s... ", output.Cyan(serverURL))
 		probeClient := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
 		if err := probeClient.Probe(ctx); err != nil {
-			p.Info("%s", output.Red("✗"))
+			p.Info("%s", output.Red(output.Failure))
 			if errors.Is(err, context.Canceled) {
 				return "", err
 			}
@@ -164,7 +164,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 			serverURL = ""
 			continue
 		}
-		p.Info("%s", output.Green("✓"))
+		p.Info("%s", output.Green(output.Success))
 		return serverURL, nil
 	}
 }
@@ -179,13 +179,13 @@ func finishGuestLogin(ctx context.Context, f *cmdutil.Factory, serverURL string)
 	).WithContext(ctx)
 	server, err := client.GetServer()
 	if err != nil {
-		p.Info("%s", output.Red("✗"))
+		p.Info("%s", output.Red(output.Failure))
 		return api.Validation(
 			"Guest access validation failed",
 			"Verify the server URL and that guest access is enabled on the server",
 		)
 	}
-	p.Info("%s", output.Green("✓"))
+	p.Info("%s", output.Green(output.Success))
 
 	if err := config.SetGuestServer(serverURL); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
@@ -268,7 +268,7 @@ func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial str
 		).WithContext(ctx)
 		user, err := client.GetCurrentUser()
 		if err != nil {
-			p.Info("%s", output.Red("✗"))
+			p.Info("%s", output.Red(output.Failure))
 			if errors.Is(err, context.Canceled) {
 				return "", nil, err
 			}
@@ -279,7 +279,7 @@ func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial str
 			token = ""
 			continue
 		}
-		p.Info("%s", output.Green("✓"))
+		p.Info("%s", output.Green(output.Success))
 		return token, user, nil
 	}
 }
@@ -306,7 +306,7 @@ func printTokenInstructions(p *output.Printer, serverURL string, pkceTried bool)
 	if err := browser.OpenURL(tokenURL); err != nil {
 		_, _ = fmt.Fprintf(p.Out, "  Could not open browser. Please visit: %s\n", tokenURL)
 	} else {
-		_, _ = fmt.Fprintln(p.Out, output.Green("  ✓"), "Opened browser")
+		_, _ = fmt.Fprintln(p.Out, output.Green(output.Green("  " + output.Success)), "Opened browser")
 	}
 	_, _ = fmt.Fprintln(p.Out)
 	return nil

--- a/internal/cmd/auth/pkce.go
+++ b/internal/cmd/auth/pkce.go
@@ -104,7 +104,7 @@ func runPkceLogin(parent context.Context, p *output.Printer, client *api.Client,
 		opening = fmt.Sprintf("Opening browser to authenticate with %d of %d permissions...", len(scopes), total)
 	}
 	p.Info("%s", opening)
-	_, _ = fmt.Fprintf(p.Out, "  %s Approve access in TeamCity\n", output.Yellow("→"))
+	_, _ = fmt.Fprintf(p.Out, "  %s Approve access in TeamCity\n", output.Yellow(output.Arrow))
 
 	result, err := browserflow.Run(parent, browserflow.Options{
 		Listener:     listener,

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -329,12 +329,12 @@ func renderCredentialsDiagnostic(ctx context.Context, p *output.Printer, s authS
 	}
 
 	_, _ = fmt.Fprintf(p.Out, "  %s To authenticate in this environment:\n", output.Yellow("!"))
-	_, _ = fmt.Fprintf(p.Out, "    • Set %s and %s environment variables\n",
-		output.Cyan("TEAMCITY_URL"), output.Cyan("TEAMCITY_TOKEN"))
-	_, _ = fmt.Fprintf(p.Out, "    • Or run %s\n",
-		output.Cyan("teamcity auth login --server "+s.Server+" --insecure-storage"))
+	_, _ = fmt.Fprintf(p.Out, "    %s Set %s and %s environment variables\n",
+		output.Bullet, output.Cyan("TEAMCITY_URL"), output.Cyan("TEAMCITY_TOKEN"))
+	_, _ = fmt.Fprintf(p.Out, "    %s Or run %s\n",
+		output.Bullet, output.Cyan("teamcity auth login --server "+s.Server+" --insecure-storage"))
 	if cmdutil.ProbeGuestAccess(ctx, s.Server) {
-		_, _ = fmt.Fprintf(p.Out, "    • Or set %s for read-only guest access\n", output.Cyan("TEAMCITY_GUEST=1"))
+		_, _ = fmt.Fprintf(p.Out, "    %s Or set %s for read-only guest access\n", output.Bullet, output.Cyan("TEAMCITY_GUEST=1"))
 	}
 }
 

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -218,7 +218,7 @@ func renderAuthStatusHuman(f *cmdutil.Factory, results []authStatus) error {
 	_, _ = fmt.Fprintln(p.Out)
 
 	if len(results) == 0 {
-		_, _ = fmt.Fprintln(p.Out, output.Red("✗"), "Not logged in to any TeamCity server")
+		_, _ = fmt.Fprintln(p.Out, output.Red(output.Failure), "Not logged in to any TeamCity server")
 		_, _ = fmt.Fprintln(p.Out, "\nRun", output.Cyan("teamcity auth login"), "to authenticate")
 		if config.IsBuildEnvironment() {
 			_, _ = fmt.Fprintln(p.Out, "\n"+output.Yellow("!")+" Build environment detected but credentials not found in properties file")
@@ -256,28 +256,28 @@ func renderOneStatus(f *cmdutil.Factory, p *output.Printer, s authStatus) {
 
 	switch {
 	case s.Status == "guest":
-		_, _ = fmt.Fprintf(p.Out, "%s Guest access to %s%s\n", output.Green("✓"), output.Cyan(s.Server), suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s Guest access to %s%s\n", output.Green(output.Success), output.Cyan(s.Server), suffix)
 		renderServerInfo(p, s)
 
 	case s.Status == "authenticated" && s.AuthMethod == "build":
-		_, _ = fmt.Fprintf(p.Out, "%s Connected to %s\n", output.Green("✓"), output.Cyan(s.Server))
+		_, _ = fmt.Fprintf(p.Out, "%s Connected to %s\n", output.Green(output.Success), output.Cyan(s.Server))
 		_, _ = fmt.Fprintf(p.Out, "  Auth: %s\n", output.Faint("Build-level credentials"))
 		_, _ = fmt.Fprintf(p.Out, "  Scope: %s\n", output.Faint("Build-level access"))
 		renderServerInfo(p, s)
 
 	case s.Status == "authenticated":
-		_, _ = fmt.Fprintf(p.Out, "%s Logged in to %s%s\n", output.Green("✓"), output.Cyan(s.Server), suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s Logged in to %s%s\n", output.Green(output.Success), output.Cyan(s.Server), suffix)
 		_, _ = fmt.Fprintf(p.Out, "  %s %s (%s) %s %s\n",
 			output.Faint("User:"), s.User.Name, s.User.Username, output.Faint("·"), output.Faint(tokenSourceLabel(s.TokenSource)))
 		renderTokenExpiry(p, s.TokenExpiry)
 		renderServerInfo(p, s)
 
 	case s.Status == "error" && s.AuthMethod == "":
-		_, _ = fmt.Fprintf(p.Out, "%s %s%s\n", output.Red("✗"), s.Server, suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s %s%s\n", output.Red(output.Failure), s.Server, suffix)
 		renderCredentialsDiagnostic(f.Context(), p, s)
 
 	case s.Status == "error":
-		_, _ = fmt.Fprintf(p.Out, "%s Server: %s%s\n", output.Red("✗"), s.Server, suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s Server: %s%s\n", output.Red(output.Failure), s.Server, suffix)
 		_, _ = fmt.Fprintf(p.Out, "  %s\n", s.Error)
 	}
 }
@@ -292,7 +292,7 @@ func renderServerInfo(p *output.Printer, s authStatus) {
 	if s.versionCheckErr != "" {
 		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Yellow("!"), s.versionCheckErr)
 	} else {
-		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Green("✓"), output.Faint("API compatible"))
+		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Green(output.Success), output.Faint("API compatible"))
 	}
 }
 
@@ -307,7 +307,7 @@ func renderTokenExpiry(p *output.Printer, expiry string) {
 	remaining := time.Until(t)
 	switch {
 	case remaining <= 0:
-		_, _ = fmt.Fprintf(p.Out, "  %s Token expired on %s\n", output.Red("✗"), t.Local().Format("Jan 2, 2006"))
+		_, _ = fmt.Fprintf(p.Out, "  %s Token expired on %s\n", output.Red(output.Failure), t.Local().Format("Jan 2, 2006"))
 		_, _ = fmt.Fprintf(p.Out, "  Run %s to re-authenticate\n", output.Cyan("teamcity auth login"))
 	case remaining <= 3*24*time.Hour:
 		_, _ = fmt.Fprintf(p.Out, "  %s Token expires %s (on %s)\n",

--- a/internal/cmd/link/link.go
+++ b/internal/cmd/link/link.go
@@ -29,11 +29,11 @@ func NewCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "link",
 		Short: "Bind this repository to a TeamCity project",
-		Long: `Upsert a [[server]] entry in teamcity.toml binding this repo to a TeamCity
-instance. Per-path scopes (monorepo) are upserted under [server.paths."<path>"].
-
-Resolution cascade (highest to lowest):
-  --flag → TEAMCITY_* env → matching [[server]] entry, deepest matching path scope`,
+		Long: "Upsert a [[server]] entry in teamcity.toml binding this repo to a TeamCity\n" +
+			"instance. Per-path scopes (monorepo) are upserted under [server.paths.\"<path>\"].\n" +
+			"\n" +
+			"Resolution cascade (highest to lowest):\n" +
+			"  --flag " + output.Arrow + " TEAMCITY_* env " + output.Arrow + " matching [[server]] entry, deepest matching path scope",
 		Example: `  # Bind the repo (uses active server, top-level scope)
   teamcity link --project Acme_Backend --job Acme_Backend_Build
 

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -94,7 +94,7 @@ func runPipelineValidate(f *cmdutil.Factory, file string, opts *validateOptions)
 	}
 
 	_, _ = fmt.Fprintf(f.Printer.ErrOut, "%s %s has %d error(s)\n\n",
-		output.Red("✗"), file, len(validationErrs))
+		output.Red(output.Failure), file, len(validationErrs))
 
 	for _, ve := range validationErrs {
 		line := findLineNumber(&rootNode, ve.path)

--- a/internal/cmd/project/connection_create.go
+++ b/internal/cmd/project/connection_create.go
@@ -140,7 +140,7 @@ func runConnectionCreateGitHubApp(f *cmdutil.Factory, opts *githubAppOptions) er
 		stepNum++
 		printWizardStep(f.Printer, stepNum, totalSteps, "Register a GitHub App",
 			"You'll be taken to GitHub to confirm the App registration.")
-		_, _ = fmt.Fprintf(f.Printer.Out, "  %s On GitHub, click %q.\n", output.Yellow("→"), "Create GitHub App for "+target)
+		_, _ = fmt.Fprintf(f.Printer.Out, "  %s On GitHub, click %q.\n", output.Yellow(output.Arrow), "Create GitHub App for "+target)
 		ok := true
 		if err := cmdutil.Confirm("Open a browser to register the App?", &ok); err != nil {
 			return err

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -129,7 +129,7 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 		statusLabel = "unavailable"
 	} else {
 		if syncingStatus := getSyncingStatus(status.Message); syncingStatus != "" {
-			statusIcon = output.Cyan("⟳")
+			statusIcon = output.Cyan(output.SyncingIcon)
 			statusLabel = syncingStatus
 		} else {
 			switch status.Type {

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -122,10 +122,10 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 		return nil
 	}
 
-	statusIcon := output.Green("✓")
+	statusIcon := output.Green(output.Success)
 	statusLabel := "synchronized"
 	if statusErr != nil {
-		statusIcon = output.Red("✗")
+		statusIcon = output.Red(output.Failure)
 		statusLabel = "unavailable"
 	} else {
 		if syncingStatus := getSyncingStatus(status.Message); syncingStatus != "" {
@@ -137,7 +137,7 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 				statusIcon = output.Yellow("!")
 				statusLabel = "warning"
 			case "error":
-				statusIcon = output.Red("✗")
+				statusIcon = output.Red(output.Failure)
 				statusLabel = "error"
 			}
 		}
@@ -413,7 +413,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 		}
 		errs := parseKotlinErrors(combinedOutput)
 
-		_, _ = fmt.Fprintf(p.Out, "%s Configuration invalid\n", output.Red("✗"))
+		_, _ = fmt.Fprintf(p.Out, "%s Configuration invalid\n", output.Red(output.Failure))
 		if len(errs) > 0 {
 			_, _ = fmt.Fprintln(p.Out)
 			for _, e := range errs {
@@ -432,7 +432,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 		return f.Printer.PrintJSON(validateResultJSON{Valid: true, Path: dslDir})
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "%s Configuration valid\n", output.Green("✓"))
+	_, _ = fmt.Fprintf(p.Out, "%s Configuration valid\n", output.Green(output.Success))
 
 	if serverURL := config.DetectServerFromDSL(); serverURL != "" {
 		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Faint("Server:"), serverURL)

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -635,11 +635,11 @@ func runConnectionTest(f *cmdutil.Factory, client api.ClientInterface, req api.T
 	_, _ = fmt.Fprint(f.Printer.ErrOut, "Testing connection... ")
 	result, err := client.TestVcsConnection(req, projectID)
 	if err != nil {
-		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red("✗"))
+		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Failure))
 		return fmt.Errorf("connection test failed: %w", err)
 	}
 	if result.Status != "OK" {
-		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red("✗"))
+		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Failure))
 		msg := "connection test failed"
 		if len(result.Errors) > 0 {
 			msg = result.Errors[0].Message
@@ -650,7 +650,7 @@ func runConnectionTest(f *cmdutil.Factory, client api.ClientInterface, req api.T
 		}
 		return fmt.Errorf("%s", msg)
 	}
-	_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Green("✓"))
+	_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Green(output.Success))
 	return nil
 }
 

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -245,14 +245,14 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		switch t.Status {
 		case "FAILURE":
 			if t.Muted {
-				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("⊘"), t.Name)
+				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint(output.CanceledIcon), t.Name)
 			} else {
-				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Red("✗"), t.Name)
+				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Red(output.Failure), t.Name)
 			}
 		case "SUCCESS":
-			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Green("✓"), t.Name)
+			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Green(output.Success), t.Name)
 		default:
-			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("○"), t.Name)
+			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint(output.DefaultIcon), t.Name)
 		}
 	}
 

--- a/internal/cmd/run/compatibility.go
+++ b/internal/cmd/run/compatibility.go
@@ -172,7 +172,7 @@ func renderIncompatibilityReasons(w io.Writer, client api.ClientInterface, build
 		}
 		_, _ = fmt.Fprintf(w, "  %s\n", r.agent.Name)
 		for _, reason := range r.reasons {
-			_, _ = fmt.Fprintf(w, "    %s %s\n", output.Red("•"), reason)
+			_, _ = fmt.Fprintf(w, "    %s %s\n", output.Red(output.Bullet), reason)
 		}
 	}
 }

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -552,7 +552,7 @@ func renderTestsDiff(p *output.Printer, t1, t2, s1, s2 *api.TestOccurrences) boo
 	if len(newFailures) > 0 {
 		_, _ = fmt.Fprintf(p.Out, "  %s\n", output.Red("New failures:"))
 		for _, t := range newFailures {
-			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red("✗"), t.Name)
+			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red(output.Failure), t.Name)
 			if t.Details != "" {
 				_, _ = fmt.Fprintf(p.Out, "      %s\n", output.Faint(truncate(t.Details, 120)))
 			}
@@ -562,7 +562,7 @@ func renderTestsDiff(p *output.Printer, t1, t2, s1, s2 *api.TestOccurrences) boo
 	if len(fixed) > 0 {
 		_, _ = fmt.Fprintf(p.Out, "  %s\n", output.Green("Fixed:"))
 		for _, name := range fixed {
-			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Green("✓"), name)
+			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Green(output.Success), name)
 		}
 	}
 

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -394,14 +394,14 @@ func renderDiffHeader(p *output.Printer, b1, b2 *api.Build) {
 		jobName = b1.BuildType.Name
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "COMPARING  %s %d  #%s  →  %s %d  #%s\n",
-		icon1, b1.ID, b1.Number, icon2, b2.ID, b2.Number)
+	_, _ = fmt.Fprintf(p.Out, "COMPARING  %s %d  #%s  %s  %s %d  #%s\n",
+		icon1, b1.ID, b1.Number, output.Arrow, icon2, b2.ID, b2.Number)
 
 	meta := output.Faint("Job: ") + output.Cyan(jobName)
 	if b1.BranchName != "" || b2.BranchName != "" {
 		branch := b1.BranchName
 		if b2.BranchName != "" && b2.BranchName != b1.BranchName {
-			branch = b1.BranchName + " → " + b2.BranchName
+			branch = b1.BranchName + " " + output.Arrow + " " + b2.BranchName
 		}
 		if branch != "" {
 			meta += output.Faint("  ·  Branch: ") + branch
@@ -502,8 +502,8 @@ func renderParamsDiff(p *output.Printer, params1, params2 *api.ParameterList) bo
 	for _, c := range diffs {
 		switch c.kind {
 		case "changed":
-			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s → %s\n",
-				output.Yellow("~"), c.name, output.Red(c.old), output.Green(c.new))
+			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s %s %s\n",
+				output.Yellow("~"), c.name, output.Red(c.old), output.Arrow, output.Green(c.new))
 		case "added":
 			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s\n",
 				output.Green("+"), c.name, output.Green(c.new))

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -117,17 +117,17 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 	for _, artifact := range flatList {
 		rel, err := filepath.Rel(absOutput, filepath.Join(absOutput, artifact.Name))
 		if err != nil || !filepath.IsLocal(rel) {
-			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s path escapes output directory\n", nameWidth, artifact.Name, "", output.Red("   ✗"))
+			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s path escapes output directory\n", nameWidth, artifact.Name, "", output.Red("   "+output.Failure))
 			continue
 		}
 		outputPath := filepath.Join(absOutput, rel)
 		size := humanize.IBytes(uint64(artifact.Size))
 
 		if err := downloadArtifact(ctx, client, runID, artifact, outputPath, nameWidth, p.Quiet, p.Out); err != nil {
-			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s %v\n", nameWidth, artifact.Name, size, output.Red("   ✗"), err)
+			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s %v\n", nameWidth, artifact.Name, size, output.Red("   "+output.Failure), err)
 			continue
 		}
-		_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s\n", nameWidth, artifact.Name, size, output.Green("   ✓"))
+		_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s\n", nameWidth, artifact.Name, size, output.Green("   "+output.Success))
 		downloaded++
 	}
 

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -131,7 +131,7 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 		downloaded++
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "\n%s %s downloaded\n", output.Green("✓"), english.Plural(downloaded, "artifact", ""))
+	_, _ = fmt.Fprintf(p.Out, "\n%s %s downloaded\n", output.Green(output.Success), english.Plural(downloaded, "artifact", ""))
 	return nil
 }
 

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -433,7 +433,7 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 	}
 
 	if build.UsedByOtherBuilds {
-		_, _ = fmt.Fprintf(p.Out, "\n%s Results shared in build chain\n", output.Yellow("⟳"))
+		_, _ = fmt.Fprintf(p.Out, "\n%s Results shared in build chain\n", output.Yellow(output.SyncingIcon))
 	}
 
 	if build.StatusText != "" && build.StatusText != build.Status {

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -165,7 +165,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) (resErr
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				if !opts.json {
-					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red("✗"))
+					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red(output.Failure))
 				}
 				return &cmdutil.ExitError{Code: cmdutil.ExitTimeout}
 			}
@@ -267,7 +267,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) (resErr
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				if !opts.json {
-					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red("✗"))
+					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red(output.Failure))
 				}
 				return &cmdutil.ExitError{Code: cmdutil.ExitTimeout}
 			}

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -8,6 +8,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/tiulpin/instill"
 )
@@ -201,9 +202,9 @@ func runSkillInstall(f *cmdutil.Factory, opts *skillOptions, args []string, chec
 		case !r.Existed:
 			p.Success("Installed %s for %s (%s)", r.Skill, r.Agent, bundled)
 		case r.PriorVersion != "" && r.PriorVersion != bundled:
-			p.Success("Updated %s for %s (%s → %s)", r.Skill, r.Agent, r.PriorVersion, bundled)
+			p.Success("Updated %s for %s (%s "+output.Arrow+" %s)", r.Skill, r.Agent, r.PriorVersion, bundled)
 		case r.PriorVersion == "":
-			p.Success("Updated %s for %s (unversioned → %s)", r.Skill, r.Agent, bundled)
+			p.Success("Updated %s for %s (unversioned "+output.Arrow+" %s)", r.Skill, r.Agent, bundled)
 		default:
 			p.Success("Reinstalled %s for %s (%s)", r.Skill, r.Agent, bundled)
 		}

--- a/internal/cmd/update/update.go
+++ b/internal/cmd/update/update.go
@@ -51,8 +51,9 @@ func runUpdate(f *cmdutil.Factory) error {
 	}
 
 	method := update.DetectInstallMethod()
-	_, _ = fmt.Fprintf(p.Out, "%s → %s: %s\n%s\n",
+	_, _ = fmt.Fprintf(p.Out, "%s %s %s: %s\n%s\n",
 		output.Faint("v"+version.Version),
+		output.Arrow,
 		output.Green("v"+release.Version),
 		output.Bold(method.UpdateCommand()),
 		output.Faint(release.URL),

--- a/internal/cmdutil/failure.go
+++ b/internal/cmdutil/failure.go
@@ -14,7 +14,7 @@ import (
 const maxFailedTestsToShow = 10
 
 func PrintFailureSummary(ctx context.Context, p *output.Printer, client api.ClientInterface, buildID, buildNumber, webURL, statusText string) {
-	header := fmt.Sprintf("%s %s  #%s failed", output.Red("✗"), buildID, buildNumber)
+	header := fmt.Sprintf("%s %s  #%s failed", output.Red(output.Failure), buildID, buildNumber)
 	if statusText != "" {
 		header += ": " + statusText
 	}
@@ -43,14 +43,14 @@ func PrintFailureSummary(ctx context.Context, p *output.Printer, client api.Clie
 			if detail == "" {
 				detail = prob.Identity
 			}
-			_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Red("•"), detail)
+			_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Red(output.Bullet), detail)
 		}
 	}
 
 	if testsErr == nil && tests != nil && tests.Failed > 0 {
 		_, _ = fmt.Fprintf(p.Out, "\nFailed tests (%d):\n", tests.Failed)
 		for _, t := range tests.TestOccurrence {
-			line := fmt.Sprintf("  %s %s", output.Red("•"), t.Name)
+			line := fmt.Sprintf("  %s %s", output.Red(output.Bullet), t.Name)
 			if t.Duration > 0 {
 				dur := time.Duration(t.Duration) * time.Millisecond
 				line += " " + output.Faint("("+output.FormatDuration(dur)+")")
@@ -85,7 +85,7 @@ func BuildResultError(ctx context.Context, p *output.Printer, client api.ClientI
 
 	switch build.Status {
 	case "SUCCESS":
-		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s succeeded\n", output.Green("✓"), output.Cyan(jobName), build.ID, build.Number)
+		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s succeeded\n", output.Green(output.Success), output.Cyan(jobName), build.ID, build.Number)
 		if showDetails {
 			_, _ = fmt.Fprintf(p.Out, "\nView details: %s\n", build.WebURL)
 		}
@@ -94,7 +94,7 @@ func BuildResultError(ctx context.Context, p *output.Printer, client api.ClientI
 		PrintFailureSummary(ctx, p, client, strconv.Itoa(build.ID), build.Number, build.WebURL, build.StatusText)
 		return &ExitError{Code: ExitFailure}
 	default:
-		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s canceled\n", output.Yellow("○"), output.Cyan(jobName), build.ID, build.Number)
+		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s canceled\n", output.Yellow(output.DefaultIcon), output.Cyan(jobName), build.ID, build.Number)
 		return &ExitError{Code: ExitCancelled}
 	}
 }

--- a/internal/cmdutil/prompt.go
+++ b/internal/cmdutil/prompt.go
@@ -141,7 +141,7 @@ func promptTheme() *huh.Theme {
 		t.Focused.Title = plain.Bold(true)
 		t.Focused.NoteTitle = plain.Bold(true)
 		t.Focused.Description = plain.Foreground(faint)
-		t.Focused.ErrorIndicator = plain.Foreground(red).SetString(" ✗")
+		t.Focused.ErrorIndicator = plain.Foreground(red).SetString(" " + output.Failure)
 		t.Focused.ErrorMessage = plain.Foreground(red)
 
 		t.Focused.SelectSelector = plain.Foreground(yellow).SetString(output.Arrow + " ")

--- a/internal/cmdutil/prompt.go
+++ b/internal/cmdutil/prompt.go
@@ -144,15 +144,15 @@ func promptTheme() *huh.Theme {
 		t.Focused.ErrorIndicator = plain.Foreground(red).SetString(" ✗")
 		t.Focused.ErrorMessage = plain.Foreground(red)
 
-		t.Focused.SelectSelector = plain.Foreground(yellow).SetString("→ ")
-		t.Focused.NextIndicator = plain.Foreground(yellow).MarginLeft(1).SetString("→")
-		t.Focused.PrevIndicator = plain.Foreground(yellow).MarginRight(1).SetString("←")
+		t.Focused.SelectSelector = plain.Foreground(yellow).SetString(output.Arrow + " ")
+		t.Focused.NextIndicator = plain.Foreground(yellow).MarginLeft(1).SetString(output.Arrow)
+		t.Focused.PrevIndicator = plain.Foreground(yellow).MarginRight(1).SetString(output.ArrowLeft)
 		t.Focused.Option = plain
 		t.Focused.SelectedOption = plain
 
-		t.Focused.MultiSelectSelector = plain.Foreground(yellow).SetString("→ ")
-		t.Focused.SelectedPrefix = plain.Foreground(green).SetString("✓ ")
-		t.Focused.UnselectedPrefix = plain.Foreground(faint).SetString("• ")
+		t.Focused.MultiSelectSelector = plain.Foreground(yellow).SetString(output.Arrow + " ")
+		t.Focused.SelectedPrefix = plain.Foreground(green).SetString(output.Success + " ")
+		t.Focused.UnselectedPrefix = plain.Foreground(faint).SetString(output.Bullet + " ")
 		t.Focused.UnselectedOption = plain
 
 		t.Focused.FocusedButton = plain.Bold(true).Foreground(cyan).MarginLeft(3)

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -38,7 +38,7 @@ func (p *Printer) Success(format string, args ...any) {
 	if p.Quiet {
 		return
 	}
-	p.write(p.Out, fmt.Sprintf("%s %s\n", Green("✓"), fmt.Sprintf(format, args...)))
+	p.write(p.Out, fmt.Sprintf("%s %s\n", Green(Success), fmt.Sprintf(format, args...)))
 }
 
 func (p *Printer) Info(format string, args ...any) {

--- a/internal/output/status.go
+++ b/internal/output/status.go
@@ -9,25 +9,25 @@ func isCanceled(status, statusText string) bool {
 // StatusIcon returns a colored status icon.
 func StatusIcon(status, state string, statusText ...string) string {
 	if state == "running" {
-		return Yellow("●")
+		return Yellow(RunningIcon)
 	}
 	if state == "queued" {
-		return Faint("◦")
+		return Faint(QueuedIcon)
 	}
 
 	if len(statusText) > 0 && isCanceled(status, statusText[0]) {
-		return Faint("⊘")
+		return Faint(CanceledIcon)
 	}
 
 	switch strings.ToUpper(status) {
 	case "SUCCESS":
-		return Green("✓")
+		return Green(Success)
 	case "FAILURE", "ERROR":
-		return Red("✗")
+		return Red(Failure)
 	case "UNKNOWN":
 		return Yellow("?")
 	default:
-		return Faint("○")
+		return Faint(DefaultIcon)
 	}
 }
 

--- a/internal/output/status_test.go
+++ b/internal/output/status_test.go
@@ -16,21 +16,21 @@ func TestStatusIcon(T *testing.T) {
 		statusText   string
 		wantContains string
 	}{
-		{"SUCCESS", "", "", "✓"},
-		{"FAILURE", "", "", "✗"},
-		{"ERROR", "", "", "✗"},
+		{"SUCCESS", "", "", Success},
+		{"FAILURE", "", "", Failure},
+		{"ERROR", "", "", Failure},
 		{"UNKNOWN", "", "", "?"},
-		{"UNKNOWN", "", "Canceled (user)", "⊘"},
-		{"OTHER", "", "", "○"},
-		{"", "running", "", "●"},
-		{"", "queued", "", "◦"},
-		{"success", "", "", "✓"},
-		{"failure", "", "", "✗"},
-		{"Success", "", "", "✓"},
-		{"Failure", "", "", "✗"},
-		{"", "", "", "○"},
-		{" ", "", "", "○"},
-		{"SUCCESS", "", "Canceled", "✓"},
+		{"UNKNOWN", "", "Canceled (user)", CanceledIcon},
+		{"OTHER", "", "", DefaultIcon},
+		{"", "running", "", RunningIcon},
+		{"", "queued", "", QueuedIcon},
+		{"success", "", "", Success},
+		{"failure", "", "", Failure},
+		{"Success", "", "", Success},
+		{"Failure", "", "", Failure},
+		{"", "", "", DefaultIcon},
+		{" ", "", "", DefaultIcon},
+		{"SUCCESS", "", "Canceled", Success},
 	}
 
 	for _, tc := range tests {

--- a/internal/output/symbols.go
+++ b/internal/output/symbols.go
@@ -30,6 +30,8 @@ var (
 	DefaultIcon = "○"
 	// Bullet is used for list items.
 	Bullet = "•"
+	// SyncingIcon indicates a versioned-settings sync in progress (cyan).
+	SyncingIcon = "⟳"
 )
 
 func init() {
@@ -43,5 +45,6 @@ func init() {
 		CanceledIcon = "/"
 		DefaultIcon = "-"
 		Bullet = "*"
+		SyncingIcon = "~"
 	}
 }

--- a/internal/output/symbols.go
+++ b/internal/output/symbols.go
@@ -1,0 +1,42 @@
+package output
+
+import "runtime"
+
+// Status symbols used throughout the CLI output.
+// On Windows (non-Terminal), Unicode glyphs like ✓/✗ may render as □ because
+// legacy console fonts (Consolas, Lucida Console) lack those code-points.
+// ASCII fallbacks keep the output readable everywhere.
+var (
+	// Success is rendered after a completed check (green).
+	Success = "✓"
+	// Failure is rendered after a failed check (red).
+	Failure = "✗"
+	// Arrow is rendered as a directional hint (yellow).
+	Arrow = "→"
+	// ArrowLeft is rendered as a left-directional hint.
+	ArrowLeft = "←"
+	// RunningIcon indicates a running build (yellow).
+	RunningIcon = "●"
+	// QueuedIcon indicates a queued build (faint).
+	QueuedIcon = "◦"
+	// CanceledIcon indicates a canceled build (faint).
+	CanceledIcon = "⊘"
+	// DefaultIcon is the fallback status icon (faint).
+	DefaultIcon = "○"
+	// Bullet is used for list items.
+	Bullet = "•"
+)
+
+func init() {
+	if runtime.GOOS == "windows" {
+		Success = "[ok]"
+		Failure = "[x]"
+		Arrow = "->"
+		ArrowLeft = "<-"
+		RunningIcon = "*"
+		QueuedIcon = "o"
+		CanceledIcon = "/"
+		DefaultIcon = "-"
+		Bullet = "*"
+	}
+}

--- a/internal/output/symbols.go
+++ b/internal/output/symbols.go
@@ -1,11 +1,16 @@
 package output
 
-import "runtime"
+import (
+	"os"
+	"runtime"
+)
 
 // Status symbols used throughout the CLI output.
-// On Windows (non-Terminal), Unicode glyphs like ✓/✗ may render as □ because
-// legacy console fonts (Consolas, Lucida Console) lack those code-points.
-// ASCII fallbacks keep the output readable everywhere.
+// On Windows with legacy console (cmd.exe, PowerShell without Windows Terminal),
+// Unicode glyphs like ✓/✗ may render as □ because console fonts (Consolas,
+// Lucida Console) lack those code-points. Windows Terminal sets the WT_SESSION
+// environment variable and ships with Cascadia Code which has full Unicode
+// support, so we only fall back to ASCII on legacy consoles.
 var (
 	// Success is rendered after a completed check (green).
 	Success = "✓"
@@ -28,7 +33,7 @@ var (
 )
 
 func init() {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && os.Getenv("WT_SESSION") == "" {
 		Success = "[ok]"
 		Failure = "[x]"
 		Arrow = "->"

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -140,9 +140,10 @@ func CheckInBackground(ctx context.Context, w io.Writer, quiet bool) func() {
 }
 
 func PrintNotice(w io.Writer, currentVersion string, r *ReleaseInfo) {
-	_, _ = fmt.Fprintf(w, "\n%s A new version is available: %s → %s — run %s to see how to upgrade\n",
+	_, _ = fmt.Fprintf(w, "\n%s A new version is available: %s %s %s — run %s to see how to upgrade\n",
 		output.Yellow("!"),
 		output.Faint("v"+currentVersion),
+		output.Arrow,
 		output.Green("v"+r.Version),
 		output.Cyan(`"teamcity update"`),
 	)


### PR DESCRIPTION
## Problem

Unicode symbols like ✓ (U+2713) and ✗ (U+2717) render as □ replacement characters on Windows when the console font doesn't have glyphs for those codepoints. Users reported confusion — one spent significant time trying to understand what the "green ? in box" symbol meant during `teamcity auth login`.

The issue affects all Windows users not running Windows Terminal (legacy conhost.exe with Consolas/Lucida Console fonts).

## Fix

Introduce `internal/output/symbols.go` that defines all status/output symbols as package-level variables with platform-specific fallbacks:

| Symbol | Default | Windows |
|--------|---------|---------|
| ✓ | `Success` | `[ok]` |
| ✗ | `Failure` | `[x]` |
| → | `Arrow` | `->` |
| ← | `ArrowLeft` | `<-` |
| ● | `RunningIcon` | `*` |
| ○ | `DefaultIcon` | `-` |
| ◦ | `QueuedIcon` | `o` |
| ⊘ | `CanceledIcon` | `/` |
| • | `Bullet` | `*` |

Replace 40+ hardcoded Unicode symbol occurrences across 17 files with references to the centralized variables. No behavioral changes on non-Windows platforms.

Fixes #308
