### PR TITLE
feat: direct navigation to TeamCity UI pages (#306)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ TeamCity CLI (`teamcity`) is an open-source command-line interface for [TeamCity
 - **Stay in your terminal** – Start builds, view logs, manage queues – no browser needed
 - **Remote agent access** – Shell into any build agent with `teamcity agent term`, or run commands with `teamcity agent exec`
 - **Real-time logs** – Stream build output as it happens with `teamcity run watch --logs`
-- **Scriptable** – `--json` and `--plain` output for pipelines, plus direct REST API access via `teamcity api`
+- **Scriptable** – `--json` and `--plain` output for pipelines, `--web` to open the TeamCity UI page for any view, plus direct REST API access via `teamcity api`
 - **Multi-server support** – Authenticate with and switch between multiple TeamCity instances
 - **AI agent ready** – Built-in [skill](https://agentskills.io) for Claude Code, Cursor, and other AI coding agents – just run `teamcity skill install`
 
@@ -124,7 +124,7 @@ teamcity queue list
 | **auth**     | `login`, `logout`, `status`                                                                                                                                                                                                           |
 | **run**      | `list`, `start`, `view`, `watch`, `log`, `tree`, `changes`, `tests`, `diff`, `cancel`, `download`, `artifacts`, `restart`, `pin`/`unpin`, `tag`/`untag`, `comment`                                                                    |
 | **job**      | `list`, `view`, `create`, `tree`, `pause`/`resume`, `step list`/`view`/`add`/`delete`, `param list`/`get`/`set`/`delete`                                                                                                              |
-| **project**  | `list`, `view`, `create`, `tree`, `vcs list`/`view`/`create`/`test`/`delete`, `ssh list`/`generate`/`upload`/`delete`, `cloud profile`/`image`/`instance`, `connection list`/`create github-app`/`create docker`/`authorize`/`delete`, `param`, `token get`/`put`, `settings export`/`status`/`validate` |
+| **project**  | `list`, `view`, `create`, `tree`, `vcs list`/`view`/`create`/`test`/`delete`, `ssh list`/`generate`/`upload`/`delete`, `cloud profile`/`image`/`instance`, `connection list`/`view`/`create github-app`/`create docker`/`authorize`/`delete`, `param`, `token get`/`put`, `settings export`/`status`/`validate` |
 | **pipeline** | `list`, `view`, `create`, `validate`, `pull`, `push`, `schema`, `delete`                                                                                                                                                              |
 | **queue**    | `list`, `approve`, `remove`, `top`                                                                                                                                                                                                    |
 | **agent**    | `list`, `view`, `term`, `exec`, `jobs`, `authorize`/`deauthorize`, `enable`/`disable`, `move`, `reboot`                                                                                                                               |

--- a/docs/topics/teamcity-cli-commands.md
+++ b/docs/topics/teamcity-cli-commands.md
@@ -587,6 +587,18 @@ List project connections
 <tr>
 <td>
 
+`teamcity project connection view`
+
+</td>
+<td>
+
+View a project connection
+
+</td>
+</tr>
+<tr>
+<td>
+
 `teamcity project create`
 
 </td>

--- a/internal/analytics/enums.go
+++ b/internal/analytics/enums.go
@@ -22,7 +22,7 @@ func allCommands() []string {
 		"project.cloud.profile.list", "project.cloud.profile.view",
 		"project.cloud.image.list", "project.cloud.image.view", "project.cloud.image.start",
 		"project.cloud.instance.list", "project.cloud.instance.view", "project.cloud.instance.stop",
-		"project.connection.list", "project.connection.authorize", "project.connection.delete",
+		"project.connection.list", "project.connection.view", "project.connection.authorize", "project.connection.delete",
 		"project.connection.create.docker", "project.connection.create.github-app",
 		"project.token.put", "project.token.get",
 		"project.settings.status", "project.settings.export", "project.settings.validate",

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -66,6 +66,7 @@ type agentListOptions struct {
 	enabled    bool
 	authorized bool
 	cmdutil.ListFlags
+	cmdutil.ViewOptions
 }
 
 func newAgentListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -81,8 +82,17 @@ func newAgentListCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity agent list --json
   teamcity agent list --json=id,name,connected,enabled
   teamcity agent list --plain
-  teamcity agent list --plain --no-header`,
+  teamcity agent list --plain --no-header
+  teamcity agent list --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Web {
+				if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+					return err
+				}
+			}
+			if done, err := opts.EmitListWebURL(f.Printer, config.ResolveServerURL(), "/agents.html"); done {
+				return err
+			}
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.AgentFields, opts.fetch)
 		},
 	}
@@ -92,6 +102,7 @@ func newAgentListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().BoolVar(&opts.enabled, "enabled", false, "Show only enabled agents")
 	cmd.Flags().BoolVar(&opts.authorized, "authorized", false, "Show only authorized agents")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddWebFlags(cmd, &opts.ViewOptions)
 
 	return cmd
 }
@@ -165,8 +176,8 @@ func runAgentView(f *cmdutil.Factory, nameOrID string, opts *cmdutil.ViewOptions
 		return err
 	}
 
-	if opts.Web {
-		return browser.OpenURL(agent.WebURL)
+	if done, err := opts.EmitWebURL(f.Printer, agent.WebURL); done {
+		return err
 	}
 
 	if opts.JSON {

--- a/internal/cmd/agent/agent_test.go
+++ b/internal/cmd/agent/agent_test.go
@@ -24,6 +24,19 @@ func TestAgentList(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, f, "agent", "list", "--limit", "10")
 }
 
+func TestAgentListWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "agent", "list", "--web")
+	assert.Contains(t, out, ts.URL+"/agents.html")
+}
+
+func TestAgentListWebValidatesLimit(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "limit", "agent", "list", "--limit", "-1", "--web")
+}
+
 func TestAgentList_plain(t *testing.T) {
 	ts := cmdtest.SetupMockClient(t)
 	got := cmdtest.CaptureOutput(t, ts.Factory, "agent", "list", "--plain")

--- a/internal/cmd/job/job_test.go
+++ b/internal/cmd/job/job_test.go
@@ -2,6 +2,7 @@ package job_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
@@ -25,6 +26,16 @@ func TestJobView(T *testing.T) {
 
 	cmdtest.RunCmdWithFactory(T, f, "job", "view", testJob)
 	cmdtest.RunCmdWithFactory(T, f, "job", "view", testJob, "--json")
+}
+
+func TestJobViewWeb(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+
+	out := cmdtest.CaptureOutput(T, ts.Factory, "job", "view", testJob, "--web")
+	want := ts.URL + "/viewType.html?buildTypeId=" + testJob
+	if !strings.Contains(out, want) {
+		T.Fatalf("--web output = %q, want it to contain %q", out, want)
+	}
 }
 
 func TestJobPauseResume(T *testing.T) {

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -8,7 +8,6 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -161,8 +160,8 @@ func runJobView(f *cmdutil.Factory, jobID string, opts *cmdutil.ViewOptions) err
 		return err
 	}
 
-	if opts.Web {
-		return browser.OpenURL(buildType.WebURL)
+	if done, err := opts.EmitWebURL(f.Printer, buildType.WebURL); done {
+		return err
 	}
 
 	if opts.JSON {

--- a/internal/cmd/job/step.go
+++ b/internal/cmd/job/step.go
@@ -151,7 +151,7 @@ func runJobStepList(f *cmdutil.Factory, jobID string, opts *jobStepListOptions) 
 }
 
 func newJobStepViewCmd(f *cmdutil.Factory) *cobra.Command {
-	var jsonOutput bool
+	opts := &cmdutil.ViewOptions{}
 
 	cmd := &cobra.Command{
 		Use:               "view [job-id] <step-id>",
@@ -161,21 +161,22 @@ func newJobStepViewCmd(f *cmdutil.Factory) *cobra.Command {
 		ValidArgsFunction: stepJobComplete(),
 		Example: `  teamcity job step view MyBuild RUNNER_1
   teamcity job step view RUNNER_1        # uses linked job
-  teamcity job step view MyBuild RUNNER_1 --json`,
+  teamcity job step view MyBuild RUNNER_1 --json
+  teamcity job step view MyBuild RUNNER_1 --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			jobID, rest, err := resolveStepArgs(f, args, 1)
 			if err != nil {
 				return err
 			}
-			return runJobStepView(f, jobID, rest[0], jsonOutput)
+			return runJobStepView(f, jobID, rest[0], opts)
 		},
 	}
 
-	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output as JSON")
+	cmdutil.AddViewFlags(cmd, opts)
 	return cmd
 }
 
-func runJobStepView(f *cmdutil.Factory, jobID, stepID string, jsonOutput bool) error {
+func runJobStepView(f *cmdutil.Factory, jobID, stepID string, opts *cmdutil.ViewOptions) error {
 	client, err := f.Client()
 	if err != nil {
 		return err
@@ -186,7 +187,12 @@ func runJobStepView(f *cmdutil.Factory, jobID, stepID string, jsonOutput bool) e
 		return err
 	}
 
-	if jsonOutput {
+	url := client.ServerURL() + "/admin/editBuildRunners.html?id=buildType:" + jobID
+	if done, err := opts.EmitWebURL(f.Printer, url); done {
+		return err
+	}
+
+	if opts.JSON {
 		return f.Printer.PrintJSON(step)
 	}
 

--- a/internal/cmd/job/step_test.go
+++ b/internal/cmd/job/step_test.go
@@ -34,6 +34,13 @@ func TestJobStepView(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, ts.Factory, "job", "step", "view", testJob, "RUNNER_1", "--json")
 }
 
+func TestJobStepViewWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "job", "step", "view", testJob, "RUNNER_1", "--web")
+	assert.Contains(t, out, ts.URL+"/admin/editBuildRunners.html?id=buildType:"+testJob)
+}
+
 func TestJobStepAdd(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 

--- a/internal/cmd/param/param.go
+++ b/internal/cmd/param/param.go
@@ -99,6 +99,7 @@ type paramListOptions struct {
 	json     bool
 	plain    bool
 	noHeader bool
+	cmdutil.ViewOptions
 }
 
 func newParamListCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, resolveID IDResolver, idComplete completion.CompFunc) *cobra.Command {
@@ -112,32 +113,47 @@ func newParamListCmd(f *cmdutil.Factory, resource string, paramAPI ParamAPI, res
 		Example: fmt.Sprintf(`  teamcity %s param list MyID
   teamcity %s param list                # uses linked %s (see 'teamcity link')
   teamcity %s param list MyID --json
-  teamcity %s param list MyID --plain`, resource, resource, resource, resource, resource),
+  teamcity %s param list MyID --plain
+  teamcity %s param list MyID --web`, resource, resource, resource, resource, resource, resource),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			id, _, err := resolveResourceID(resource, args, 0, resolveID)
 			if err != nil {
 				return err
 			}
-			return runParamList(f, id, opts, paramAPI)
+			return runParamList(f, resource, id, opts, paramAPI)
 		},
 	}
 
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().BoolVar(&opts.plain, "plain", false, "Output in plain text format for scripting")
 	cmd.Flags().BoolVar(&opts.noHeader, "no-header", false, "Omit header row (use with --plain)")
