### PR TITLE
feat(output): degrade Unicode glyphs to ASCII on incapable terminals

### DIFF
--- a/acceptance/testdata/run/run-tree.txtar
+++ b/acceptance/testdata/run/run-tree.txtar
@@ -1,16 +1,17 @@
 # Test run tree subcommand.
 # Uses CLI_CiCd (Pipeline Head) which always has snapshot dependencies.
+# Pipeline marker is ⬡, or * on ASCII-only consoles (e.g. non-UTF-8 Windows).
 
 exec teamcity api '/app/rest/builds?locator=buildType:CLI_CiCd,state:finished,count:1&fields=build(id)' --raw --no-input
 extract '"id":(\d+)' BUILD_ID
 
 exec teamcity run tree $BUILD_ID --no-input
-stdout '⬡'
+stdout '⬡|\*'
 stdout 'passed'
 ! stderr 'Error'
 
 exec teamcity run tree $BUILD_ID --depth 1 --no-input
-stdout '⬡'
+stdout '⬡|\*'
 ! stderr 'Error'
 
 exec teamcity run tree $BUILD_ID --json --no-input

--- a/api/probe.go
+++ b/api/probe.go
@@ -12,7 +12,7 @@ import (
 const probeTimeout = 10 * time.Second
 
 // ErrLoginGatewayDetected indicates the API endpoint was served by an SSO / login gateway rather than TeamCity itself.
-var ErrLoginGatewayDetected = errors.New("login gateway detected — VPN may be required")
+var ErrLoginGatewayDetected = errors.New("login gateway detected - VPN may be required")
 
 // Probe checks whether c.BaseURL points to a reachable TeamCity server without sending credentials.
 func (c *Client) Probe(ctx context.Context) error {

--- a/docs/topics/teamcity-cli-configuration.md
+++ b/docs/topics/teamcity-cli-configuration.md
@@ -324,6 +324,18 @@ App-specific alternative to `NO_COLOR` for disabling colored output.
 <tr>
 <td>
 
+`TEAMCITY_ASCII`
+
+</td>
+<td>
+
+Restrict output to ASCII characters, replacing Unicode glyphs (status icons, arrows, tree connectors) with ASCII equivalents. Detected automatically on Windows consoles whose code page is not UTF-8; set this to force it elsewhere.
+
+</td>
+</tr>
+<tr>
+<td>
+
 `TEAMCITY_NO_UPDATE`
 
 </td>

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.42.0
 	github.com/tiulpin/instill v0.0.0-20260521174322-b563ba2627d7
 	github.com/zalando/go-keyring v0.2.8
+	golang.org/x/sys v0.44.0
 	golang.org/x/term v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -118,7 +119,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 )

--- a/internal/cmd/agent/agent_jobs.go
+++ b/internal/cmd/agent/agent_jobs.go
@@ -137,7 +137,7 @@ func showIncompatibleJobs(p *output.Printer, client api.ClientInterface, agentID
 		if c.Reasons != nil && len(c.Reasons.Reasons) > 0 {
 			_, _ = fmt.Fprintf(p.Out, "  Reasons:\n")
 			for _, reason := range c.Reasons.Reasons {
-				_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red("•"), reason)
+				_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red(output.Sym().Bullet), reason)
 			}
 		}
 		_, _ = fmt.Fprintln(p.Out)

--- a/internal/cmd/agent/terminal.go
+++ b/internal/cmd/agent/terminal.go
@@ -166,7 +166,7 @@ func connectToAgent(f *cmdutil.Factory, ctx context.Context, nameOrID string, sh
 		return nil, err
 	}
 
-	_, _ = fmt.Fprintf(f.Printer.Out, "%s %s\n", output.Green("✓"), agentURL)
+	_, _ = fmt.Fprintf(f.Printer.Out, "%s %s\n", output.Green(output.Sym().Check), agentURL)
 
 	return conn, nil
 }

--- a/internal/cmd/auth/errors.go
+++ b/internal/cmd/auth/errors.go
@@ -16,22 +16,22 @@ func friendlyError(err error, serverURL string) string {
 	}
 	if errors.Is(err, api.ErrLoginGatewayDetected) {
 		if u, perr := url.Parse(serverURL); perr == nil && strings.HasSuffix(strings.ToLower(u.Hostname()), ".labs.intellij.net") {
-			return "login gateway detected — https://jb.gg/warp may be required"
+			return "login gateway detected - https://jb.gg/warp may be required"
 		}
 		return err.Error()
 	}
 	s := err.Error()
 	switch {
 	case strings.Contains(s, "no such host"):
-		return "DNS lookup failed — check the hostname"
+		return "DNS lookup failed - check the hostname"
 	case strings.Contains(s, "connection refused"):
-		return "connection refused — is the server running?"
+		return "connection refused - is the server running?"
 	case strings.Contains(s, "i/o timeout"):
 		return "connection timed out"
 	case strings.Contains(s, "x509"), strings.Contains(s, "certificate"):
-		return "TLS certificate error — check the URL scheme and hostname"
+		return "TLS certificate error - check the URL scheme and hostname"
 	case strings.Contains(s, "401"), strings.Contains(strings.ToLower(s), "unauthorized"):
-		return "token rejected — the token is invalid, expired, or lacks required permissions"
+		return "token rejected - the token is invalid, expired, or lacks required permissions"
 	}
 	return s
 }

--- a/internal/cmd/auth/login.go
+++ b/internal/cmd/auth/login.go
@@ -130,7 +130,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 				switch {
 				case detected != "":
 					_, _ = fmt.Fprintf(p.Out, "%s Detected server from %s/pom.xml\n",
-						output.Green("✓"), config.DetectTeamCityDir())
+						output.Green(output.Sym().Check), config.DetectTeamCityDir())
 					serverURL = detected
 					detected = ""
 				case savedDefault != "":
@@ -152,7 +152,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 		p.Progress("Checking %s... ", output.Cyan(serverURL))
 		probeClient := api.NewGuestClient(serverURL, api.WithVersion(version.String()))
 		if err := probeClient.Probe(ctx); err != nil {
-			p.Info("%s", output.Red("✗"))
+			p.Info("%s", output.Red(output.Sym().Cross))
 			if errors.Is(err, context.Canceled) {
 				return "", err
 			}
@@ -164,7 +164,7 @@ func resolveServerURL(ctx context.Context, p *output.Printer, initial string, in
 			serverURL = ""
 			continue
 		}
-		p.Info("%s", output.Green("✓"))
+		p.Info("%s", output.Green(output.Sym().Check))
 		return serverURL, nil
 	}
 }
@@ -179,13 +179,13 @@ func finishGuestLogin(ctx context.Context, f *cmdutil.Factory, serverURL string)
 	).WithContext(ctx)
 	server, err := client.GetServer()
 	if err != nil {
-		p.Info("%s", output.Red("✗"))
+		p.Info("%s", output.Red(output.Sym().Cross))
 		return api.Validation(
 			"Guest access validation failed",
 			"Verify the server URL and that guest access is enabled on the server",
 		)
 	}
-	p.Info("%s", output.Green("✓"))
+	p.Info("%s", output.Green(output.Sym().Check))
 
 	if err := config.SetGuestServer(serverURL); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
@@ -268,7 +268,7 @@ func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial str
 		).WithContext(ctx)
 		user, err := client.GetCurrentUser()
 		if err != nil {
-			p.Info("%s", output.Red("✗"))
+			p.Info("%s", output.Red(output.Sym().Cross))
 			if errors.Is(err, context.Canceled) {
 				return "", nil, err
 			}
@@ -279,7 +279,7 @@ func resolveToken(ctx context.Context, p *output.Printer, serverURL, initial str
 			token = ""
 			continue
 		}
-		p.Info("%s", output.Green("✓"))
+		p.Info("%s", output.Green(output.Sym().Check))
 		return token, user, nil
 	}
 }
@@ -306,7 +306,7 @@ func printTokenInstructions(p *output.Printer, serverURL string, pkceTried bool)
 	if err := browser.OpenURL(tokenURL); err != nil {
 		_, _ = fmt.Fprintf(p.Out, "  Could not open browser. Please visit: %s\n", tokenURL)
 	} else {
-		_, _ = fmt.Fprintln(p.Out, output.Green("  ✓"), "Opened browser")
+		_, _ = fmt.Fprintln(p.Out, output.Green("  "+output.Sym().Check), "Opened browser")
 	}
 	_, _ = fmt.Fprintln(p.Out)
 	return nil

