### PR TITLE
docs(contributing): require status:finalized issue for external PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -53,5 +53,7 @@ body:
     id: contribution
     attributes:
       label: Contribution
+      description: |
+        External contributors: wait for the `status:finalized` label before opening a PR — discussion here isn't approval.
       options:
-        - label: I'd be willing to submit a PR for this feature
+        - label: I'd be willing to submit a PR (once it's `status:finalized`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,3 +35,4 @@ teamcity <command>
 - [ ] If adding a data-producing command: includes `--json` support
 - [ ] If modifying `--json` output: no field removals/renames (additive only)
 - [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
+- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -344,9 +344,23 @@ The command still runs — users are warned but not broken. Remove it in the tar
 
 Currently deprecated flags: none.
 
+## Before you open a pull request
+
+Issues come first — we agree on scope and approach there, before any code.
+
+AI makes it trivial to generate a plausible PR against any issue in seconds, and reviewing that slop costs us more than generating it costs you. So we gate on the issue, not the PR.
+
+**External contributors:** your PR must reference an issue labeled `status:finalized` — a maintainer has agreed the problem is real and the approach is wanted. No finalized issue, no PR; we'll close it and point you here.
+
+- **Bugs** get finalized fast — comment with a clear repro and ask for the label.
+- **Features** need scope agreement first. Discussion isn't approval — wait for the label.
+- **Trivial changes** (typos, doc fixes, dependency bumps) — skip the issue, just open the PR.
+
+**JetBrains members** can open PRs without a finalized issue, but link related issues where they exist.
+
 ## Submit a pull request
 
-Push your branch and open a PR against `main`. The [PR template](.github/PULL_REQUEST_TEMPLATE.md) will guide you through describing the change — fill in every section it defines.
+Push your branch and open a PR against `main`. Link the issue with `Fixes #123`. The [PR template](.github/PULL_REQUEST_TEMPLATE.md) will guide you through describing the change — fill in every section it defines.
 
 ## AI-assisted contributions
 


### PR DESCRIPTION
## Summary

External contributors keep opening PRs against issues that don't exist or haven't been triaged. This documents a gate: external PRs must reference an issue labeled `status:finalized`. The motivation is explicit — AI makes plausible PRs cheap to generate and expensive to review, so we gate on the issue, not the PR. JetBrains members are exempt for maintainer-driven work.

## Changes

- `CONTRIBUTING.md`: new "Before you open a pull request" section — the `status:finalized` rule, bug/feature/trivial breakdown, and the JetBrains-member exemption.
- `.github/PULL_REQUEST_TEMPLATE.md`: checkbox for external contributors to confirm a linked `status:finalized` issue.
- `.github/ISSUE_TEMPLATE/feature_request.yml`: note that discussion isn't approval — wait for the label before opening a PR.
- New `status:finalized` label created in the repo (out-of-band, not in this diff).

## Design Decisions

Docs + template only, no CI enforcement — maintainers close non-compliant PRs by hand. Kept the `specs/` directory and bot-review machinery (Warp's model) out as overkill for this repo's size.

## Example

N/A — not user-visible (docs and GitHub templates only).

## Test Plan

- [ ] Unit tests pass (`just unit`) — N/A, no code change
- [ ] Linter passes (`just lint`) — N/A, no code change
- [ ] Acceptance tests pass (`just acceptance`) — N/A, no code change
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A, contributor-facing docs only
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — trivial docs change