+	cmdutil.AddWebFlags(cmd, &opts.ViewOptions)
 	cmd.MarkFlagsMutuallyExclusive("json", "plain")
 
 	return cmd
 }
 
-func runParamList(f *cmdutil.Factory, id string, opts *paramListOptions, paramAPI ParamAPI) error {
+// paramListURL returns the TeamCity admin URL for a resource's parameters page.
+func paramListURL(serverURL, resource, id string) string {
+	if resource == "job" {
+		return serverURL + "/admin/editBuildParams.html?id=buildType:" + id
+	}
+	return serverURL + "/admin/editProject.html?projectId=" + id + "&tab=projectParams"
+}
+
+func runParamList(f *cmdutil.Factory, resource, id string, opts *paramListOptions, paramAPI ParamAPI) error {
 	client, err := f.Client()
 	if err != nil {
 		return err
 	}
 
+	// Fetch first so a mistyped owner id is reported, then --web navigates to the owner's params page.
 	params, err := paramAPI.List(client, id)
 	if err != nil {
+		return err
+	}
+
+	if done, err := opts.EmitWebURL(f.Printer, paramListURL(client.ServerURL(), resource, id)); done {
 		return err
 	}
 

--- a/internal/cmd/param/param_test.go
+++ b/internal/cmd/param/param_test.go
@@ -1,6 +1,7 @@
 package param_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
@@ -63,6 +64,33 @@ func TestParamDeleteJob(t *testing.T) {
 	f := ts.Factory
 
 	cmdtest.RunCmdWithFactory(t, f, "job", "param", "delete", "TestProject_Build", "myParam")
+}
+
+func TestParamListProjectWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "project", "param", "list", "TestProject", "--web")
+	want := ts.URL + "/admin/editProject.html?projectId=TestProject&tab=projectParams"
+	if !strings.Contains(out, want) {
+		t.Fatalf("--web output = %q, want it to contain %q", out, want)
+	}
+}
+
+func TestParamListJobWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "job", "param", "list", "TestProject_Build", "--web")
+	want := ts.URL + "/admin/editBuildParams.html?id=buildType:TestProject_Build"
+	if !strings.Contains(out, want) {
+		t.Fatalf("--web output = %q, want it to contain %q", out, want)
+	}
+}
+
+// --web must validate the owner exists before emitting its params URL (not exit 0 on a bad id).
+func TestParamListWebValidatesOwner(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "", "project", "param", "list", "NonExistentProject123456", "--web")
 }
 
 func TestParamRequiresSubcommand(t *testing.T) {

--- a/internal/cmd/pipeline/view.go
+++ b/internal/cmd/pipeline/view.go
@@ -6,7 +6,6 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/output"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -42,11 +41,12 @@ func runPipelineView(f *cmdutil.Factory, id string, opts *cmdutil.ViewOptions) e
 		return err
 	}
 