--- a/internal/cmd/auth/pkce.go
+++ b/internal/cmd/auth/pkce.go
@@ -64,7 +64,7 @@ func selectPkceScopes() []string {
 
 	if err := cmdutil.Prompt(huh.NewMultiSelect[string]().
 		Title("Select permissions to request").
-		Description(fmt.Sprintf("%d total · your server role limits the final permission set", len(all))).
+		Description(fmt.Sprintf("%d total "+output.Sym().Sep+" your server role limits the final permission set", len(all))).
 		Options(options...).
 		Value(&selected).
 		Height(7).
@@ -104,7 +104,7 @@ func runPkceLogin(parent context.Context, p *output.Printer, client *api.Client,
 		opening = fmt.Sprintf("Opening browser to authenticate with %d of %d permissions...", len(scopes), total)
 	}
 	p.Info("%s", opening)
-	_, _ = fmt.Fprintf(p.Out, "  %s Approve access in TeamCity\n", output.Yellow("→"))
+	_, _ = fmt.Fprintf(p.Out, "  %s Approve access in TeamCity\n", output.Yellow(output.Sym().Arrow))
 
 	result, err := browserflow.Run(parent, browserflow.Options{
 		Listener:     listener,

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -218,7 +218,7 @@ func renderAuthStatusHuman(f *cmdutil.Factory, results []authStatus) error {
 	_, _ = fmt.Fprintln(p.Out)
 
 	if len(results) == 0 {
-		_, _ = fmt.Fprintln(p.Out, output.Red("✗"), "Not logged in to any TeamCity server")
+		_, _ = fmt.Fprintln(p.Out, output.Red(output.Sym().Cross), "Not logged in to any TeamCity server")
 		_, _ = fmt.Fprintln(p.Out, "\nRun", output.Cyan("teamcity auth login"), "to authenticate")
 		if config.IsBuildEnvironment() {
 			_, _ = fmt.Fprintln(p.Out, "\n"+output.Yellow("!")+" Build environment detected but credentials not found in properties file")
@@ -256,28 +256,28 @@ func renderOneStatus(f *cmdutil.Factory, p *output.Printer, s authStatus) {
 
 	switch {
 	case s.Status == "guest":
-		_, _ = fmt.Fprintf(p.Out, "%s Guest access to %s%s\n", output.Green("✓"), output.Cyan(s.Server), suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s Guest access to %s%s\n", output.Green(output.Sym().Check), output.Cyan(s.Server), suffix)
 		renderServerInfo(p, s)
 
 	case s.Status == "authenticated" && s.AuthMethod == "build":
-		_, _ = fmt.Fprintf(p.Out, "%s Connected to %s\n", output.Green("✓"), output.Cyan(s.Server))
+		_, _ = fmt.Fprintf(p.Out, "%s Connected to %s\n", output.Green(output.Sym().Check), output.Cyan(s.Server))
 		_, _ = fmt.Fprintf(p.Out, "  Auth: %s\n", output.Faint("Build-level credentials"))
 		_, _ = fmt.Fprintf(p.Out, "  Scope: %s\n", output.Faint("Build-level access"))
 		renderServerInfo(p, s)
 
 	case s.Status == "authenticated":
-		_, _ = fmt.Fprintf(p.Out, "%s Logged in to %s%s\n", output.Green("✓"), output.Cyan(s.Server), suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s Logged in to %s%s\n", output.Green(output.Sym().Check), output.Cyan(s.Server), suffix)
 		_, _ = fmt.Fprintf(p.Out, "  %s %s (%s) %s %s\n",
-			output.Faint("User:"), s.User.Name, s.User.Username, output.Faint("·"), output.Faint(tokenSourceLabel(s.TokenSource)))
+			output.Faint("User:"), s.User.Name, s.User.Username, output.Faint(output.Sym().Sep), output.Faint(tokenSourceLabel(s.TokenSource)))
 		renderTokenExpiry(p, s.TokenExpiry)
 		renderServerInfo(p, s)
 
 	case s.Status == "error" && s.AuthMethod == "":
-		_, _ = fmt.Fprintf(p.Out, "%s %s%s\n", output.Red("✗"), s.Server, suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s %s%s\n", output.Red(output.Sym().Cross), s.Server, suffix)
 		renderCredentialsDiagnostic(f.Context(), p, s)
 
 	case s.Status == "error":
-		_, _ = fmt.Fprintf(p.Out, "%s Server: %s%s\n", output.Red("✗"), s.Server, suffix)
+		_, _ = fmt.Fprintf(p.Out, "%s Server: %s%s\n", output.Red(output.Sym().Cross), s.Server, suffix)
 		_, _ = fmt.Fprintf(p.Out, "  %s\n", s.Error)
 	}
 }
@@ -292,7 +292,7 @@ func renderServerInfo(p *output.Printer, s authStatus) {
 	if s.versionCheckErr != "" {
 		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Yellow("!"), s.versionCheckErr)
 	} else {
-		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Green("✓"), output.Faint("API compatible"))
+		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Green(output.Sym().Check), output.Faint("API compatible"))
 	}
 }
 
@@ -307,7 +307,7 @@ func renderTokenExpiry(p *output.Printer, expiry string) {
 	remaining := time.Until(t)
 	switch {
 	case remaining <= 0:
-		_, _ = fmt.Fprintf(p.Out, "  %s Token expired on %s\n", output.Red("✗"), t.Local().Format("Jan 2, 2006"))
+		_, _ = fmt.Fprintf(p.Out, "  %s Token expired on %s\n", output.Red(output.Sym().Cross), t.Local().Format("Jan 2, 2006"))
 		_, _ = fmt.Fprintf(p.Out, "  Run %s to re-authenticate\n", output.Cyan("teamcity auth login"))
 	case remaining <= 3*24*time.Hour:
 		_, _ = fmt.Fprintf(p.Out, "  %s Token expires %s (on %s)\n",
@@ -329,12 +329,12 @@ func renderCredentialsDiagnostic(ctx context.Context, p *output.Printer, s authS
 	}
 
 	_, _ = fmt.Fprintf(p.Out, "  %s To authenticate in this environment:\n", output.Yellow("!"))
-	_, _ = fmt.Fprintf(p.Out, "    • Set %s and %s environment variables\n",
+	_, _ = fmt.Fprintf(p.Out, "    "+output.Sym().Bullet+" Set %s and %s environment variables\n",
 		output.Cyan("TEAMCITY_URL"), output.Cyan("TEAMCITY_TOKEN"))
-	_, _ = fmt.Fprintf(p.Out, "    • Or run %s\n",
+	_, _ = fmt.Fprintf(p.Out, "    "+output.Sym().Bullet+" Or run %s\n",
 		output.Cyan("teamcity auth login --server "+s.Server+" --insecure-storage"))
 	if cmdutil.ProbeGuestAccess(ctx, s.Server) {
-		_, _ = fmt.Fprintf(p.Out, "    • Or set %s for read-only guest access\n", output.Cyan("TEAMCITY_GUEST=1"))
+		_, _ = fmt.Fprintf(p.Out, "    "+output.Sym().Bullet+" Or set %s for read-only guest access\n", output.Cyan("TEAMCITY_GUEST=1"))
 	}
 }
 

--- a/internal/cmd/job/tree.go
+++ b/internal/cmd/job/tree.go
@@ -137,8 +137,8 @@ func runJobTree(f *cmdutil.Factory, jobID string, depth int, only string, jsonOu
 	p.PrintTree(output.TreeNode{
 		Label: output.Cyan(bt.Name),
 		Children: []output.TreeNode{
-			section("▲ Dependents", upNodes),
-			section("▼ Dependencies", downNodes),
+			section(output.Sym().DeltaUp+" Dependents", upNodes),
+			section(output.Sym().DeltaDown+" Dependencies", downNodes),
 		},
 	})
 	return nil

--- a/internal/cmd/link/discover.go
+++ b/internal/cmd/link/discover.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/git"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 )
 
 // projectMatch groups all build types in a single TC project that match a repo's remotes.
@@ -174,10 +175,10 @@ func discoverProjects(client api.ClientInterface, remoteURLs []string) (*discove
 func jobLabel(o jobOption) string {
 	prefix := o.ProjectName
 	if prefix != "" {
-		prefix += " · "
+		prefix += " " + output.Sym().Sep + " "
 	}
 	if o.Pipeline {
-		return prefix + o.Name + "  ⬡ pipeline"
+		return prefix + o.Name + "  " + output.Sym().Pipeline + " pipeline"
 	}
 	return prefix + o.Name
 }

--- a/internal/cmd/link/interactive.go
+++ b/internal/cmd/link/interactive.go
@@ -226,7 +226,7 @@ func pickerClient(f *cmdutil.Factory, serverURL string) (api.ClientInterface, er
 	}
 	token, _, _ := config.GetTokenForServer(serverURL)
 	if token == "" {
-		return nil, fmt.Errorf("no saved credentials for %s — run 'teamcity auth login -s %s'", serverURL, serverURL)
+		return nil, fmt.Errorf("no saved credentials for %s - run 'teamcity auth login -s %s'", serverURL, serverURL)
 	}
 	return api.NewClient(serverURL, token, api.WithVersion(version.String())).WithContext(f.Context()), nil
 }
@@ -325,7 +325,7 @@ func buildGroups(hits []serverResult, hitByURL map[string]*discovery, cfg *link.
 						return []huh.Option[string]{huh.NewOption(output.Faint("(no jobs in this project)"), "")}
 					}
 					out := make([]huh.Option[string], 0, len(jobs)+1)
-					out = append(out, huh.NewOption(output.Faint("(skip — set later)"), ""))
+					out = append(out, huh.NewOption(output.Faint("(skip - set later)"), ""))
 					for _, j := range jobs {
 						out = append(out, huh.NewOption(j.Label, j.ID))
 					}

--- a/internal/cmd/link/interactive.go
+++ b/internal/cmd/link/interactive.go
@@ -336,7 +336,7 @@ func buildGroups(hits []serverResult, hitByURL map[string]*discovery, cfg *link.
 		huh.NewGroup(
 			huh.NewMultiSelect[string]().
 				Title("Select additional jobs").
-				Description("Surfaced in TAB completion alongside the default · saved to teamcity.toml").
+				Description("Surfaced in TAB completion alongside the default "+output.Sym().Sep+" saved to teamcity.toml").
 				OptionsFunc(func() []huh.Option[string] {
 					all := allJobsOnServer(hitByURL[in.server])
 					out := make([]huh.Option[string], 0, len(all))

--- a/internal/cmd/link/link.go
+++ b/internal/cmd/link/link.go
@@ -125,7 +125,7 @@ Resolution cascade (highest to lowest):
 			if label == "" {
 				label = "(top-level)"
 			}
-			f.Printer.Success("Linked %s — %s", output.Cyan(serverURL), label)
+			f.Printer.Success("Linked %s - %s", output.Cyan(serverURL), label)
 			if project != "" {
 				f.Printer.Info("  Project: %s", project)
 			}

--- a/internal/cmd/param/param.go
+++ b/internal/cmd/param/param.go
@@ -64,7 +64,7 @@ build behavior, can reference other parameters, and may be marked
 as password (secure) so their values never appear in logs.
 
 The <%s-id> positional is optional when teamcity.toml binds this
-repo via 'teamcity link' — the linked %s is used automatically.
+repo via 'teamcity link' - the linked %s is used automatically.
 
 See: https://www.jetbrains.com/help/teamcity/configuring-build-parameters.html`, resource, resource, resource, resource),
 		Args: cobra.NoArgs,

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -94,7 +94,7 @@ func runPipelineValidate(f *cmdutil.Factory, file string, opts *validateOptions)
 	}
 
 	_, _ = fmt.Fprintf(f.Printer.ErrOut, "%s %s has %d error(s)\n\n",
-		output.Red("✗"), file, len(validationErrs))
+		output.Red(output.Sym().Cross), file, len(validationErrs))
 
 	for _, ve := range validationErrs {
 		line := findLineNumber(&rootNode, ve.path)

--- a/internal/cmd/project/connection.go
+++ b/internal/cmd/project/connection.go
@@ -158,7 +158,7 @@ func connectionOptions(client api.ClientInterface, projectID string) (ids, label
 			continue
 		}
 		ids = append(ids, feat.ID)
-		labels = append(labels, feat.ID+" — "+name+" ("+ptype+")")
+		labels = append(labels, feat.ID+" - "+name+" ("+ptype+")")
 	}
 	return ids, labels, nil
 }

--- a/internal/cmd/project/connection_create.go
+++ b/internal/cmd/project/connection_create.go
@@ -62,7 +62,7 @@ choice for CI workflows that don't need user-context OAuth.
 In interactive mode, the CLI registers a new App for you via GitHub's manifest
 flow: it opens a browser, you click "Create", and the credentials are captured
 automatically. Use --no-manifest to enter existing credentials manually.`,
-		Example: `  # Interactive — registers a new App via the manifest flow
+		Example: `  # Interactive - registers a new App via the manifest flow
   teamcity project connection create github-app -p Backend
   teamcity project connection create github-app -p Backend --owner my-org
 
@@ -240,7 +240,7 @@ func runConnectionCreateGitHubApp(f *cmdutil.Factory, opts *githubAppOptions) er
 	if interactive && installSlug != "" {
 		stepNum++
 		printWizardStep(f.Printer, stepNum, totalSteps, "Install on a repository",
-			"GitHub Apps grant access per repo — install on the ones TeamCity should clone.")
+			"GitHub Apps grant access per repo - install on the ones TeamCity should clone.")
 		ok := true
 		if err := cmdutil.Confirm("Open a browser to install the App?", &ok); err != nil {
 			return err
@@ -349,7 +349,7 @@ func newConnectionCreateDockerCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Create a Docker registry connection",
 		Long: `Register Docker registry credentials in a TeamCity project.
 
-Stores a long-lived password — prefer a service account / robot user
+Stores a long-lived password - prefer a service account / robot user
 over a personal account.`,
 		Example: `  # Interactive
   teamcity project connection create docker -p Backend

--- a/internal/cmd/project/connection_create.go
+++ b/internal/cmd/project/connection_create.go
@@ -140,7 +140,7 @@ func runConnectionCreateGitHubApp(f *cmdutil.Factory, opts *githubAppOptions) er
 		stepNum++
 		printWizardStep(f.Printer, stepNum, totalSteps, "Register a GitHub App",
 			"You'll be taken to GitHub to confirm the App registration.")
-		_, _ = fmt.Fprintf(f.Printer.Out, "  %s On GitHub, click %q.\n", output.Yellow("→"), "Create GitHub App for "+target)
+		_, _ = fmt.Fprintf(f.Printer.Out, "  %s On GitHub, click %q.\n", output.Yellow(output.Sym().Arrow), "Create GitHub App for "+target)
 		ok := true
 		if err := cmdutil.Confirm("Open a browser to register the App?", &ok); err != nil {
 			return err

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -560,7 +560,7 @@ func projectPickerOptions(f *cmdutil.Factory, permission string) []huh.Option[st
 	for i, p := range roots {
 		label := p.ID
 		if p.Name != "" && p.Name != p.ID {
-			label = p.ID + " — " + p.Name
+			label = p.ID + " - " + p.Name
 		}
 		options[i] = huh.Option[string]{Key: label, Value: p.ID}
 	}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -469,9 +469,9 @@ func (n ProjectTreeNode) toDisplayNode() output.TreeNode {
 		node.Children = append(node.Children, child.toDisplayNode())
 	}
 	for _, p := range n.Pipelines {
-		label := output.Cyan(p.Name) + " " + output.Faint(p.ID) + " " + output.Faint("⬡ pipeline")
+		label := output.Cyan(p.Name) + " " + output.Faint(p.ID) + " " + output.Faint(output.Sym().Pipeline+" pipeline")
 		if p.JobCount > 0 {
-			label += output.Faint(fmt.Sprintf(" · %d jobs", p.JobCount))
+			label += output.Faint(fmt.Sprintf(" "+output.Sym().Sep+" %d jobs", p.JobCount))
 		}
 		node.Children = append(node.Children, output.TreeNode{Label: label})
 	}
@@ -586,7 +586,7 @@ func permissionRoots(projects []api.Project) []api.Project {
 func pickerDescription(total int) string {
 	desc := fmt.Sprintf("%s %s", humanize.Comma(int64(total)), english.PluralWord(total, "project", ""))
 	if total > pickerVisibleRows {
-		desc += " · type to filter"
+		desc += " " + output.Sym().Sep + " type to filter"
 	}
 	return desc
 }

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -117,19 +117,19 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 
 	p := f.Printer
 	if configErr != nil {
-		_, _ = fmt.Fprintf(p.Out, "%s %s %s %s\n", output.Yellow("!"), output.Cyan(project.Name), output.Faint("·"), "not configured")
+		_, _ = fmt.Fprintf(p.Out, "%s %s %s %s\n", output.Yellow("!"), output.Cyan(project.Name), output.Faint(output.Sym().Sep), "not configured")
 		_, _ = fmt.Fprintf(p.Out, "\n%s\n", output.Faint(configErr.Error()))
 		return nil
 	}
 
-	statusIcon := output.Green("✓")
+	statusIcon := output.Green(output.Sym().Check)
 	statusLabel := "synchronized"
 	if statusErr != nil {
-		statusIcon = output.Red("✗")
+		statusIcon = output.Red(output.Sym().Cross)
 		statusLabel = "unavailable"
 	} else {
 		if syncingStatus := getSyncingStatus(status.Message); syncingStatus != "" {
-			statusIcon = output.Cyan("⟳")
+			statusIcon = output.Cyan(output.Sym().Recycle)
 			statusLabel = syncingStatus
 		} else {
 			switch status.Type {
@@ -137,7 +137,7 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 				statusIcon = output.Yellow("!")
 				statusLabel = "warning"
 			case "error":
-				statusIcon = output.Red("✗")
+				statusIcon = output.Red(output.Sym().Cross)
 				statusLabel = "error"
 			}
 		}
@@ -147,7 +147,7 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 	if project.ID != project.Name {
 		header += " " + output.Faint("("+project.ID+")")
 	}
-	_, _ = fmt.Fprintf(p.Out, "%s %s %s %s\n", statusIcon, header, output.Faint("·"), statusLabel)
+	_, _ = fmt.Fprintf(p.Out, "%s %s %s %s\n", statusIcon, header, output.Faint(output.Sym().Sep), statusLabel)
 
 	_, _ = fmt.Fprintln(p.Out)
 	_, _ = fmt.Fprintf(p.Out, "%-12s %s\n", output.Faint("Format"), formatSettingsFormat(cfg.Format))
@@ -413,7 +413,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 		}
 		errs := parseKotlinErrors(combinedOutput)
 
-		_, _ = fmt.Fprintf(p.Out, "%s Configuration invalid\n", output.Red("✗"))
+		_, _ = fmt.Fprintf(p.Out, "%s Configuration invalid\n", output.Red(output.Sym().Cross))
 		if len(errs) > 0 {
 			_, _ = fmt.Fprintln(p.Out)
 			for _, e := range errs {
@@ -432,7 +432,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 		return f.Printer.PrintJSON(validateResultJSON{Valid: true, Path: dslDir})
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "%s Configuration valid\n", output.Green("✓"))
+	_, _ = fmt.Fprintf(p.Out, "%s Configuration valid\n", output.Green(output.Sym().Check))
 
 	if serverURL := config.DetectServerFromDSL(); serverURL != "" {
 		_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Faint("Server:"), serverURL)

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -456,7 +456,7 @@ func resolveAuth(f *cmdutil.Factory, client api.ClientInterface, projectID, auth
 				return nil, testReq, fmt.Errorf("failed to list SSH keys: %w", err)
 			}
 			if len(names) == 0 {
-				return nil, testReq, fmt.Errorf("no SSH keys uploaded to project %s — upload one with: teamcity project ssh upload", projectID)
+				return nil, testReq, fmt.Errorf("no SSH keys uploaded to project %s - upload one with: teamcity project ssh upload", projectID)
 			}
 			options := make([]huh.Option[string], len(names))
 			for i, n := range names {

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -635,11 +635,11 @@ func runConnectionTest(f *cmdutil.Factory, client api.ClientInterface, req api.T
 	_, _ = fmt.Fprint(f.Printer.ErrOut, "Testing connection... ")
 	result, err := client.TestVcsConnection(req, projectID)
 	if err != nil {
-		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red("✗"))
+		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Sym().Cross))
 		return fmt.Errorf("connection test failed: %w", err)
 	}
 	if result.Status != "OK" {
-		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red("✗"))
+		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Sym().Cross))
 		msg := "connection test failed"
 		if len(result.Errors) > 0 {
 			msg = result.Errors[0].Message
@@ -650,7 +650,7 @@ func runConnectionTest(f *cmdutil.Factory, client api.ClientInterface, req api.T
 		}
 		return fmt.Errorf("%s", msg)
 	}
-	_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Green("✓"))
+	_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Green(output.Sym().Check))
 	return nil
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -55,7 +55,7 @@ Report issues:  https://jb.gg/tc/issues`,
 			_, _ = fmt.Fprintln(out, "Usage: teamcity <command> [flags]")
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintln(out, "Common commands:")
-			_, _ = fmt.Fprintln(out, "  auth login              Authenticate with TeamCity")
+			_, _ = fmt.Fprintln(out, "  auth login              Authenticate (or set TEAMCITY_URL + TEAMCITY_TOKEN)")
 			_, _ = fmt.Fprintln(out, "  run list                List recent runs")
 			_, _ = fmt.Fprintln(out, "  run start <job>         Trigger a new run")
 			_, _ = fmt.Fprintln(out, "  run view <id>           View run details")

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -45,10 +46,12 @@ Report issues:  https://jb.gg/tc/issues`,
 		Version: version.String(),
 		Run: func(cmd *cobra.Command, args []string) {
 			out := f.Printer.Out
-			output.PrintLogo(out)
-			_, _ = fmt.Fprintln(out)
-			_, _ = fmt.Fprintln(out, "TeamCity CLI "+output.Faint("v"+version.String())+" - "+output.Faint("https://jb.gg/tc/docs"))
-			_, _ = fmt.Fprintln(out)
+			if !f.Quiet && os.Getenv("TERM") != "dumb" {
+				output.PrintLogo(out)
+				_, _ = fmt.Fprintln(out)
+				_, _ = fmt.Fprintln(out, "TeamCity CLI "+output.Faint("v"+version.String())+" - "+output.Faint("https://jb.gg/tc/docs"))
+				_, _ = fmt.Fprintln(out)
+			}
 			_, _ = fmt.Fprintln(out, "Usage: teamcity <command> [flags]")
 			_, _ = fmt.Fprintln(out)
 			_, _ = fmt.Fprintln(out, "Common commands:")

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -245,14 +245,14 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		switch t.Status {
 		case "FAILURE":
 			if t.Muted {
-				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("⊘"), t.Name)
+				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint(output.Sym().Skip), t.Name)
 			} else {
-				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Red("✗"), t.Name)
+				_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Red(output.Sym().Cross), t.Name)
 			}
 		case "SUCCESS":
-			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Green("✓"), t.Name)
+			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Green(output.Sym().Check), t.Name)
 		default:
-			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("○"), t.Name)
+			_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint(output.Sym().Neutral), t.Name)
 		}
 	}
 

--- a/internal/cmd/run/compatibility.go
+++ b/internal/cmd/run/compatibility.go
@@ -88,7 +88,7 @@ func renderAgentGroup(w io.Writer, title string, total int, agents []api.Agent, 
 			_, _ = fmt.Fprintf(w, "  %s %d\n", output.Faint("["+pool.name+"]"), len(pool.agents))
 		}
 		if total > len(agents) {
-			_, _ = fmt.Fprintf(w, "  %s %d more not shown\n", output.Faint("…"), total-len(agents))
+			_, _ = fmt.Fprintf(w, "  %s %d more not shown\n", output.Faint(output.Sym().Ellipsis), total-len(agents))
 		}
 	}
 }
@@ -172,7 +172,7 @@ func renderIncompatibilityReasons(w io.Writer, client api.ClientInterface, build
 		}
 		_, _ = fmt.Fprintf(w, "  %s\n", r.agent.Name)
 		for _, reason := range r.reasons {
-			_, _ = fmt.Fprintf(w, "    %s %s\n", output.Red("•"), reason)
+			_, _ = fmt.Fprintf(w, "    %s %s\n", output.Red(output.Sym().Bullet), reason)
 		}
 	}
 }

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -394,17 +394,17 @@ func renderDiffHeader(p *output.Printer, b1, b2 *api.Build) {
 		jobName = b1.BuildType.Name
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "COMPARING  %s %d  #%s  →  %s %d  #%s\n",
+	_, _ = fmt.Fprintf(p.Out, "COMPARING  %s %d  #%s  "+output.Sym().Arrow+"  %s %d  #%s\n",
 		icon1, b1.ID, b1.Number, icon2, b2.ID, b2.Number)
 
 	meta := output.Faint("Job: ") + output.Cyan(jobName)
 	if b1.BranchName != "" || b2.BranchName != "" {
 		branch := b1.BranchName
 		if b2.BranchName != "" && b2.BranchName != b1.BranchName {
-			branch = b1.BranchName + " → " + b2.BranchName
+			branch = b1.BranchName + " " + output.Sym().Arrow + " " + b2.BranchName
 		}
 		if branch != "" {
-			meta += output.Faint("  ·  Branch: ") + branch
+			meta += output.Faint("  "+output.Sym().Sep+"  Branch: ") + branch
 		}
 	}
 	_, _ = fmt.Fprintln(p.Out, meta)
@@ -502,7 +502,7 @@ func renderParamsDiff(p *output.Printer, params1, params2 *api.ParameterList) bo
 	for _, c := range diffs {
 		switch c.kind {
 		case "changed":
-			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s → %s\n",
+			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s "+output.Sym().Arrow+" %s\n",
 				output.Yellow("~"), c.name, output.Red(c.old), output.Green(c.new))
 		case "added":
 			_, _ = fmt.Fprintf(p.Out, "  %s %s: %s\n",
@@ -552,7 +552,7 @@ func renderTestsDiff(p *output.Printer, t1, t2, s1, s2 *api.TestOccurrences) boo
 	if len(newFailures) > 0 {
 		_, _ = fmt.Fprintf(p.Out, "  %s\n", output.Red("New failures:"))
 		for _, t := range newFailures {
-			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red("✗"), t.Name)
+			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Red(output.Sym().Cross), t.Name)
 			if t.Details != "" {
 				_, _ = fmt.Fprintf(p.Out, "      %s\n", output.Faint(truncate(t.Details, 120)))
 			}
@@ -562,7 +562,7 @@ func renderTestsDiff(p *output.Printer, t1, t2, s1, s2 *api.TestOccurrences) boo
 	if len(fixed) > 0 {
 		_, _ = fmt.Fprintf(p.Out, "  %s\n", output.Green("Fixed:"))
 		for _, name := range fixed {
-			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Green("✓"), name)
+			_, _ = fmt.Fprintf(p.Out, "    %s %s\n", output.Green(output.Sym().Check), name)
 		}
 	}
 

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -117,21 +117,21 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 	for _, artifact := range flatList {
 		rel, err := filepath.Rel(absOutput, filepath.Join(absOutput, artifact.Name))
 		if err != nil || !filepath.IsLocal(rel) {
-			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s path escapes output directory\n", nameWidth, artifact.Name, "", output.Red("   ✗"))
+			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s path escapes output directory\n", nameWidth, artifact.Name, "", output.Red("   "+output.Sym().Cross))
 			continue
 		}
 		outputPath := filepath.Join(absOutput, rel)
 		size := humanize.IBytes(uint64(artifact.Size))
 
 		if err := downloadArtifact(ctx, client, runID, artifact, outputPath, nameWidth, p.Quiet, p.Out); err != nil {
-			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s %v\n", nameWidth, artifact.Name, size, output.Red("   ✗"), err)
+			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s %v\n", nameWidth, artifact.Name, size, output.Red("   "+output.Sym().Cross), err)
 			continue
 		}
-		_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s\n", nameWidth, artifact.Name, size, output.Green("   ✓"))
+		_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s\n", nameWidth, artifact.Name, size, output.Green("   "+output.Sym().Check))
 		downloaded++
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "\n%s %s downloaded\n", output.Green("✓"), english.Plural(downloaded, "artifact", ""))
+	_, _ = fmt.Fprintf(p.Out, "\n%s %s downloaded\n", output.Green(output.Sym().Check), english.Plural(downloaded, "artifact", ""))
 	return nil
 }
 

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -401,14 +401,14 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 	icon := output.StatusIcon(build.Status, build.State, build.StatusText)
 	jobName := build.BuildTypeID
 	if pipelineRun != nil && pipelineRun.Pipeline != nil && pipelineRun.Pipeline.Name != "" {
-		jobName = pipelineRun.Pipeline.Name + " ⬡"
+		jobName = pipelineRun.Pipeline.Name + " " + output.Sym().Pipeline
 	} else if build.BuildType != nil {
 		jobName = build.BuildType.Name
 	}
 
 	_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s", icon, output.Cyan(jobName), build.ID, build.Number)
 	if build.BranchName != "" {
-		_, _ = fmt.Fprintf(p.Out, " · %s", build.BranchName)
+		_, _ = fmt.Fprintf(p.Out, " "+output.Sym().Sep+" %s", build.BranchName)
 	}
 	_, _ = fmt.Fprintln(p.Out)
 
@@ -421,19 +421,19 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 
 		if build.StartDate != "" {
 			startTime, _ := api.ParseTeamCityTime(build.StartDate)
-			_, _ = fmt.Fprintf(p.Out, " · %s", output.RelativeTime(startTime))
+			_, _ = fmt.Fprintf(p.Out, " "+output.Sym().Sep+" %s", output.RelativeTime(startTime))
 
 			if build.FinishDate != "" {
 				finishTime, _ := api.ParseTeamCityTime(build.FinishDate)
 				duration := finishTime.Sub(startTime)
-				_, _ = fmt.Fprintf(p.Out, " · Took %s", output.FormatDuration(duration))
+				_, _ = fmt.Fprintf(p.Out, " "+output.Sym().Sep+" Took %s", output.FormatDuration(duration))
 			}
 		}
 		_, _ = fmt.Fprintln(p.Out)
 	}
 
 	if build.UsedByOtherBuilds {
-		_, _ = fmt.Fprintf(p.Out, "\n%s Results shared in build chain\n", output.Yellow("⟳"))
+		_, _ = fmt.Fprintf(p.Out, "\n%s Results shared in build chain\n", output.Yellow(output.Sym().Recycle))
 	}
 
 	if build.StatusText != "" && build.StatusText != build.Status {
@@ -454,13 +454,13 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 	if build.Agent != nil {
 		_, _ = fmt.Fprintf(p.Out, "\nAgent: %s", output.Faint(build.Agent.Name))
 		if build.State == "running" {
-			_, _ = fmt.Fprintf(p.Out, "  %s teamcity agent term %d", output.Faint("·"), build.Agent.ID)
+			_, _ = fmt.Fprintf(p.Out, "  %s teamcity agent term %d", output.Faint(output.Sym().Sep), build.Agent.ID)
 		}
 		_, _ = fmt.Fprintln(p.Out)
 	}
 
 	if build.Pinned {
-		_, _ = fmt.Fprintf(p.Out, "\n%s\n", output.Yellow("📌 Pinned"))
+		_, _ = fmt.Fprintf(p.Out, "\n%s\n", output.Yellow(output.Sym().Pinned+" Pinned"))
 	}
 
 	if build.Tags != nil && len(build.Tags.Tag) > 0 {

--- a/internal/cmd/run/tree.go
+++ b/internal/cmd/run/tree.go
@@ -96,9 +96,9 @@ func runRunTree(f *cmdutil.Factory, runID string, depth int, jsonOut bool) error
 
 func printPipelineTree(p *output.Printer, build *api.Build, pr *api.PipelineRun, node RunTreeNode) {
 	icon := output.StatusIcon(build.Status, build.State, build.StatusText)
-	header := fmt.Sprintf("%s %s ⬡  %d  #%s", icon, output.Cyan(pr.Pipeline.Name), build.ID, build.Number)
+	header := fmt.Sprintf("%s %s "+output.Sym().Pipeline+"  %d  #%s", icon, output.Cyan(pr.Pipeline.Name), build.ID, build.Number)
 	if build.BranchName != "" {
-		header += "  · " + build.BranchName
+		header += "  " + output.Sym().Sep + " " + build.BranchName
 	}
 	_, _ = fmt.Fprintln(p.Out, header)
 
@@ -151,7 +151,7 @@ func buildStatusSummary(deps []RunTreeNode) string {
 	if queued > 0 {
 		parts = append(parts, output.Faint(fmt.Sprintf("%d queued", queued)))
 	}
-	return strings.Join(parts, " · ")
+	return strings.Join(parts, " "+output.Sym().Sep+" ")
 }
 
 func buildRunTree(client api.ClientInterface, b api.Build, depth int, path map[string]bool) (RunTreeNode, error) {

--- a/internal/cmd/run/tui/tui.go
+++ b/internal/cmd/run/tui/tui.go
@@ -196,7 +196,7 @@ func (m watchModel) View() string {
 	}
 	footer := output.Faint("q quit")
 	if m.build != nil && m.build.Agent != nil {
-		footer += output.Faint("  ·  ") + output.Cyan(fmt.Sprintf("teamcity agent term %d", m.build.Agent.ID))
+		footer += output.Faint("  "+output.Sym().Sep+"  ") + output.Cyan(fmt.Sprintf("teamcity agent term %d", m.build.Agent.ID))
 	}
 	b.WriteString(footer + output.Faint(spinnerView))
 
@@ -216,7 +216,7 @@ func (m watchModel) renderHeader() string {
 	icon := output.StatusIcon(m.build.Status, m.build.State, m.build.StatusText)
 	status := output.StatusText(m.build.Status, m.build.State, m.build.StatusText)
 
-	header := fmt.Sprintf("%s %s %d  #%s %s · %s", icon, output.Bold(jobName), m.build.ID, m.build.Number, output.Faint(m.build.WebURL), status)
+	header := fmt.Sprintf("%s %s %d  #%s %s "+output.Sym().Sep+" %s", icon, output.Bold(jobName), m.build.ID, m.build.Number, output.Faint(m.build.WebURL), status)
 	if m.build.PercentageComplete > 0 && m.build.State != "finished" {
 		header += fmt.Sprintf(" (%d%%)", m.build.PercentageComplete)
 	}

--- a/internal/cmd/run/watch.go
+++ b/internal/cmd/run/watch.go
@@ -165,7 +165,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) (resErr
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				if !opts.json {
-					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red("✗"))
+					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red(output.Sym().Cross))
 				}
 				return &cmdutil.ExitError{Code: cmdutil.ExitTimeout}
 			}
@@ -223,14 +223,14 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) (resErr
 			if build.State == "queued" {
 				status = output.Faint("Queued")
 				if build.WaitReason != "" {
-					status = output.Faint("Queued · " + build.WaitReason)
+					status = output.Faint("Queued " + output.Sym().Sep + " " + build.WaitReason)
 				}
 			}
 			progress := ""
 			if build.PercentageComplete > 0 {
 				progress = fmt.Sprintf(" (%d%%)", build.PercentageComplete)
 			}
-			_, _ = fmt.Fprintf(p.Out, "\r%s %s %d  #%s %s · %s%s    ",
+			_, _ = fmt.Fprintf(p.Out, "\r%s %s %d  #%s %s "+output.Sym().Sep+" %s%s    ",
 				output.StatusIcon(build.Status, build.State, build.StatusText),
 				output.Cyan(jobName),
 				build.ID,
@@ -267,7 +267,7 @@ func doRunWatch(f *cmdutil.Factory, runID string, opts *runWatchOptions) (resErr
 		case <-ctx.Done():
 			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 				if !opts.json {
-					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red("✗"))
+					_, _ = fmt.Fprintf(p.Out, "\n%s Timeout exceeded\n", output.Red(output.Sym().Cross))
 				}
 				return &cmdutil.ExitError{Code: cmdutil.ExitTimeout}
 			}

--- a/internal/cmd/skill/skill.go
+++ b/internal/cmd/skill/skill.go
@@ -8,6 +8,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/tiulpin/instill"
 )
@@ -201,9 +202,9 @@ func runSkillInstall(f *cmdutil.Factory, opts *skillOptions, args []string, chec
 		case !r.Existed:
 			p.Success("Installed %s for %s (%s)", r.Skill, r.Agent, bundled)
 		case r.PriorVersion != "" && r.PriorVersion != bundled:
-			p.Success("Updated %s for %s (%s → %s)", r.Skill, r.Agent, r.PriorVersion, bundled)
+			p.Success("Updated %s for %s (%s "+output.Sym().Arrow+" %s)", r.Skill, r.Agent, r.PriorVersion, bundled)
 		case r.PriorVersion == "":
-			p.Success("Updated %s for %s (unversioned → %s)", r.Skill, r.Agent, bundled)
+			p.Success("Updated %s for %s (unversioned "+output.Sym().Arrow+" %s)", r.Skill, r.Agent, bundled)
 		default:
 			p.Success("Reinstalled %s for %s (%s)", r.Skill, r.Agent, bundled)
 		}

--- a/internal/cmd/update/update.go
+++ b/internal/cmd/update/update.go
@@ -51,7 +51,7 @@ func runUpdate(f *cmdutil.Factory) error {
 	}
 
 	method := update.DetectInstallMethod()
-	_, _ = fmt.Fprintf(p.Out, "%s → %s: %s\n%s\n",
+	_, _ = fmt.Fprintf(p.Out, "%s "+output.Sym().Arrow+" %s: %s\n%s\n",
 		output.Faint("v"+version.Version),
 		output.Green("v"+release.Version),
 		output.Bold(method.UpdateCommand()),

--- a/internal/cmdutil/experimental.go
+++ b/internal/cmdutil/experimental.go
@@ -15,7 +15,7 @@ func MarkExperimental(f *Factory, cmd *cobra.Command) {
 		return
 	}
 	cmd.RunE = func(cmd *cobra.Command, args []string) error {
-		f.Printer.Warn("%q is experimental: flags, output, and JSON schema may change or the command may be removed without notice. It is intentionally undocumented — do not rely on it in scripts.", cmd.CommandPath())
+		f.Printer.Warn("%q is experimental: flags, output, and JSON schema may change or the command may be removed without notice. It is intentionally undocumented - do not rely on it in scripts.", cmd.CommandPath())
 		return inner(cmd, args)
 	}
 }

--- a/internal/cmdutil/factory.go
+++ b/internal/cmdutil/factory.go
@@ -91,6 +91,10 @@ func (f *Factory) InitOutput() {
 	output.NoColor = !forceColor &&
 		(explicitDisable || os.Getenv("TERM") == "dumb" || !term.IsTerminal(int(os.Stdout.Fd())))
 
+	output.ASCII = os.Getenv("TEAMCITY_ASCII") != "" ||
+		os.Getenv("TERM") == "dumb" ||
+		!output.ConsoleSupportsUTF8()
+
 	f.Printer.Quiet = f.Quiet
 	f.Printer.Verbose = f.Verbose
 }

--- a/internal/cmdutil/failure.go
+++ b/internal/cmdutil/failure.go
@@ -14,7 +14,7 @@ import (
 const maxFailedTestsToShow = 10
 
 func PrintFailureSummary(ctx context.Context, p *output.Printer, client api.ClientInterface, buildID, buildNumber, webURL, statusText string) {
-	header := fmt.Sprintf("%s %s  #%s failed", output.Red("✗"), buildID, buildNumber)
+	header := fmt.Sprintf("%s %s  #%s failed", output.Red(output.Sym().Cross), buildID, buildNumber)
 	if statusText != "" {
 		header += ": " + statusText
 	}
@@ -43,14 +43,14 @@ func PrintFailureSummary(ctx context.Context, p *output.Printer, client api.Clie
 			if detail == "" {
 				detail = prob.Identity
 			}
-			_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Red("•"), detail)
+			_, _ = fmt.Fprintf(p.Out, "  %s %s\n", output.Red(output.Sym().Bullet), detail)
 		}
 	}
 
 	if testsErr == nil && tests != nil && tests.Failed > 0 {
 		_, _ = fmt.Fprintf(p.Out, "\nFailed tests (%d):\n", tests.Failed)
 		for _, t := range tests.TestOccurrence {
-			line := fmt.Sprintf("  %s %s", output.Red("•"), t.Name)
+			line := fmt.Sprintf("  %s %s", output.Red(output.Sym().Bullet), t.Name)
 			if t.Duration > 0 {
 				dur := time.Duration(t.Duration) * time.Millisecond
 				line += " " + output.Faint("("+output.FormatDuration(dur)+")")
@@ -85,7 +85,7 @@ func BuildResultError(ctx context.Context, p *output.Printer, client api.ClientI
 
 	switch build.Status {
 	case "SUCCESS":
-		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s succeeded\n", output.Green("✓"), output.Cyan(jobName), build.ID, build.Number)
+		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s succeeded\n", output.Green(output.Sym().Check), output.Cyan(jobName), build.ID, build.Number)
 		if showDetails {
 			_, _ = fmt.Fprintf(p.Out, "\nView details: %s\n", build.WebURL)
 		}
@@ -94,7 +94,7 @@ func BuildResultError(ctx context.Context, p *output.Printer, client api.ClientI
 		PrintFailureSummary(ctx, p, client, strconv.Itoa(build.ID), build.Number, build.WebURL, build.StatusText)
 		return &ExitError{Code: ExitFailure}
 	default:
-		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s canceled\n", output.Yellow("○"), output.Cyan(jobName), build.ID, build.Number)
+		_, _ = fmt.Fprintf(p.Out, "%s %s %d  #%s canceled\n", output.Yellow(output.Sym().Neutral), output.Cyan(jobName), build.ID, build.Number)
 		return &ExitError{Code: ExitCancelled}
 	}
 }

--- a/internal/cmdutil/prompt.go
+++ b/internal/cmdutil/prompt.go
@@ -141,18 +141,18 @@ func promptTheme() *huh.Theme {
 		t.Focused.Title = plain.Bold(true)
 		t.Focused.NoteTitle = plain.Bold(true)
 		t.Focused.Description = plain.Foreground(faint)
-		t.Focused.ErrorIndicator = plain.Foreground(red).SetString(" ✗")
+		t.Focused.ErrorIndicator = plain.Foreground(red).SetString(" " + output.Sym().Cross)
 		t.Focused.ErrorMessage = plain.Foreground(red)
 
-		t.Focused.SelectSelector = plain.Foreground(yellow).SetString("→ ")
-		t.Focused.NextIndicator = plain.Foreground(yellow).MarginLeft(1).SetString("→")
-		t.Focused.PrevIndicator = plain.Foreground(yellow).MarginRight(1).SetString("←")
+		t.Focused.SelectSelector = plain.Foreground(yellow).SetString(output.Sym().Arrow + " ")
+		t.Focused.NextIndicator = plain.Foreground(yellow).MarginLeft(1).SetString(output.Sym().Arrow)
+		t.Focused.PrevIndicator = plain.Foreground(yellow).MarginRight(1).SetString(output.Sym().ArrowLeft)
 		t.Focused.Option = plain
 		t.Focused.SelectedOption = plain
 
-		t.Focused.MultiSelectSelector = plain.Foreground(yellow).SetString("→ ")
-		t.Focused.SelectedPrefix = plain.Foreground(green).SetString("✓ ")
-		t.Focused.UnselectedPrefix = plain.Foreground(faint).SetString("• ")
+		t.Focused.MultiSelectSelector = plain.Foreground(yellow).SetString(output.Sym().Arrow + " ")
+		t.Focused.SelectedPrefix = plain.Foreground(green).SetString(output.Sym().Check + " ")
+		t.Focused.UnselectedPrefix = plain.Foreground(faint).SetString(output.Sym().Bullet + " ")
 		t.Focused.UnselectedOption = plain
 
 		t.Focused.FocusedButton = plain.Bold(true).Foreground(cyan).MarginLeft(3)

--- a/internal/output/color.go
+++ b/internal/output/color.go
@@ -15,6 +15,12 @@ import (
 // tests flip it directly for deterministic golden output.
 var NoColor bool
 
+// ASCII restricts output to 7-bit ASCII glyphs when true. Factory.InitOutput
+// writes it from TEAMCITY_ASCII / TERM=dumb / console-codepage detection;
+// tests flip it directly for deterministic golden output. Orthogonal to
+// NoColor: color and glyph repertoire are independent terminal capabilities.
+var ASCII bool
+
 // ansiRenderer emits 16-color ANSI SGR sequences regardless of the detected
 // terminal profile, so output bytes are stable across TTY / piped / CI contexts.
 var ansiRenderer = lipgloss.NewRenderer(os.Stdout)

--- a/internal/output/logo.go
+++ b/internal/output/logo.go
@@ -17,7 +17,18 @@ const Logo = `████████╗ ██████╗
    ██║   ╚██████╗
    ╚═╝    ╚═════╝`
 
+// LogoASCII is the 7-bit fallback wordmark for terminals that can't render Logo.
+const LogoASCII = `######## ######
+   ##    ##
+   ##    ##
+   ##    ##
+   ##    ######`
+
 func PrintLogo(w io.Writer) {
+	if ASCII {
+		_, _ = fmt.Fprintln(w, Cyan("\n"+LogoASCII))
+		return
+	}
 	if !IsTerminal() {
 		_, _ = fmt.Fprintln(w, Cyan("\n"+Logo))
 		return

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -38,7 +38,7 @@ func (p *Printer) Success(format string, args ...any) {
 	if p.Quiet {
 		return
 	}
-	p.write(p.Out, fmt.Sprintf("%s %s\n", Green("✓"), fmt.Sprintf(format, args...)))
+	p.write(p.Out, fmt.Sprintf("%s %s\n", Green(Sym().Check), fmt.Sprintf(format, args...)))
 }
 
 func (p *Printer) Info(format string, args ...any) {
@@ -128,10 +128,11 @@ func (p *Printer) PrintTree(root TreeNode) {
 }
 
 func writeTreeNodes(w io.Writer, nodes []TreeNode, prefix string) {
+	s := Sym()
 	for i, n := range nodes {
-		conn, next := "├── ", "│   "
+		conn, next := s.TreeMid, s.TreePipe
 		if i == len(nodes)-1 {
-			conn, next = "└── ", "    "
+			conn, next = s.TreeEnd, s.TreeGap
 		}
 		_, _ = fmt.Fprintf(w, "%s%s%s\n", prefix, conn, n.Label)
 		writeTreeNodes(w, n.Children, prefix+next)

--- a/internal/output/status.go
+++ b/internal/output/status.go
@@ -6,28 +6,36 @@ func isCanceled(status, statusText string) bool {
 	return strings.EqualFold(status, "UNKNOWN") && strings.HasPrefix(strings.ToLower(statusText), "canceled")
 }
 
-// StatusIcon returns a colored status icon.
+// StatusIcon returns a colored status icon. In ASCII mode the glyph degrades to
+// its PlainStatusIcon equivalent while keeping the color.
 func StatusIcon(status, state string, statusText ...string) string {
-	if state == "running" {
-		return Yellow("●")
+	glyph, color := statusGlyph(status, state, statusText...)
+	if ASCII {
+		glyph = PlainStatusIcon(status, state, statusText...)
 	}
-	if state == "queued" {
-		return Faint("◦")
-	}
+	return color(glyph)
+}
 
-	if len(statusText) > 0 && isCanceled(status, statusText[0]) {
-		return Faint("⊘")
+// statusGlyph returns the Unicode icon and its color function for a status.
+func statusGlyph(status, state string, statusText ...string) (string, func(...any) string) {
+	switch {
+	case state == "running":
+		return "●", Yellow
+	case state == "queued":
+		return "◦", Faint
+	case len(statusText) > 0 && isCanceled(status, statusText[0]):
+		return "⊘", Faint
 	}
 
 	switch strings.ToUpper(status) {
 	case "SUCCESS":
-		return Green("✓")
+		return "✓", Green
 	case "FAILURE", "ERROR":
-		return Red("✗")
+		return "✗", Red
 	case "UNKNOWN":
-		return Yellow("?")
+		return "?", Yellow
 	default:
-		return Faint("○")
+		return "○", Faint
 	}
 }
 

--- a/internal/output/symbols.go
+++ b/internal/output/symbols.go
@@ -1,0 +1,49 @@
+package output
+
+// Symbols is the glyph vocabulary for status marks and structural decoration.
+// Sym() returns the Unicode set, or an ASCII-only set when ASCII is true. The
+// ASCII status marks match PlainStatusIcon so both modes share one repertoire.
+type Symbols struct {
+	Check     string // success
+	Cross     string // failure
+	Neutral   string // neutral / unknown
+	Skip      string // canceled / skipped
+	Arrow     string // transition / "then"
+	ArrowLeft string
+	Bullet    string // list item
+	Sep       string // inline separator (callers supply surrounding spaces)
+	Pipeline  string // pipeline marker
+	Recycle   string // rebuilding / shared result
+	Pinned    string
+	DeltaUp   string
+	DeltaDown string
+	Ellipsis  string
+	TreeMid   string // child with following siblings
+	TreeEnd   string // last child
+	TreePipe  string // vertical run under TreeMid
+	TreeGap   string // blank run under TreeEnd
+}
+
+var unicodeSymbols = Symbols{
+	Check: "✓", Cross: "✗", Neutral: "○", Skip: "⊘",
+	Arrow: "→", ArrowLeft: "←", Bullet: "•", Sep: "·",
+	Pipeline: "⬡", Recycle: "⟳", Pinned: "📌",
+	DeltaUp: "▲", DeltaDown: "▼", Ellipsis: "…",
+	TreeMid: "├── ", TreeEnd: "└── ", TreePipe: "│   ", TreeGap: "    ",
+}
+
+var asciiSymbols = Symbols{
+	Check: "+", Cross: "x", Neutral: "-", Skip: "/",
+	Arrow: "->", ArrowLeft: "<-", Bullet: "*", Sep: "|",
+	Pipeline: "*", Recycle: "~", Pinned: "*",
+	DeltaUp: "^", DeltaDown: "v", Ellipsis: "...",
+	TreeMid: "|-- ", TreeEnd: "`-- ", TreePipe: "|   ", TreeGap: "    ",
+}
+
+// Sym returns the active glyph set for the current ASCII mode.
+func Sym() Symbols {
+	if ASCII {
+		return asciiSymbols
+	}
+	return unicodeSymbols
+}

--- a/internal/output/symbols_test.go
+++ b/internal/output/symbols_test.go
@@ -1,0 +1,68 @@
+package output
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/stretchr/testify/assert"
+)
+
+// withASCII flips the global ASCII mode for the duration of a (non-parallel) test.
+func withASCII(t *testing.T, v bool) {
+	t.Helper()
+	prev := ASCII
+	ASCII = v
+	t.Cleanup(func() { ASCII = prev })
+}
+
+func TestSymSelectsMode(t *testing.T) {
+	withASCII(t, false)
+	assert.Equal(t, "→", Sym().Arrow)
+	withASCII(t, true)
+	assert.Equal(t, "->", Sym().Arrow)
+}
+
+func TestASCIISymbolsArePureASCII(t *testing.T) {
+	t.Parallel()
+	v := reflect.ValueOf(asciiSymbols)
+	for i := range v.NumField() {
+		field := v.Type().Field(i).Name
+		for _, r := range v.Field(i).String() {
+			assert.Lessf(t, r, rune(0x80), "asciiSymbols.%s contains non-ASCII %q", field, r)
+		}
+	}
+}
+
+func TestStatusIconASCIIMatchesPlain(t *testing.T) {
+	withASCII(t, true)
+	cases := []struct{ status, state, text string }{
+		{"SUCCESS", "", ""},
+		{"FAILURE", "", ""},
+		{"UNKNOWN", "", "Canceled (user)"},
+		{"OTHER", "", ""},
+		{"", "running", ""},
+		{"", "queued", ""},
+	}
+	for _, c := range cases {
+		got := ansi.Strip(StatusIcon(c.status, c.state, c.text))
+		assert.Equal(t, PlainStatusIcon(c.status, c.state, c.text), got)
+	}
+}
+
+func TestPrintTreeASCIIConnectors(t *testing.T) {
+	withASCII(t, true)
+	var buf bytes.Buffer
+	p := &Printer{Out: &buf}
+	p.PrintTree(TreeNode{Label: "root", Children: []TreeNode{
+		{Label: "a", Children: []TreeNode{{Label: "a1"}}},
+		{Label: "b"},
+	}})
+	out := buf.String()
+	assert.Contains(t, out, "|-- a")
+	assert.Contains(t, out, "`-- b")
+	for _, r := range out {
+		assert.Less(t, r, rune(0x80), "tree output must be ASCII-only")
+	}
+}

--- a/internal/output/utf8_other.go
+++ b/internal/output/utf8_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package output
+
+// ConsoleSupportsUTF8 reports whether the active console can render UTF-8.
+// Non-Windows terminals are assumed UTF-8 capable; force ASCII with
+// TEAMCITY_ASCII when that assumption is wrong.
+func ConsoleSupportsUTF8() bool { return true }

--- a/internal/output/utf8_windows.go
+++ b/internal/output/utf8_windows.go
@@ -1,0 +1,18 @@
+package output
+
+import "golang.org/x/sys/windows"
+
+// cpUTF8 is the Windows console code page for UTF-8.
+const cpUTF8 = 65001
+
+// ConsoleSupportsUTF8 reports whether the active console can render UTF-8.
+// On Windows this is true only when the output code page is UTF-8 (65001);
+// legacy code pages (437, 866, …) mangle multi-byte glyphs, so we fall back to
+// ASCII. A failed query is treated as capable to avoid false downgrades.
+func ConsoleSupportsUTF8() bool {
+	cp, err := windows.GetConsoleOutputCP()
+	if err != nil {
+		return true
+	}
+	return cp == cpUTF8
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -140,7 +140,7 @@ func CheckInBackground(ctx context.Context, w io.Writer, quiet bool) func() {
 }
 
 func PrintNotice(w io.Writer, currentVersion string, r *ReleaseInfo) {
-	_, _ = fmt.Fprintf(w, "\n%s A new version is available: %s → %s — run %s to see how to upgrade\n",
+	_, _ = fmt.Fprintf(w, "\n%s A new version is available: %s "+output.Sym().Arrow+" %s — run %s to see how to upgrade\n",
 		output.Yellow("!"),
 		output.Faint("v"+currentVersion),
 		output.Green("v"+r.Version),

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -140,7 +140,7 @@ func CheckInBackground(ctx context.Context, w io.Writer, quiet bool) func() {
 }
 
 func PrintNotice(w io.Writer, currentVersion string, r *ReleaseInfo) {
-	_, _ = fmt.Fprintf(w, "\n%s A new version is available: %s "+output.Sym().Arrow+" %s — run %s to see how to upgrade\n",
+	_, _ = fmt.Fprintf(w, "\n%s A new version is available: %s "+output.Sym().Arrow+" %s - run %s to see how to upgrade\n",
 		output.Yellow("!"),
 		output.Faint("v"+currentVersion),
 		output.Green("v"+r.Version),


### PR DESCRIPTION
## Summary

Renders `teamcity` legibly on terminals that can't display our Unicode glyphs (non-UTF-8 Windows consoles, `TERM=dumb`, `C`-locale CI logs), where status icons, arrows, separators, tree connectors, and the logo currently show as mojibake. Mirrors the existing `NoColor` design. Also makes the bare-command help screen quieter and less misleading. Fixes #308, #314, #315.

## Changes

- `output.ASCII` global + `output/symbols.go` (`Sym()` glyph table: Unicode/ASCII sets). (#308)
- `StatusIcon` degrades to the existing `PlainStatusIcon` chars in ASCII mode, keeping color.
- Detection in `InitOutput`: `TEAMCITY_ASCII`, `TERM=dumb`, Windows code-page probe (no-CGO, build-tagged).
- Glyph literals → `Sym()` across `cmd`/`cmdutil`/`update`; ASCII logo fallback.
- Em dashes (`—`) in user-facing strings → ASCII `-`, so ASCII mode emits no non-ASCII bytes.
- Skip the startup banner (logo + title line) when `--quiet` or `TERM=dumb`. (#315)
- Bare-command help: `auth login` line now reads `Authenticate (or set TEAMCITY_URL + TEAMCITY_TOKEN)` so env-supplied credentials aren't contradicted. (#314)
- Docs `TEAMCITY_ASCII` beside `NO_COLOR`.

## Design Decisions

- `--plain` untouched — scripting output stays byte-stable; the mode governs only the human path.
- Auto-detect is conservative (Windows code-page + `TERM=dumb` only); `TEAMCITY_ASCII` is the manual override, no new flag.
- Em dashes use a plain ASCII `-` unconditionally (not a mode-gated glyph) — one dash style everywhere, no extra `Sym()` field.
- #315: banner is gated on `--quiet`/`TERM=dumb` (the issue's noted `--quiet` gap), not blanket non-TTY suppression — piping still shows the static logo.
- #314 fixed by wording, not env-conditional logic — the hint is accurate in every state, no new code path.

## Example

```bash
$ TEAMCITY_ASCII=1 teamcity run list   # ✓✗○ -> +x-, · -> |, → -> ->, ├── -> |--
```

## Test Plan

- [x] Unit tests pass (`just unit`) — added `symbols_test.go` incl. an all-ASCII invariant guard
- [x] Linter passes (`just lint`) — 0 issues; cross-compiles `GOOS=windows`
- [ ] Acceptance tests pass (`just acceptance`) — N/A locally (needs guest network); fixed the `run-tree` assertion to accept the ASCII pipeline marker (`⬡` or `*`) that broke the Windows agent, CI verifies
- [ ] If adding a new command/flag: added `.txtar` test — N/A — env-var only
- [ ] If adding a data-producing command: includes `--json` — N/A
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [x] If changing docs-visible behavior: updated `docs/` — README/skill don't list env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)
