### PR TITLE
fix: suppress auth-login hint when TEAMCITY_TOKEN is set

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -52,7 +53,9 @@ Report issues:  https://jb.gg/tc/issues`,
 			_, _ = fmt.Fprintln(out, "Usage: teamcity <command> [flags]")
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintln(out, "Common commands:")
-			_, _ = fmt.Fprintln(out, "  auth login              Authenticate with TeamCity")
+			if os.Getenv(config.EnvToken) == "" {
+				_, _ = fmt.Fprintln(out, "  auth login              Authenticate with TeamCity")
+			}
 			_, _ = fmt.Fprintln(out, "  run list                List recent runs")
 			_, _ = fmt.Fprintln(out, "  run start <job>         Trigger a new run")
 			_, _ = fmt.Fprintln(out, "  run view <id>           View run details")

--- a/internal/output/render_error.go
+++ b/internal/output/render_error.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -43,6 +44,9 @@ func tipFor(err error) string {
 	}
 	switch ue.Category() {
 	case api.CatAuth:
+		if os.Getenv("TEAMCITY_TOKEN") != "" {
+			return "Your TEAMCITY_TOKEN may be invalid or expired; reissue it in your TeamCity user profile"
+		}
 		return "Run 'teamcity auth login' to re-authenticate"
 	case api.CatPermission:
 		pe, ok := errors.AsType[*api.PermissionError](ue)


### PR DESCRIPTION
When TEAMCITY_TOKEN is already exported in the environment, the CLI has a working credential and shouldn't suggest running 'auth login'. This is noisy for wrapping/sub-tool integrations that provide the token via env on every call.

Closes #314.

<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->

## Summary

<!-- One paragraph. What does this PR do, and why? Link related issues with "Fixes #123". -->



## Changes

<!-- Short bullet list of key changes; group by area if useful. Keep terse. -->

-

## Design Decisions

<!-- Non-obvious choices and trade-offs. Write "Straightforward." if there are none. -->

## Example

<!-- For CLI changes: show command + output. Write "N/A — not user-visible." if not applicable. -->

```bash
teamcity <command>
```

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [ ] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only)
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