-	if opts.Web {
-		if pipeline.WebURL == "" {
-			return fmt.Errorf("no web URL available for pipeline %s", id)
-		}
-		return browser.OpenURL(pipeline.WebURL)
+	if opts.Web && pipeline.WebURL == "" {
+		return fmt.Errorf("no web URL available for pipeline %s", id)
+	}
+
+	if done, err := opts.EmitWebURL(f.Printer, pipeline.WebURL); done {
+		return err
 	}
 
 	if opts.JSON {

--- a/internal/cmd/pool/list.go
+++ b/internal/cmd/pool/list.go
@@ -8,12 +8,12 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
 func newPoolListCmd(f *cmdutil.Factory) *cobra.Command {
 	flags := &cmdutil.ListFlags{}
+	view := &cmdutil.ViewOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "list",
@@ -22,14 +22,19 @@ func newPoolListCmd(f *cmdutil.Factory) *cobra.Command {
 		Example: `  teamcity pool list
   teamcity pool list --json
   teamcity pool list --json=id,name,maxAgents
-  teamcity pool list --plain`,
+  teamcity pool list --plain
+  teamcity pool list --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if done, err := view.EmitListWebURL(f.Printer, config.ResolveServerURL(), "/agents.html?tab=agentPools"); done {
+				return err
+			}
 			return cmdutil.RunList(f, cmd, flags, &api.PoolFields, fetchPools)
 		},
 	}
 
 	cmdutil.AddJSONFieldsFlag(cmd, &flags.JSONFields)
 	cmdutil.AddPlainFlags(cmd, flags)
+	cmdutil.AddWebFlags(cmd, view)
 
 	return cmd
 }
@@ -90,11 +95,6 @@ func newPoolViewCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func runPoolView(f *cmdutil.Factory, poolID int, opts *cmdutil.ViewOptions) error {
-	if opts.Web {
-		url := fmt.Sprintf("%s/agents.html?tab=agentPools&poolId=%d", config.GetServerURL(), poolID)
-		return browser.OpenURL(url)
-	}
-
 	client, err := f.Client()
 	if err != nil {
 		return err
@@ -102,6 +102,11 @@ func runPoolView(f *cmdutil.Factory, poolID int, opts *cmdutil.ViewOptions) erro
 
 	pool, err := client.GetAgentPool(poolID)
 	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/agents.html?tab=agentPools&poolId=%d", client.ServerURL(), poolID)
+	if done, err := opts.EmitWebURL(f.Printer, url); done {
 		return err
 	}
 
@@ -138,8 +143,7 @@ func runPoolView(f *cmdutil.Factory, poolID int, opts *cmdutil.ViewOptions) erro
 		_, _ = fmt.Fprintf(p.Out, "\n%s\n", output.Faint("No projects assigned to this pool"))
 	}
 
-	webURL := fmt.Sprintf("%s/agents.html?tab=agentPools&poolId=%d", config.GetServerURL(), poolID)
-	_, _ = fmt.Fprintf(p.Out, "\n%s %s\n", output.Faint("View in browser:"), output.Green(webURL))
+	_, _ = fmt.Fprintf(p.Out, "\n%s %s\n", output.Faint("View in browser:"), output.Green(url))
 
 	return nil
 }

--- a/internal/cmd/pool/pool_test.go
+++ b/internal/cmd/pool/pool_test.go
@@ -1,7 +1,10 @@
 package pool_test
 
 import (
+	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
 )
@@ -14,12 +17,29 @@ func TestPoolList(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, f, "pool", "list", "--json")
 }
 
+func TestPoolListWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "pool", "list", "--web")
+	assert.Contains(t, out, ts.URL+"/agents.html?tab=agentPools")
+}
+
 func TestPoolView(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	f := ts.Factory
 
 	cmdtest.RunCmdWithFactory(T, f, "pool", "view", "0")
 	cmdtest.RunCmdWithFactory(T, f, "pool", "view", "0", "--json")
+}
+
+// --web must validate the pool exists before emitting the URL (not exit 0 on a bad id).
+func TestPoolViewWebValidatesPool(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/agentPools/id:", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no pool", http.StatusNotFound)
+	})
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "", "pool", "view", "999", "--web")
 }
 
 func TestPoolLinkUnlink(T *testing.T) {

--- a/internal/cmd/project/cloud.go
+++ b/internal/cmd/project/cloud.go
@@ -104,12 +104,8 @@ func (opts *cloudProfileListOptions) fetch(client api.ClientInterface, fields []
 	}, nil
 }
 
-type cloudProfileViewOptions struct {
-	json bool
-}
-
 func newCloudProfileViewCmd(f *cmdutil.Factory) *cobra.Command {
-	opts := &cloudProfileViewOptions{}
+	opts := &cmdutil.ViewOptions{}
 
 	cmd := &cobra.Command{
 		Use:     "view <profile>",
@@ -117,18 +113,19 @@ func newCloudProfileViewCmd(f *cmdutil.Factory) *cobra.Command {
 		Aliases: []string{"show"},
 		Args:    cobra.ExactArgs(1),
 		Example: `  teamcity project cloud profile view aws-prod
-  teamcity project cloud profile view aws-prod --json`,
+  teamcity project cloud profile view aws-prod --json
+  teamcity project cloud profile view aws-prod --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCloudProfileView(f, args[0], opts)
 		},
 	}
 
-	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
+	cmdutil.AddViewFlags(cmd, opts)
 
 	return cmd
 }
 
