### PR TITLE
fix: guard against nil BuildType in agent view

### DIFF
--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -202,8 +202,12 @@ func runAgentView(f *cmdutil.Factory, nameOrID string, opts *cmdutil.ViewOptions
 	}
 
 	if agent.Build != nil {
+		jobName := agent.Build.BuildTypeID
+		if agent.Build.BuildType != nil {
+			jobName = agent.Build.BuildType.Name
+		}
 		_, _ = fmt.Fprintf(p.Out, "\nCurrent build: %s %d  #%s (%s)\n",
-			agent.Build.BuildType.Name,
+			jobName,
 			agent.Build.ID,
 			agent.Build.Number,
 			agent.Build.Status)


### PR DESCRIPTION
When 'teamcity agent view' displays the current build, it accesses agent.Build.BuildType.Name without checking if BuildType is nil. This can panic for queued builds where the API may omit BuildType.

Fall back to the BuildTypeID string when BuildType is nil, following the same pattern used in run/tree.go, run/diff.go, and run/watch.go.

<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->

## Summary

<!-- One paragraph. What does this PR do, and why? Link related issues with "Fixes #123". -->



## Changes

<!-- Short bullet list of key changes; group by area if useful. Keep terse. -->

-

## Design Decisions

<!-- Non-obvious choices and trade-offs. Write "Straightforward." if there are none. -->

## Example

<!-- For CLI changes: show command + output. Write "N/A — not user-visible." if not applicable. -->

```bash
teamcity <command>
```

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [ ] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only)
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
