### PR TITLE
feat: suppress banner with TEAMCITY_NO_BANNER env var and --quiet

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -45,7 +45,9 @@ Report issues:  https://jb.gg/tc/issues`,
 		Version: version.String(),
 		Run: func(cmd *cobra.Command, args []string) {
 			out := f.Printer.Out
-			output.PrintLogo(out)
+			if os.Getenv("TEAMCITY_NO_BANNER") == "" && !f.Quiet && output.IsTerminal() {
+				output.PrintLogo(out)
+			}
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintln(out, "TeamCity CLI "+output.Faint("v"+version.String())+" - "+output.Faint("https://jb.gg/tc/docs"))
 			_, _ = fmt.Fprintln(out)


### PR DESCRIPTION
Three ways to disable the ASCII-art logo:
1. TEAMCITY_NO_BANNER=1 env var (matches TEAMCITY_NO_UPDATE pattern)
2. --quiet global flag (now consistently suppresses the banner)
3. Auto-disabled when stdout is not a TTY (CI, pipes, sub-tools)

Addresses #315.

<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->

## Summary

<!-- One paragraph. What does this PR do, and why? Link related issues with "Fixes #123". -->



## Changes

<!-- Short bullet list of key changes; group by area if useful. Keep terse. -->

-

## Design Decisions

<!-- Non-obvious choices and trade-offs. Write "Straightforward." if there are none. -->

## Example

<!-- For CLI changes: show command + output. Write "N/A — not user-visible." if not applicable. -->

```bash
teamcity <command>
```

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [ ] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only)
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