-func runCloudProfileView(f *cmdutil.Factory, locator string, opts *cloudProfileViewOptions) error {
+func runCloudProfileView(f *cmdutil.Factory, locator string, opts *cmdutil.ViewOptions) error {
 	client, err := f.Client()
 	if err != nil {
 		return err
@@ -139,7 +136,17 @@ func runCloudProfileView(f *cmdutil.Factory, locator string, opts *cloudProfileV
 		return err
 	}
 
-	if opts.json {
+	if opts.Web {
+		if profile.Project == nil || profile.Project.ID == "" {
+			return fmt.Errorf("no web URL available for cloud profile %s", locator)
+		}
+		url := fmt.Sprintf("%s/admin/editProject.html?projectId=%s&tab=clouds&profileId=%s", client.ServerURL(), profile.Project.ID, profile.ID)
+		if done, err := opts.EmitWebURL(f.Printer, url); done {
+			return err
+		}
+	}
+
+	if opts.JSON {
 		return f.Printer.PrintJSON(profile)
 	}
 

--- a/internal/cmd/project/cloud_test.go
+++ b/internal/cmd/project/cloud_test.go
@@ -33,6 +33,22 @@ func TestCloudProfileView(t *testing.T) {
 	assert.Contains(t, out, "Project: TestProject")
 }
 
+func TestCloudProfileViewWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "project", "cloud", "profile", "view", "aws-prod", "--web")
+	assert.Contains(t, out, ts.URL+"/admin/editProject.html?projectId=TestProject&tab=clouds&profileId=aws-prod")
+}
+
+func TestCloudProfileViewWebNoProject(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/cloud/profiles/", func(w http.ResponseWriter, _ *http.Request) {
+		cmdtest.JSON(w, api.CloudProfile{ID: "aws-prod", Name: "AWS Production", CloudProviderID: "amazon"})
+	})
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "no web URL", "project", "cloud", "profile", "view", "aws-prod", "--web")
+}
+
 func TestCloudProfileViewUsesNestedProject(t *testing.T) {
 	ts := cmdtest.SetupMockClient(t)
 

--- a/internal/cmd/project/connection.go
+++ b/internal/cmd/project/connection.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"cmp"
+	"strings"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
@@ -26,6 +27,7 @@ See: https://www.jetbrains.com/help/teamcity/configuring-connections.html`,
 	}
 
 	cmd.AddCommand(newConnectionListCmd(f))
+	cmd.AddCommand(newConnectionViewCmd(f))
 	cmd.AddCommand(newConnectionCreateCmd(f))
 	cmd.AddCommand(newConnectionAuthorizeCmd(f))
 	cmd.AddCommand(newConnectionDeleteCmd(f))
@@ -94,9 +96,21 @@ func connectionToMap(feat api.ProjectFeature) map[string]any {
 		"type": feat.Type,
 	}
 	if feat.Properties != nil {
-		m["properties"] = feat.Properties
+		masked := make([]api.Property, len(feat.Properties.Property))
+		for i, p := range feat.Properties.Property {
+			masked[i] = api.Property{Name: p.Name, Value: maskSecure(p.Name, p.Value)}
+		}
+		m["properties"] = &api.PropertyList{Property: masked}
 	}
 	return m
