### PR TITLE
feat: add TEAMCITY_NO_SKILL_HINT env var to suppress AI skill hint

### DIFF
--- a/internal/cmd/skill_hint.go
+++ b/internal/cmd/skill_hint.go
@@ -16,6 +16,9 @@ func maybePromoteSkillInstall(f *cmdutil.Factory, cmd *cobra.Command, runErr err
 	if f == nil || cmd == nil || runErr != nil || f.Quiet || f.JSONOutput || f.NoInput {
 		return
 	}
+	if os.Getenv("TEAMCITY_NO_SKILL_HINT") != "" {
+		return
+	}
 	if p := cmd.Parent(); p != nil && p.Name() == "skill" {
 		return
 	}


### PR DESCRIPTION
When TEAMCITY_NO_SKILL_HINT is set, the CLI skips the "Install the TeamCity skill" promotion that appears when an AI coding agent is detected but the teamcity-cli skill isn't installed.

Useful for users who have custom skills or don't want the hint in automated agent contexts.

Closes #323.

<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->

## Summary

<!-- One paragraph. What does this PR do, and why? Link related issues with "Fixes #123". -->



## Changes

<!-- Short bullet list of key changes; group by area if useful. Keep terse. -->

-

## Design Decisions

<!-- Non-obvious choices and trade-offs. Write "Straightforward." if there are none. -->

## Example

<!-- For CLI changes: show command + output. Write "N/A — not user-visible." if not applicable. -->

```bash
teamcity <command>
```

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [ ] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only)
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