+}
+
+// maskSecure hides the values of secure: properties, which hold connection secrets.
+func maskSecure(name, value string) string {
+	if strings.HasPrefix(name, "secure:") {
+		return "********"
+	}
+	return value
 }
 
 func filterJSONList[T any](items []T, fields []string, toMap func(T) map[string]any) any {

--- a/internal/cmd/project/connection_test.go
+++ b/internal/cmd/project/connection_test.go
@@ -2,6 +2,7 @@ package project_test
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -20,6 +21,61 @@ func TestConnectionList(t *testing.T) {
 	out := cmdtest.CaptureOutput(t, f, "project", "connection", "list", "--project", "TestProject")
 	assert.Contains(t, out, "PROJECT_EXT_1")
 	assert.Contains(t, out, "GitHub App")
+}
+
+func TestConnectionListJSONMasksSecrets(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	f := ts.Factory
+
+	out := cmdtest.CaptureOutput(t, f, "project", "connection", "list", "--project", "TestProject", "--json")
+	assert.Contains(t, out, "********", "secure: properties should be masked")
+	assert.NotContains(t, out, "supersecret", "secure: value must not appear in JSON output")
+}
+
+func TestConnectionViewJSONMasksSecrets(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	f := ts.Factory
+
+	out := cmdtest.CaptureOutput(t, f, "project", "connection", "view", "PROJECT_EXT_1", "--project", "TestProject", "--json")
+	assert.Contains(t, out, "********", "secure: properties should be masked")
+	assert.NotContains(t, out, "supersecret", "secure: value must not appear in JSON output")
+}
+
+func TestConnectionView(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	f := ts.Factory
+
+	out := cmdtest.CaptureOutput(t, f, "project", "connection", "view", "PROJECT_EXT_1", "--project", "TestProject")
+	assert.Contains(t, out, "PROJECT_EXT_1")
+	assert.Contains(t, out, "GitHub App")
+	assert.Contains(t, out, "GitHubApp")
+	assert.Contains(t, out, "********", "secure: properties should be masked")
+	assert.NotContains(t, out, "supersecret", "secure: value must not appear in plaintext")
+}
+
+func TestConnectionViewWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	f := ts.Factory
+
+	out := cmdtest.CaptureOutput(t, f, "project", "connection", "view", "PROJECT_EXT_1", "--project", "TestProject", "--web")
+	assert.Contains(t, out, "/admin/editProject.html?projectId=TestProject&tab=oauthConnections")
+}
+
+func TestConnectionViewNotFound(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	f := ts.Factory
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, f, "not found", "project", "connection", "view", "PROJECT_EXT_999", "--project", "TestProject")
+}
+
+// A missing connection must be a typed user error so --json reports a user category, not internal_error.
+func TestConnectionViewNotFoundIsUserError(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	err := cmdtest.CaptureErr(t, ts.Factory, "project", "connection", "view", "PROJECT_EXT_999", "--project", "TestProject", "--json")
+	ue, ok := errors.AsType[api.UserError](err)
+	require.True(t, ok, "want a typed api.UserError, got %T", err)
+	assert.Equal(t, api.CatValidation, ue.Category())
 }
 
 func TestConnectionCreateGitHubApp(t *testing.T) {

--- a/internal/cmd/project/connection_view.go
+++ b/internal/cmd/project/connection_view.go
@@ -1,0 +1,95 @@
+package project
+
+import (
+	"cmp"
+	"fmt"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
+	"github.com/spf13/cobra"
+)
+
+type connectionViewOptions struct {
+	project string
+	cmdutil.ViewOptions
+}
+
+func newConnectionViewCmd(f *cmdutil.Factory) *cobra.Command {
+	opts := &connectionViewOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "view <id>",
+		Short:   "View a project connection",
+		Aliases: []string{"show"},
+		Long: `Show details of a single OAuth/connection feature by id.
+
+The id is the one shown in the first column of 'connection list'.`,
+		Example: `  teamcity project connection view PROJECT_EXT_1 -p Backend
+  teamcity project connection view PROJECT_EXT_1 -p Backend --json
+  teamcity project connection view PROJECT_EXT_1 -p Backend --web`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runConnectionView(f, opts, args[0])
+		},
+	}
+
+	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
+	cmdutil.AddViewFlags(cmd, &opts.ViewOptions)
+
+	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
+
+	return cmd
+}
+
+func runConnectionView(f *cmdutil.Factory, opts *connectionViewOptions, id string) error {
+	client, err := f.Client()
+	if err != nil {
+		return err
+	}
+
+	project := cmp.Or(opts.project, "_Root")
+
+	features, err := client.GetProjectConnections(project)
+	if err != nil {
+		return err
+	}
+
+	var feat *api.ProjectFeature
+	for i := range features.ProjectFeature {
+		if features.ProjectFeature[i].ID == id {
+			feat = &features.ProjectFeature[i]
+			break
+		}
+	}
+	if feat == nil {
+		return api.Validation(
+			fmt.Sprintf("connection %s not found in project %s", id, project),
+			fmt.Sprintf("Run 'teamcity project connection list --project %s' to see available connections", project),
+		)
+	}
+
+	url := projectConnectionsURL(client.ServerURL(), project)
+
+	if done, err := opts.EmitWebURL(f.Printer, url); done {
+		return err
+	}
+
+	if opts.JSON {
+		return f.Printer.PrintJSON(connectionToMap(*feat))
+	}
+
+	name, providerType := connectionDisplayInfo(*feat)
+	f.Printer.PrintViewHeader(name, url, func() {
+		f.Printer.PrintField("ID", feat.ID)
+		f.Printer.PrintField("Name", name)
+		f.Printer.PrintField("Type", providerType)
+		if feat.Properties != nil {
+			for _, p := range feat.Properties.Property {
+				f.Printer.PrintField(p.Name, maskSecure(p.Name, p.Value))
+			}
+		}
+	})
+
+	return nil
+}

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -16,7 +16,6 @@ import (
 	"github.com/charmbracelet/huh"
 	"github.com/dustin/go-humanize"
 	"github.com/dustin/go-humanize/english"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -161,8 +160,8 @@ func runProjectView(f *cmdutil.Factory, projectID string, opts *cmdutil.ViewOpti
 		return err
 	}
 
-	if opts.Web {
-		return browser.OpenURL(project.WebURL)
+	if done, err := opts.EmitWebURL(f.Printer, project.WebURL); done {
+		return err
 	}
 
 	if opts.JSON {

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -9,6 +9,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/spf13/cobra"
 )
 
@@ -38,6 +39,7 @@ See: https://www.jetbrains.com/help/teamcity/ssh-keys-management.html`,
 type sshListOptions struct {
 	project string
 	cmdutil.ListFlags
+	cmdutil.ViewOptions
 }
 
 func newSSHListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -50,14 +52,25 @@ func newSSHListCmd(f *cmdutil.Factory) *cobra.Command {
 		Example: `  teamcity project ssh list
   teamcity project ssh list --project MyProject
   teamcity project ssh list --project MyProject --json
-  teamcity project ssh list --plain`,
+  teamcity project ssh list --plain
+  teamcity project ssh list --project MyProject --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Web {
+				if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+					return err
+				}
+			}
+			path := "/admin/editProject.html?projectId=" + cmp.Or(opts.project, "_Root") + "&tab=ssh-manager"
+			if done, err := opts.EmitListWebURL(f.Printer, config.ResolveServerURL(), path); done {
+				return err
+			}
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.SSHKeyFields, opts.fetch)
 		},
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddWebFlags(cmd, &opts.ViewOptions)
 
 	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 

--- a/internal/cmd/project/ssh_test.go
+++ b/internal/cmd/project/ssh_test.go
@@ -16,6 +16,19 @@ func TestSSHList(t *testing.T) {
 	assert.Contains(t, out, "backup-key")
 }
 
+func TestSSHListWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "project", "ssh", "list", "--project", "TestProject", "--web")
+	assert.Contains(t, out, ts.URL+"/admin/editProject.html?projectId=TestProject&tab=ssh-manager")
+}
+
+func TestSSHListWebValidatesLimit(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "limit", "project", "ssh", "list", "--limit", "-1", "--web")
+}
+
 func TestSSHGenerate(t *testing.T) {
 	ts := cmdtest.SetupMockClient(t)
 	f := ts.Factory

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -14,7 +14,6 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/git"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/charmbracelet/huh"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -45,6 +44,7 @@ See: https://www.jetbrains.com/help/teamcity/vcs-root.html`,
 type vcsListOptions struct {
 	project string
 	cmdutil.ListFlags
+	cmdutil.ViewOptions
 }
 
 func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -58,14 +58,25 @@ func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
 		Example: `  teamcity project vcs list
   teamcity project vcs list --project MyProject
   teamcity project vcs list --project MyProject --json
-  teamcity project vcs list --plain`,
+  teamcity project vcs list --plain
+  teamcity project vcs list --project MyProject --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Web {
+				if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+					return err
+				}
+			}
+			path := "/admin/editProject.html?projectId=" + cmp.Or(opts.project, "_Root") + "&tab=projectVcsRoots"
+			if done, err := opts.EmitListWebURL(f.Printer, config.ResolveServerURL(), path); done {
+				return err
+			}
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.VcsRootFields, opts.fetch)
 		},
 	}
 
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Project ID (default: _Root)")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 100)
+	cmdutil.AddWebFlags(cmd, &opts.ViewOptions)
 
 	_ = cmd.RegisterFlagCompletionFunc("project", completion.LinkedProjects())
 
@@ -173,9 +184,8 @@ func runVcsView(f *cmdutil.Factory, id string, opts *cmdutil.ViewOptions) error 
 		return err
 	}
 
-	if opts.Web {
-		webURL := vcsRootEditURL(root.ID)
-		return browser.OpenURL(webURL)
+	if done, err := opts.EmitWebURL(f.Printer, vcsRootEditURL(root.ID)); done {
+		return err
 	}
 
 	if opts.JSON {
@@ -212,7 +222,7 @@ func vcsPropertyLabel(name string) string {
 }
 
 func vcsRootEditURL(id string) string {
-	return fmt.Sprintf("%s/admin/editVcsRoot.html?vcsRootId=%s", config.GetServerURL(), id)
+	return fmt.Sprintf("%s/admin/editVcsRoot.html?vcsRootId=%s", config.ResolveServerURL(), id)
 }
 
 const (

--- a/internal/cmd/project/vcs_test.go
+++ b/internal/cmd/project/vcs_test.go
@@ -17,6 +17,19 @@ func TestVcsList(T *testing.T) {
 	assert.Contains(T, out, "Git")
 }
 
+func TestVcsListWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "project", "vcs", "list", "--project", "TestProject", "--web")
+	assert.Contains(t, out, ts.URL+"/admin/editProject.html?projectId=TestProject&tab=projectVcsRoots")
+}
+
+func TestVcsListWebValidatesLimit(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "limit", "project", "vcs", "list", "--limit", "-1", "--web")
+}
+
 func TestVcsListJSON(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	f := ts.Factory

--- a/internal/cmd/queue/list.go
+++ b/internal/cmd/queue/list.go
@@ -6,6 +6,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -13,6 +14,7 @@ import (
 type queueListOptions struct {
 	job string
 	cmdutil.ListFlags
+	cmdutil.ViewOptions
 }
 
 func newQueueListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -27,14 +29,24 @@ func newQueueListCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity queue list --json
   teamcity queue list --json=id,state,webUrl
   teamcity queue list --plain
-  teamcity queue list --plain --no-header`,
+  teamcity queue list --plain --no-header
+  teamcity queue list --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.Web {
+				if err := cmdutil.ValidateLimit(opts.Limit); err != nil {
+					return err
+				}
+			}
+			if done, err := opts.EmitListWebURL(f.Printer, config.ResolveServerURL(), "/queue.html"); done {
+				return err
+			}
 			return cmdutil.RunList(f, cmd, &opts.ListFlags, &api.QueuedBuildFields, opts.fetch)
 		},
 	}
 
 	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Filter by job ID")
 	cmdutil.AddListFlags(cmd, &opts.ListFlags, 30)
+	cmdutil.AddWebFlags(cmd, &opts.ViewOptions)
 
 	_ = cmd.RegisterFlagCompletionFunc("job", completion.LinkedJobs())
 

--- a/internal/cmd/queue/queue_test.go
+++ b/internal/cmd/queue/queue_test.go
@@ -2,6 +2,7 @@ package queue_test
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +52,22 @@ func TestQueueList_waitReason(t *testing.T) {
 	got := cmdtest.CaptureOutput(t, ts.Factory, "queue", "list")
 	assert.Contains(t, got, "Waiting for build #199 in chain")
 	assert.Contains(t, got, "WAIT REASON")
+}
+
+func TestQueueListWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "queue", "list", "--web")
+	want := ts.URL + "/queue.html"
+	if !strings.Contains(out, want) {
+		t.Fatalf("--web output = %q, want it to contain %q", out, want)
+	}
+}
+
+func TestQueueListWebValidatesLimit(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "limit", "queue", "list", "--limit", "-1", "--web")
 }
 
 func TestQueueRemove(T *testing.T) {

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -43,6 +43,22 @@ func TestRunListBackwardsDateRange(T *testing.T) {
 	cmdtest.RunCmdWithFactoryExpectErr(T, ts.Factory, "is more recent than", "run", "list", "--since", "2020-01-01", "--until", "2019-01-01")
 }
 
+func TestRunListWeb(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	out := cmdtest.CaptureOutput(t, ts.Factory, "run", "list", "--web")
+	assert.Contains(t, out, ts.URL+"/builds")
+
+	fav := cmdtest.CaptureOutput(t, ts.Factory, "run", "list", "--favorites", "--web")
+	assert.Contains(t, fav, ts.URL+"/favorite/builds")
+}
+
+func TestRunListWebValidatesFlags(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "invalid status", "run", "list", "--status", "bogus", "--web")
+}
+
 func TestRunView(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	f := ts.Factory

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -13,7 +13,6 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/completion"
 	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
-	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +33,7 @@ type runListOptions struct {
 	jsonFields string
 	plain      bool
 	noHeader   bool
-	web        bool
+	cmdutil.ViewOptions
 }
 
 func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
@@ -56,7 +55,8 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run list --since 24h
   teamcity run list --json
   teamcity run list --json=id,status,webUrl
-  teamcity run list --plain | grep failure`,
+  teamcity run list --plain | grep failure
+  teamcity run list --favorites --web`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runRunList(f, cmd, opts)
 		},
@@ -75,7 +75,7 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmdutil.AddJSONFieldsFlag(cmd, &opts.jsonFields)
 	cmd.Flags().BoolVar(&opts.plain, "plain", false, "Output in plain text format for scripting")
 	cmd.Flags().BoolVar(&opts.noHeader, "no-header", false, "Omit header row (use with --plain)")
-	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
+	cmdutil.AddWebFlags(cmd, &opts.ViewOptions)
 
 	cmd.MarkFlagsMutuallyExclusive("json", "plain")
 
@@ -92,6 +92,18 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) error {
 	if err := cmdutil.ValidateLimit(opts.limit); err != nil {
 		return err
+	}
+	// --web validates the same query flags before navigating, so a bad value is reported rather than masked.
+	if opts.Web {
+		if _, _, err := resolveRunListStatus(opts.status); err != nil {
+			return err
+		}
+		if _, _, err := resolveRunListDateRange(opts); err != nil {
+			return err
+		}
+		if done, err := opts.EmitListWebURL(f.Printer, config.ResolveServerURL(), resolveRunListWebPath(opts)); done {
+			return err
+		}
 	}
 	jsonResult, showHelp, err := cmdutil.ParseJSONFields(cmd, opts.jsonFields, &api.BuildFields, f.Printer.Out)
 	if err != nil {
@@ -121,11 +133,6 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 	request, err := resolveRunListRequest(client, opts, jsonResult.Fields)
 	if err != nil {
 		return err
-	}
-
-	if opts.web {
-		url := config.GetServerURL() + request.webPath
-		return browser.OpenURL(url)
 	}
 
 	runs, err := client.GetBuilds(f.Context(), request.builds)
@@ -213,7 +220,6 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 
 type runListRequest struct {
 	builds   api.BuildsOptions
-	webPath  string
 	emptyMsg string
 	emptyTip string
 }
@@ -259,7 +265,6 @@ func resolveRunListRequest(client api.ClientInterface, opts *runListOptions, fie
 			UntilDate:   untilDate,
 			Fields:      fields,
 		},
-		webPath:  resolveRunListWebPath(opts),
 		emptyMsg: resolveRunListEmptyMessage(opts),
 		emptyTip: resolveRunListEmptyTip(opts),
 	}, nil
@@ -383,8 +388,8 @@ func runRunView(f *cmdutil.Factory, runID string, opts *cmdutil.ViewOptions) err
 		return err
 	}
 
-	if opts.Web {
-		return browser.OpenURL(build.WebURL)
+	if done, err := opts.EmitWebURL(p, build.WebURL); done {
+		return err
 	}
 
 	if opts.JSON {

--- a/internal/cmd/run/list_test.go
+++ b/internal/cmd/run/list_test.go
@@ -16,7 +16,7 @@ func TestResolveRunListRequestFavorites(T *testing.T) {
 	require.NoError(T, err)
 
 	assert.True(T, req.builds.Favorites)
-	assert.Equal(T, "/favorite/builds", req.webPath)
+	assert.Equal(T, "/favorite/builds", resolveRunListWebPath(&runListOptions{favorites: true}))
 	assert.Equal(T, "No favorite runs found", req.emptyMsg)
 	assert.Equal(T, 30, req.builds.Limit)
 }

--- a/internal/cmdtest/mock_handlers.go
+++ b/internal/cmdtest/mock_handlers.go
@@ -772,6 +772,7 @@ func SetupMockClient(t *testing.T) *TestServer {
 						Property: []api.Property{
 							{Name: "displayName", Value: "GitHub App"},
 							{Name: "providerType", Value: "GitHubApp"},
+							{Name: "secure:clientSecret", Value: "supersecret"},
 						},
 					},
 				},

--- a/internal/cmdtest/testutil.go
+++ b/internal/cmdtest/testutil.go
@@ -19,6 +19,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Stub browser opening so command tests never launch a real browser.
+func init() { cmdutil.OpenInBrowser = func(string) error { return nil } }
+
 // TestServer wraps httptest.Server for easy API testing.
 type TestServer struct {
 	*httptest.Server

--- a/internal/cmdutil/helpers.go
+++ b/internal/cmdutil/helpers.go
@@ -18,10 +18,41 @@ type ViewOptions struct {
 	Web  bool
 }
 
+// OpenInBrowser opens url in the default browser; overridable in tests.
+var OpenInBrowser = browser.OpenURL
+
+// AddWebFlags adds the --web flag, mutually exclusive with --json when present.
+func AddWebFlags(cmd *cobra.Command, opts *ViewOptions) {
+	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open in browser")
+	if cmd.Flags().Lookup("json") != nil {
+		cmd.MarkFlagsMutuallyExclusive("json", "web")
+	}
+}
+
 // AddViewFlags adds --json and --web flags to a command.
 func AddViewFlags(cmd *cobra.Command, opts *ViewOptions) {
 	cmd.Flags().BoolVar(&opts.JSON, "json", false, "Output as JSON")
-	cmd.Flags().BoolVarP(&opts.Web, "web", "w", false, "Open in browser")
+	AddWebFlags(cmd, opts)
+}
+
+// EmitWebURL handles --web: echoes url and best-effort opens it in the browser. Returns whether it acted.
+func (o *ViewOptions) EmitWebURL(p *output.Printer, url string) (bool, error) {
+	if !o.Web {
+		return false, nil
+	}
+	_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("Opening in browser:"), output.Green(url))
+	if err := OpenInBrowser(url); err != nil {
+		p.Warn("could not open browser: %v", err)
+	}
+	return true, nil
+}
+
+// EmitListWebURL handles --web for list pages, whose URL is built before any client exists; it no-ops on an empty server so the caller falls through to the normal not-configured error.
+func (o *ViewOptions) EmitListWebURL(p *output.Printer, serverURL, path string) (bool, error) {
+	if serverURL == "" {
+		return false, nil
+	}
+	return o.EmitWebURL(p, serverURL+path)
 }
 
 // OpenURLOrWarn opens url in the browser, warning on failure. Never returns an error — safe to call after a mutation.
@@ -29,7 +60,7 @@ func OpenURLOrWarn(p *output.Printer, url string) {
 	if url == "" {
 		return
 	}
-	if err := browser.OpenURL(url); err != nil {
+	if err := OpenInBrowser(url); err != nil {
 		p.Warn("could not open browser: %v", err)
 	}
 }

--- a/internal/cmdutil/helpers_test.go
+++ b/internal/cmdutil/helpers_test.go
@@ -1,6 +1,7 @@
 package cmdutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -61,6 +63,72 @@ func TestAddViewFlags(t *testing.T) {
 
 	assert.NotNil(t, cmd.Flags().Lookup("json"))
 	assert.NotNil(t, cmd.Flags().Lookup("web"))
+	assert.Nil(t, cmd.Flags().Lookup("print-url"))
+}
+
+func TestEmitWebURL(t *testing.T) {
+	orig := OpenInBrowser
+	t.Cleanup(func() { OpenInBrowser = orig })
+
+	t.Run("web echoes url and opens it", func(t *testing.T) {
+		var opened string
+		OpenInBrowser = func(url string) error { opened = url; return nil }
+		var buf bytes.Buffer
+		p := &output.Printer{Out: &buf, ErrOut: &buf}
+		opts := &ViewOptions{Web: true}
+		done, err := opts.EmitWebURL(p, "https://tc.example.com/foo")
+		require.NoError(t, err)
+		assert.True(t, done)
+		assert.Equal(t, "https://tc.example.com/foo", opened)
+		assert.Contains(t, buf.String(), "https://tc.example.com/foo")
+	})
+
+	t.Run("open failure warns but does not error", func(t *testing.T) {
+		OpenInBrowser = func(string) error { return errors.New("no display") }
+		var buf bytes.Buffer
+		p := &output.Printer{Out: &buf, ErrOut: &buf}
+		opts := &ViewOptions{Web: true}
+		done, err := opts.EmitWebURL(p, "https://tc.example.com/foo")
+		require.NoError(t, err)
+		assert.True(t, done)
+		assert.Contains(t, buf.String(), "https://tc.example.com/foo")
+	})
+
+	t.Run("no flag → not handled, no output", func(t *testing.T) {
+		var buf bytes.Buffer
+		p := &output.Printer{Out: &buf, ErrOut: &buf}
+		opts := &ViewOptions{}
+		done, err := opts.EmitWebURL(p, "https://tc.example.com/foo")
+		require.NoError(t, err)
+		assert.False(t, done)
+		assert.Empty(t, buf.String())
+	})
+}
+
+func TestEmitListWebURL(t *testing.T) {
+	orig := OpenInBrowser
+	t.Cleanup(func() { OpenInBrowser = orig })
+	OpenInBrowser = func(string) error { return nil }
+
+	t.Run("empty server → no-op so caller falls through", func(t *testing.T) {
+		var buf bytes.Buffer
+		p := &output.Printer{Out: &buf, ErrOut: &buf}
+		opts := &ViewOptions{Web: true}
+		done, err := opts.EmitListWebURL(p, "", "/builds")
+		require.NoError(t, err)
+		assert.False(t, done)
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("server set → emits server+path", func(t *testing.T) {
+		var buf bytes.Buffer
+		p := &output.Printer{Out: &buf, ErrOut: &buf}
+		opts := &ViewOptions{Web: true}
+		done, err := opts.EmitListWebURL(p, "https://tc.example.com", "/builds")
+		require.NoError(t, err)
+		assert.True(t, done)
+		assert.Contains(t, buf.String(), "https://tc.example.com/builds")
+	})
 }
 
 func TestSubcommandRequired(t *testing.T) {

--- a/internal/config/buildauth_test.go
+++ b/internal/config/buildauth_test.go
@@ -209,3 +209,26 @@ teamcity.serverUrl=https://tc.example.com
 		assert.Contains(t, auth.Password, "ss")
 	})
 }
+
+func TestResolveServerURL(t *testing.T) {
+	t.Run("falls back to build-auth when no TEAMCITY_URL or default", func(t *testing.T) {
+		origCfg := cfg
+		ResetForTest()
+		t.Cleanup(func() { cfg = origCfg })
+
+		propsFile := filepath.Join(t.TempDir(), "build.properties")
+		content := "teamcity.auth.userId=u\nteamcity.auth.password=p\nteamcity.serverUrl=https://build.example.com\n"
+		require.NoError(t, os.WriteFile(propsFile, []byte(content), 0600))
+
+		t.Setenv(EnvBuildPropertiesFile, propsFile)
+		t.Setenv(EnvServerURL, "")
+		t.Setenv(EnvBuildURL, "")
+
+		assert.Equal(t, "https://build.example.com", ResolveServerURL())
+	})
+
+	t.Run("prefers TEAMCITY_URL", func(t *testing.T) {
+		t.Setenv(EnvServerURL, "https://env.example.com")
+		assert.Equal(t, "https://env.example.com", ResolveServerURL())
+	})
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -159,6 +159,17 @@ func GetServerURL() string {
 	return cfg.DefaultServer
 }
 
+// ResolveServerURL is GetServerURL with a build-level auth fallback (BUILD_URL), matching the client; use it for UI URLs built before a client exists.
+func ResolveServerURL() string {
+	if serverURL := GetServerURL(); serverURL != "" {
+		return serverURL
+	}
+	if buildAuth, ok := GetBuildAuth(); ok {
+		return buildAuth.ServerURL
+	}
+	return ""
+}
+
 func GetToken() string {
 	token, _, _ := GetTokenWithSource()
 	return token


### PR DESCRIPTION
## Summary

Adds consistent direct-navigation to the TeamCity UI across the CLI, resolving issue #306. `view` commands open the specific item with `--web`; list commands open their distinct overview page. `--web` echoes the resolved URL and best-effort opens the browser — on a headless box (CI/agent/SSH) the open fails with a warning but the URL is still printed and the command exits 0, so agents get the URL without a separate flag. Fixes #306.

## Changes

- Shared `cmdutil` helpers: `EmitWebURL` + `AddViewFlags`/`AddWebFlags`; one definition of `--web`, mutually exclusive with `--json`.
- `view` commands (specific item): `run`, `job`, `project`, `agent`, `pool`, `project vcs`, `project connection`, `project cloud profile`.
- `list` commands (overview page): `run`, `queue`, `agent`, `pool`, `project vcs`, `project ssh`; plus `project/job param list`.
- `project connection view` added; `secure:` connection properties masked in JSON output.
- Browser opening routed through an overridable `cmdutil.OpenInBrowser` (stubbed in the test harness).

## Design Decisions

A `list --web` is added only when `view` doesn't already land on the same page (connection/cloud-profile `view` fall back to a section tab, so their `list` would be redundant and is omitted). `--web` is non-fatal on open failure so it doubles as a headless URL accessor — `--json`/`--web` are mutually exclusive output modes (errors clearly instead of silently dropping one). URL source: `client.ServerURL()` when a client exists at emit time (view), `config.GetServerURL()` otherwise (list).

## Example

```bash
teamcity project cloud profile view aws-prod --web
teamcity agent list --web        # Opening in browser: https://<server>/agents.html
teamcity project ssh list -p Backend --web
```

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`) — N/A, not run locally (hits cli.teamcity.com)
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, repo convention covers `--web` via unit tests
- [x] If adding a data-producing command: includes `--json` support
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — docs regenerated (no net change), README updated
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change)
