### PR TITLE
feat: allow --limit 0 to fetch all results with truncation hint

### DIFF
--- a/acceptance/testdata/agent/agent-list.txtar
+++ b/acceptance/testdata/agent/agent-list.txtar
@@ -11,8 +11,8 @@ stdout '"count"'
 exec teamcity agent list --limit 5 --no-input
 ! stderr 'Error'
 
-! exec teamcity agent list --limit 0 --no-input
-stderr 'must be a positive number'
+! exec teamcity agent list --limit -1 --no-input
+stderr 'must not be negative'
 
 exec teamcity agent list --limit 1 --json=id,name --no-input
 stdout '"count"'

--- a/acceptance/testdata/job/job-list.txtar
+++ b/acceptance/testdata/job/job-list.txtar
@@ -23,8 +23,8 @@ stdout '"name"'
 stdout '"projectId"'
 ! stderr 'Error'
 
-! exec teamcity job list --limit 0 --no-input
-stderr 'must be a positive number'
+! exec teamcity job list --limit -1 --no-input
+stderr 'must not be negative'
 
 exec teamcity job list --all --plain --no-input
 stdout '.'

--- a/acceptance/testdata/project/project-list.txtar
+++ b/acceptance/testdata/project/project-list.txtar
@@ -27,11 +27,8 @@ exec teamcity project list --plain --no-header --no-input
 exec teamcity project list --limit 1 --no-input
 ! stderr 'Error'
 
-! exec teamcity project list --limit 0 --no-input
-stderr 'must be a positive number'
-
 ! exec teamcity project list --limit -1 --no-input
-stderr 'must be a positive number'
+stderr 'must not be negative'
 
 exec teamcity project list --parent _Root --limit 5 --no-input
 ! stderr 'Error'

--- a/acceptance/testdata/run/run-validation.txtar
+++ b/acceptance/testdata/run/run-validation.txtar
@@ -7,11 +7,8 @@ stderr 'job id is required'
 ! exec teamcity run cancel --no-input
 stderr 'accepts 1 arg'
 
-! exec teamcity run list --limit 0 --no-input
-stderr 'must be a positive number'
-
 ! exec teamcity run list --limit -1 --no-input
-stderr 'must be a positive number'
+stderr 'must not be negative'
 
 ! exec teamcity run list --status bogus --no-input
 stderr 'invalid status'

--- a/api/agents.go
+++ b/api/agents.go
@@ -19,8 +19,8 @@ type AgentsOptions struct {
 	Fields     []string // Fields to return (uses AgentFields.Default if empty)
 }
 
-// GetAgents returns a list of agents, automatically following pagination.
-func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
+// GetAgents returns a list of agents, following pagination; the bool is true when a finite limit capped the result.
+func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, bool, error) {
 	locator := NewLocator()
 
 	if opts.Authorized {
@@ -42,7 +42,7 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
 			locator.AddRaw("pool", "(name:"+opts.Pool+")")
 		}
 	}
-	locator.AddIntDefault("count", opts.Limit, 100)
+	locator.AddInt("count", pageCount(opts.Limit))
 
 	fields := opts.Fields
 	if len(fields) == 0 {
@@ -51,7 +51,7 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
 	fieldsParam := fmt.Sprintf("count,nextHref,agent(%s)", ToAPIFields(fields))
 	path := fmt.Sprintf("/app/rest/agents?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	agents, err := collectPages(c, path, opts.Limit, func(p string) ([]Agent, string, error) {
+	agents, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]Agent, string, error) {
 		var page AgentList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -59,10 +59,10 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, error) {
 		return page.Agents, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return &AgentList{Count: len(agents), Agents: agents}, nil
+	return &AgentList{Count: len(agents), Agents: agents}, truncated, nil
 }
 
 // AuthorizeAgent sets the authorized status of an agent

--- a/api/agents_test.go
+++ b/api/agents_test.go
@@ -22,7 +22,7 @@ func TestGetAgents(t *testing.T) {
 		})
 	})
 
-	result, err := client.GetAgents(AgentsOptions{})
+	result, _, err := client.GetAgents(AgentsOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Count)
 	assert.Equal(t, "Agent-1", result.Agents[0].Name)
@@ -39,7 +39,7 @@ func TestGetAgentsWithFilters(t *testing.T) {
 		json.NewEncoder(w).Encode(AgentList{Count: 0})
 	})
 
-	_, err := client.GetAgents(AgentsOptions{Authorized: true, Connected: true, Enabled: true})
+	_, _, err := client.GetAgents(AgentsOptions{Authorized: true, Connected: true, Enabled: true})
 	require.NoError(t, err)
 }
 
@@ -53,7 +53,7 @@ func TestGetAgentsWithPoolFilter(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(AgentList{Count: 0})
 		})
-		_, err := client.GetAgents(AgentsOptions{Pool: "Default"})
+		_, _, err := client.GetAgents(AgentsOptions{Pool: "Default"})
 		require.NoError(t, err)
 	})
 
@@ -64,7 +64,7 @@ func TestGetAgentsWithPoolFilter(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(AgentList{Count: 0})
 		})
-		_, err := client.GetAgents(AgentsOptions{Pool: "5"})
+		_, _, err := client.GetAgents(AgentsOptions{Pool: "5"})
 		require.NoError(t, err)
 	})
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -48,15 +48,15 @@ func requireIdleAgent(t *testing.T) api.Agent {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Minute)
 	for time.Until(deadline) > 0 {
-		agents, err := client.GetAgents(api.AgentsOptions{
+		agents, _, err := client.GetAgents(api.AgentsOptions{
 			Authorized: true, Connected: true, Enabled: true, Limit: 1,
 		})
 		if err != nil || len(agents.Agents) == 0 {
 			time.Sleep(2 * time.Second)
 			continue
 		}
-		running, _ := client.GetBuilds(t.Context(), api.BuildsOptions{State: "running", Limit: 10})
-		queued, _ := client.GetBuildQueue(api.QueueOptions{Limit: 10})
+		running, _, _ := client.GetBuilds(t.Context(), api.BuildsOptions{State: "running", Limit: 10})
+		queued, _, _ := client.GetBuildQueue(api.QueueOptions{Limit: 10})
 		if running != nil {
 			for _, b := range running.Builds {
 				_ = client.CancelBuild(fmt.Sprintf("%d", b.ID), "test cleanup")
@@ -133,7 +133,7 @@ func waitForOwnedAgentsReleased(t *testing.T) {
 	t.Helper()
 	deadline := time.Now().Add(3 * time.Minute)
 	for time.Until(deadline) > 0 {
-		agents, err := client.GetAgents(api.AgentsOptions{
+		agents, _, err := client.GetAgents(api.AgentsOptions{
 			Authorized: true, Connected: true, Enabled: true, Limit: 10,
 		})
 		if err != nil || len(agents.Agents) == 0 {
@@ -195,7 +195,7 @@ func TestGetProjects(T *testing.T) {
 	T.Run("basic list", func(t *testing.T) {
 		t.Parallel()
 
-		projects, err := client.GetProjects(api.ProjectsOptions{Limit: 5})
+		projects, _, err := client.GetProjects(api.ProjectsOptions{Limit: 5})
 		require.NoError(t, err)
 		assert.Greater(t, projects.Count, 0)
 	})
@@ -203,7 +203,7 @@ func TestGetProjects(T *testing.T) {
 	T.Run("with parent filter", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := client.GetProjects(api.ProjectsOptions{Parent: "_Root", Limit: 3})
+		_, _, err := client.GetProjects(api.ProjectsOptions{Parent: "_Root", Limit: 3})
 		require.NoError(t, err)
 	})
 }
@@ -222,7 +222,7 @@ func TestGetBuildTypes(T *testing.T) {
 	T.Run("with project filter", func(t *testing.T) {
 		t.Parallel()
 
-		configs, err := client.GetBuildTypes(api.BuildTypesOptions{Project: testProject, Limit: 10})
+		configs, _, err := client.GetBuildTypes(api.BuildTypesOptions{Project: testProject, Limit: 10})
 		require.NoError(t, err)
 		assert.Greater(t, configs.Count, 0)
 	})
@@ -230,7 +230,7 @@ func TestGetBuildTypes(T *testing.T) {
 	T.Run("without project filter", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := client.GetBuildTypes(api.BuildTypesOptions{Limit: 5})
+		_, _, err := client.GetBuildTypes(api.BuildTypesOptions{Limit: 5})
 		require.NoError(t, err)
 	})
 }
@@ -249,7 +249,7 @@ func TestGetBuilds(T *testing.T) {
 	T.Run("basic list", func(t *testing.T) {
 		t.Parallel()
 
-		builds, err := client.GetBuilds(t.Context(), api.BuildsOptions{BuildTypeID: testConfig, Limit: 5})
+		builds, _, err := client.GetBuilds(t.Context(), api.BuildsOptions{BuildTypeID: testConfig, Limit: 5})
 		require.NoError(t, err)
 		t.Logf("Found %d builds", builds.Count)
 	})
@@ -257,7 +257,7 @@ func TestGetBuilds(T *testing.T) {
 	T.Run("with filters", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := client.GetBuilds(t.Context(), api.BuildsOptions{
+		_, _, err := client.GetBuilds(t.Context(), api.BuildsOptions{
 			BuildTypeID: testConfig,
 			Status:      "success",
 			State:       "finished",
@@ -270,7 +270,7 @@ func TestGetBuilds(T *testing.T) {
 	T.Run("by project", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := client.GetBuilds(t.Context(), api.BuildsOptions{Project: testProject, Limit: 3})
+		_, _, err := client.GetBuilds(t.Context(), api.BuildsOptions{Project: testProject, Limit: 3})
 		require.NoError(t, err)
 	})
 }
@@ -332,7 +332,7 @@ func TestGetBuildQueue(T *testing.T) {
 	T.Run("basic list", func(t *testing.T) {
 		t.Parallel()
 
-		queue, err := client.GetBuildQueue(api.QueueOptions{Limit: 10})
+		queue, _, err := client.GetBuildQueue(api.QueueOptions{Limit: 10})
 		require.NoError(t, err)
 		t.Logf("Queue has %d builds", queue.Count)
 	})
@@ -340,7 +340,7 @@ func TestGetBuildQueue(T *testing.T) {
 	T.Run("with config filter", func(t *testing.T) {
 		t.Parallel()
 
-		_, err := client.GetBuildQueue(api.QueueOptions{BuildTypeID: testConfig, Limit: 5})
+		_, _, err := client.GetBuildQueue(api.QueueOptions{BuildTypeID: testConfig, Limit: 5})
 		require.NoError(t, err)
 	})
 }
@@ -1010,7 +1010,7 @@ func TestPoolOperations(T *testing.T) {
 	})
 
 	T.Run("move agent to pool and back", func(t *testing.T) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		require.NoError(t, err)
 		if len(agents.Agents) == 0 {
 			t.Skip("no agents available")
@@ -1047,7 +1047,7 @@ func TestGetAgentIncompatibleBuildTypes(T *testing.T) {
 	skipIfGuest(T)
 	T.Parallel()
 
-	agents, err := client.GetAgents(api.AgentsOptions{})
+	agents, _, err := client.GetAgents(api.AgentsOptions{})
 	require.NoError(T, err)
 	require.Greater(T, len(agents.Agents), 0)
 
@@ -1093,7 +1093,7 @@ func TestRunBuildAdvancedOptions(T *testing.T) {
 	})
 
 	T.Run("with agent ID", func(t *testing.T) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		require.NoError(t, err)
 		if len(agents.Agents) == 0 {
 			t.Skip("no agents available")
@@ -1132,7 +1132,7 @@ func TestGetAgentsPoolFilter(T *testing.T) {
 		pool, err := client.GetAgentPool(0)
 		require.NoError(t, err)
 
-		agents, err := client.GetAgents(api.AgentsOptions{Pool: pool.Name})
+		agents, _, err := client.GetAgents(api.AgentsOptions{Pool: pool.Name})
 		require.NoError(t, err)
 		t.Logf("Found %d agents in pool '%s'", agents.Count, pool.Name)
 	})
@@ -1140,7 +1140,7 @@ func TestGetAgentsPoolFilter(T *testing.T) {
 	T.Run("filter by pool numeric ID", func(t *testing.T) {
 		t.Parallel()
 
-		agents, err := client.GetAgents(api.AgentsOptions{Pool: "0"})
+		agents, _, err := client.GetAgents(api.AgentsOptions{Pool: "0"})
 		require.NoError(t, err)
 		t.Logf("Found %d agents in pool ID 0", agents.Count)
 	})
@@ -1191,7 +1191,7 @@ func TestRebootAgentCancelledContext(T *testing.T) {
 	skipIfGuest(T)
 	T.Parallel()
 
-	agents, err := client.GetAgents(api.AgentsOptions{})
+	agents, _, err := client.GetAgents(api.AgentsOptions{})
 	require.NoError(T, err)
 	if len(agents.Agents) == 0 {
 		T.Skip("no agents available")
@@ -1207,7 +1207,7 @@ func TestRebootAgentCancelledContext(T *testing.T) {
 func TestGetBuildQueueWithFilter(T *testing.T) {
 	T.Parallel()
 
-	queue, err := client.GetBuildQueue(api.QueueOptions{BuildTypeID: testConfig, Limit: 5})
+	queue, _, err := client.GetBuildQueue(api.QueueOptions{BuildTypeID: testConfig, Limit: 5})
 	require.NoError(T, err)
 	T.Logf("Queue has %d builds for config %s", queue.Count, testConfig)
 }
@@ -1219,14 +1219,14 @@ func TestAgentOperations(T *testing.T) {
 	// Not parallel - modifies agent state
 
 	T.Run("list agents", func(t *testing.T) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		require.NoError(t, err)
 		assert.Greater(t, agents.Count, 0, "should have at least one agent")
 		t.Logf("Found %d agents", agents.Count)
 	})
 
 	T.Run("get agent by id", func(t *testing.T) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		require.NoError(t, err)
 		require.Greater(t, len(agents.Agents), 0)
 
@@ -1238,7 +1238,7 @@ func TestAgentOperations(T *testing.T) {
 	})
 
 	T.Run("get agent by name", func(t *testing.T) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		require.NoError(t, err)
 		require.Greater(t, len(agents.Agents), 0)
 
@@ -1250,7 +1250,7 @@ func TestAgentOperations(T *testing.T) {
 	})
 
 	T.Run("get compatible build types", func(t *testing.T) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		require.NoError(t, err)
 		require.Greater(t, len(agents.Agents), 0)
 
@@ -1260,7 +1260,7 @@ func TestAgentOperations(T *testing.T) {
 	})
 
 	T.Run("enable and disable", func(t *testing.T) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		require.NoError(t, err)
 		require.Greater(t, len(agents.Agents), 0)
 

--- a/api/builds.go
+++ b/api/builds.go
@@ -66,10 +66,10 @@ func currentUserFavoriteBuildsTagLocator() *Locator {
 			Add("ignoreCase", "false"))
 }
 
-// GetBuilds returns a list of builds, automatically following pagination.
-func (c *Client) GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList, error) {
+// GetBuilds returns a list of builds, following pagination; the bool is true when a finite limit capped the result.
+func (c *Client) GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList, bool, error) {
 	locator := opts.Locator().
-		AddIntDefault("count", opts.Limit, 30)
+		AddInt("count", pageCount(opts.Limit))
 
 	buildFields := opts.Fields
 	if len(buildFields) == 0 {
@@ -78,7 +78,7 @@ func (c *Client) GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList,
 	fields := fmt.Sprintf("count,nextHref,build(%s)", ToAPIFields(buildFields))
 	path := fmt.Sprintf("/app/rest/builds?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fields))
 
-	builds, err := collectPages(c, path, opts.Limit, func(p string) ([]Build, string, error) {
+	builds, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]Build, string, error) {
 		var page BuildList
 		if err := c.get(ctx, p, &page); err != nil {
 			return nil, "", err
@@ -86,14 +86,14 @@ func (c *Client) GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList,
 		return page.Builds, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	for i := range builds {
 		cleanupBuildTriggered(&builds[i])
 	}
 
-	return &BuildList{Count: len(builds), Builds: builds}, nil
+	return &BuildList{Count: len(builds), Builds: builds}, truncated, nil
 }
 
 // cleanupBuildTriggered removes empty User objects from build trigger info
@@ -115,7 +115,7 @@ func (c *Client) ResolveBuildID(ctx context.Context, ref string) (string, error)
 	}
 
 	number := strings.TrimPrefix(ref, "#")
-	builds, err := c.GetBuilds(ctx, BuildsOptions{Limit: 1, Number: number})
+	builds, _, err := c.GetBuilds(ctx, BuildsOptions{Limit: 1, Number: number})
 	if err != nil {
 		return "", err
 	}
@@ -404,11 +404,11 @@ func (c *Client) CancelBuild(buildID string, comment string) error {
 
 // GetBuildSnapshotDependencies returns all immediate dependency builds in a snapshot dependency chain.
 func (c *Client) GetBuildSnapshotDependencies(buildID string) (*BuildList, error) {
-	locator := fmt.Sprintf("snapshotDependency:(to:(id:%s),recursive:false),defaultFilter:false", buildID)
+	locator := fmt.Sprintf("snapshotDependency:(to:(id:%s),recursive:false),defaultFilter:false,count:%d", buildID, pageCount(0))
 	fields := "count,nextHref,build(id,number,status,statusText,state,buildTypeId,buildType(id,name))"
 	path := fmt.Sprintf("/app/rest/builds?locator=%s&fields=%s", url.QueryEscape(locator), url.QueryEscape(fields))
 
-	builds, err := collectPages(c, path, 0, func(p string) ([]Build, string, error) {
+	builds, _, err := collectPages(c, path, 0, func(p string) ([]Build, string, error) {
 		var page BuildList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err

--- a/api/builds_queue.go
+++ b/api/builds_queue.go
@@ -14,11 +14,11 @@ type QueueOptions struct {
 	Fields      []string
 }
 
-// GetBuildQueue returns the build queue, automatically following pagination.
-func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
+// GetBuildQueue returns the build queue, following pagination; the bool is true when a finite limit capped the result.
+func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, bool, error) {
 	locator := NewLocator().
 		Add("buildType", opts.BuildTypeID).
-		AddInt("count", opts.Limit)
+		AddInt("count", pageCount(opts.Limit))
 
 	fields := opts.Fields
 	if len(fields) == 0 {
@@ -33,7 +33,7 @@ func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
 		path = fmt.Sprintf("%s?fields=%s", path, url.QueryEscape(fieldsParam))
 	}
 
-	builds, err := collectPages(c, path, opts.Limit, func(p string) ([]QueuedBuild, string, error) {
+	builds, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]QueuedBuild, string, error) {
 		var page BuildQueue
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -41,9 +41,9 @@ func (c *Client) GetBuildQueue(opts QueueOptions) (*BuildQueue, error) {
 		return page.Builds, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return &BuildQueue{Count: len(builds), Builds: builds}, nil
+	return &BuildQueue{Count: len(builds), Builds: builds}, truncated, nil
 }
 
 // RemoveFromQueue removes a build from the queue

--- a/api/builds_queue_test.go
+++ b/api/builds_queue_test.go
@@ -21,7 +21,7 @@ func TestGetBuildQueue(t *testing.T) {
 		})
 	})
 
-	result, err := client.GetBuildQueue(QueueOptions{})
+	result, _, err := client.GetBuildQueue(QueueOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Count)
 }
@@ -34,7 +34,7 @@ func TestGetBuildQueueWithFilter(t *testing.T) {
 		json.NewEncoder(w).Encode(BuildQueue{Count: 0})
 	})
 
-	_, err := client.GetBuildQueue(QueueOptions{BuildTypeID: "bt1"})
+	_, _, err := client.GetBuildQueue(QueueOptions{BuildTypeID: "bt1"})
 	require.NoError(t, err)
 }
 

--- a/api/builds_test.go
+++ b/api/builds_test.go
@@ -83,7 +83,7 @@ func TestGetBuildsUsesFavoritesLocator(T *testing.T) {
 		json.NewEncoder(w).Encode(BuildList{Count: 0, Builds: []Build{}})
 	})
 
-	_, err := client.GetBuilds(T.Context(), BuildsOptions{Favorites: true, Limit: 5})
+	_, _, err := client.GetBuilds(T.Context(), BuildsOptions{Favorites: true, Limit: 5})
 	require.NoError(T, err)
 
 	assert.Contains(T, capturedQuery, BuildsOptions{Favorites: true}.Locator().Encode())

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -107,7 +107,7 @@ func TestBasicAuthWorksForAPIRequests(T *testing.T) {
 	T.Cleanup(server.Close)
 
 	client := NewClientWithBasicAuth(server.URL, "testuser", "testpass")
-	projects, err := client.GetProjects(ProjectsOptions{})
+	projects, _, err := client.GetProjects(ProjectsOptions{})
 
 	require.NoError(T, err)
 	assert.Equal(T, 1, projects.Count)

--- a/api/cloud.go
+++ b/api/cloud.go
@@ -81,10 +81,10 @@ func isCloudIDLikeLocator(value string) bool {
 		strings.HasPrefix(value, "projectId:")
 }
 
-func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList, error) {
+func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList, bool, error) {
 	locator := NewLocator().
 		Add("project", opts.ProjectID).
-		AddIntDefault("count", opts.Limit, 100)
+		AddInt("count", pageCount(opts.Limit))
 
 	fields := opts.Fields
 	if len(fields) == 0 {
@@ -93,7 +93,7 @@ func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList,
 	fieldsParam := fmt.Sprintf("count,nextHref,cloudProfile(%s)", ToAPIFields(fields))
 	path := fmt.Sprintf("/app/rest/cloud/profiles?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	profiles, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudProfile, string, error) {
+	profiles, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudProfile, string, error) {
 		var page CloudProfileList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -101,9 +101,9 @@ func (c *Client) GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList,
 		return page.Profiles, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return &CloudProfileList{Count: len(profiles), Profiles: profiles}, nil
+	return &CloudProfileList{Count: len(profiles), Profiles: profiles}, truncated, nil
 }
 
 func (c *Client) GetCloudProfile(locator string) (*CloudProfile, error) {
@@ -116,13 +116,13 @@ func (c *Client) GetCloudProfile(locator string) (*CloudProfile, error) {
 	return &result, nil
 }
 
-func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error) {
+func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, bool, error) {
 	locator := NewLocator().
 		Add("project", opts.ProjectID)
 	if opts.Profile != "" {
 		locator.AddRaw("profile", "("+cloudLocator(opts.Profile, "id")+")")
 	}
-	locator.AddIntDefault("count", opts.Limit, 100)
+	locator.AddInt("count", pageCount(opts.Limit))
 
 	fields := opts.Fields
 	if len(fields) == 0 {
@@ -131,7 +131,7 @@ func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error
 	fieldsParam := fmt.Sprintf("count,nextHref,cloudImage(%s)", ToAPIFields(fields))
 	path := fmt.Sprintf("/app/rest/cloud/images?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	images, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudImage, string, error) {
+	images, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudImage, string, error) {
 		var page CloudImageList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -139,9 +139,9 @@ func (c *Client) GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error
 		return page.Images, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return &CloudImageList{Count: len(images), Images: images}, nil
+	return &CloudImageList{Count: len(images), Images: images}, truncated, nil
 }
 
 func (c *Client) GetCloudImage(locator string) (*CloudImage, error) {
@@ -154,13 +154,13 @@ func (c *Client) GetCloudImage(locator string) (*CloudImage, error) {
 	return &result, nil
 }
 
-func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceList, error) {
+func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceList, bool, error) {
 	locator := NewLocator().
 		Add("project", opts.ProjectID)
 	if opts.Image != "" {
 		locator.AddRaw("image", "("+cloudLocator(opts.Image, "name")+")")
 	}
-	locator.AddIntDefault("count", opts.Limit, 100)
+	locator.AddInt("count", pageCount(opts.Limit))
 
 	fields := opts.Fields
 	if len(fields) == 0 {
@@ -169,7 +169,7 @@ func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceLi
 	fieldsParam := fmt.Sprintf("count,nextHref,cloudInstance(%s)", ToAPIFields(fields))
 	path := fmt.Sprintf("/app/rest/cloud/instances?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	instances, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudInstance, string, error) {
+	instances, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]CloudInstance, string, error) {
 		var page CloudInstanceList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -177,9 +177,9 @@ func (c *Client) GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceLi
 		return page.Instances, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return &CloudInstanceList{Count: len(instances), Instances: instances}, nil
+	return &CloudInstanceList{Count: len(instances), Instances: instances}, truncated, nil
 }
 
 func (c *Client) GetCloudInstance(locator string) (*CloudInstance, error) {

--- a/api/cloud_test.go
+++ b/api/cloud_test.go
@@ -74,7 +74,7 @@ func TestGetCloudInstancesBareImageSelectorUsesNameLocator(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(CloudInstanceList{})
 	})
 
-	_, err := client.GetCloudInstances(CloudInstancesOptions{
+	_, _, err := client.GetCloudInstances(CloudInstancesOptions{
 		ProjectID: "TestProject",
 		Image:     "ubuntu-22-large",
 	})
@@ -90,7 +90,7 @@ func TestGetCloudInstancesColonInImageNameUsesWrappedNameLocator(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(CloudInstanceList{})
 	})
 
-	_, err := client.GetCloudInstances(CloudInstancesOptions{
+	_, _, err := client.GetCloudInstances(CloudInstancesOptions{
 		ProjectID: "TestProject",
 		Image:     "ubuntu:22.04",
 	})
@@ -106,7 +106,7 @@ func TestGetCloudInstancesPreservesExplicitCompoundImageLocator(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(CloudInstanceList{})
 	})
 
-	_, err := client.GetCloudInstances(CloudInstancesOptions{
+	_, _, err := client.GetCloudInstances(CloudInstancesOptions{
 		ProjectID: "TestProject",
 		Image:     "id:img-1,profileId:aws-prod",
 	})

--- a/api/drift_test.go
+++ b/api/drift_test.go
@@ -325,7 +325,7 @@ func TestAPIDriftEndpoints(t *testing.T) {
 		{"GetCurrentUser", func() (any, error) { return client.GetCurrentUser() }},
 
 		// Project graph
-		{"GetProjects", func() (any, error) { return client.GetProjects(api.ProjectsOptions{}) }},
+		{"GetProjects", func() (any, error) { r, _, err := client.GetProjects(api.ProjectsOptions{}); return r, err }},
 		{"GetProject", func() (any, error) { return client.GetProject(testProject) }},
 		{"GetVersionedSettingsConfig", func() (any, error) { return client.GetVersionedSettingsConfig(testProject) }},
 		{"GetVersionedSettingsStatus", func() (any, error) { return client.GetVersionedSettingsStatus(testProject) }},
@@ -333,7 +333,7 @@ func TestAPIDriftEndpoints(t *testing.T) {
 		{"GetProjectConnections", func() (any, error) { return client.GetProjectConnections(testProject) }},
 
 		// Build configurations
-		{"GetBuildTypes", func() (any, error) { return client.GetBuildTypes(api.BuildTypesOptions{}) }},
+		{"GetBuildTypes", func() (any, error) { r, _, err := client.GetBuildTypes(api.BuildTypesOptions{}); return r, err }},
 		{"GetBuildType", func() (any, error) { return client.GetBuildType(testConfig) }},
 		{"GetBuildTypeParameters", func() (any, error) { return client.GetBuildTypeParameters(testConfig) }},
 		{"GetSnapshotDependencies", func() (any, error) { return client.GetSnapshotDependencies(testConfig) }},
@@ -341,7 +341,10 @@ func TestAPIDriftEndpoints(t *testing.T) {
 		{"GetVcsRootEntries", func() (any, error) { return client.GetVcsRootEntries(testConfig) }},
 
 		// Builds (read)
-		{"GetBuilds", func() (any, error) { return client.GetBuilds(t.Context(), api.BuildsOptions{Limit: 5}) }},
+		{"GetBuilds", func() (any, error) {
+			r, _, err := client.GetBuilds(t.Context(), api.BuildsOptions{Limit: 5})
+			return r, err
+		}},
 		{"GetBuild", func() (any, error) { return client.GetBuild(t.Context(), buildID) }},
 		{"GetBuildChanges", func() (any, error) { return client.GetBuildChanges(t.Context(), buildID) }},
 		{"GetBuildTags", func() (any, error) { return client.GetBuildTags(buildID) }},
@@ -357,22 +360,22 @@ func TestAPIDriftEndpoints(t *testing.T) {
 		{"GetArtifacts", func() (any, error) { return client.GetArtifacts(t.Context(), buildID, "") }},
 
 		// Queue
-		{"GetBuildQueue", func() (any, error) { return client.GetBuildQueue(api.QueueOptions{}) }},
+		{"GetBuildQueue", func() (any, error) { r, _, err := client.GetBuildQueue(api.QueueOptions{}); return r, err }},
 
 		// Agents and pools
-		{"GetAgents", func() (any, error) { return client.GetAgents(api.AgentsOptions{}) }},
+		{"GetAgents", func() (any, error) { r, _, err := client.GetAgents(api.AgentsOptions{}); return r, err }},
 		{"GetAgentPools", func() (any, error) { return client.GetAgentPools(nil) }},
 
 		// VCS
-		{"GetVcsRoots", func() (any, error) { return client.GetVcsRoots(api.VcsRootsOptions{}) }},
+		{"GetVcsRoots", func() (any, error) { r, _, err := client.GetVcsRoots(api.VcsRootsOptions{}); return r, err }},
 
 		// Cloud
-		{"GetCloudProfiles", func() (any, error) { return client.GetCloudProfiles(api.CloudProfilesOptions{}) }},
-		{"GetCloudImages", func() (any, error) { return client.GetCloudImages(api.CloudImagesOptions{}) }},
-		{"GetCloudInstances", func() (any, error) { return client.GetCloudInstances(api.CloudInstancesOptions{}) }},
+		{"GetCloudProfiles", func() (any, error) { r, _, err := client.GetCloudProfiles(api.CloudProfilesOptions{}); return r, err }},
+		{"GetCloudImages", func() (any, error) { r, _, err := client.GetCloudImages(api.CloudImagesOptions{}); return r, err }},
+		{"GetCloudInstances", func() (any, error) { r, _, err := client.GetCloudInstances(api.CloudInstancesOptions{}); return r, err }},
 
 		// Pipelines (TeamCity 2026.1+; skips cleanly on older servers)
-		{"GetPipelines", func() (any, error) { return client.GetPipelines(api.PipelinesOptions{}) }},
+		{"GetPipelines", func() (any, error) { r, _, err := client.GetPipelines(api.PipelinesOptions{}); return r, err }},
 		{"GetPipelineSchema", func() (any, error) { return client.GetPipelineSchema() }},
 	}
 
@@ -397,7 +400,7 @@ func TestAPIDriftAgentEndpoints(t *testing.T) {
 	if client == nil {
 		t.Skip("no TeamCity client configured")
 	}
-	agents, err := client.GetAgents(api.AgentsOptions{})
+	agents, _, err := client.GetAgents(api.AgentsOptions{})
 	if err != nil {
 		t.Skipf("could not list agents: %v", err)
 	}

--- a/api/interface.go
+++ b/api/interface.go
@@ -20,7 +20,7 @@ type ClientInterface interface {
 	CreateAPIToken(name string) (*Token, error)
 	DeleteAPIToken(name string) error
 
-	GetProjects(opts ProjectsOptions) (*ProjectList, error)
+	GetProjects(opts ProjectsOptions) (*ProjectList, bool, error)
 	GetProject(id string) (*Project, error)
 	CreateProject(req CreateProjectRequest) (*Project, error)
 	ProjectExists(id string) bool
@@ -30,7 +30,7 @@ type ClientInterface interface {
 	GetVersionedSettingsConfig(projectID string) (*VersionedSettingsConfig, error)
 	ExportProjectSettings(projectID, format string, useRelativeIds bool) ([]byte, error)
 
-	GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error)
+	GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, bool, error)
 	GetBuildType(id string) (*BuildType, error)
 	SetBuildTypePaused(id string, paused bool) error
 	CreateBuildType(projectID string, req CreateBuildTypeRequest) (*BuildType, error)
@@ -44,7 +44,7 @@ type ClientInterface interface {
 	GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error)
 	SetBuildTypeSetting(buildTypeID, setting, value string) error
 
-	GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList, error)
+	GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList, bool, error)
 	GetBuild(ctx context.Context, ref string) (*Build, error)
 	GetBuildUsedByOtherBuilds(id string) (bool, error)
 	WaitForBuild(ctx context.Context, buildID string, opts WaitForBuildOptions) (*Build, error)
@@ -74,7 +74,7 @@ type ClientInterface interface {
 	DownloadArtifact(ctx context.Context, buildID, artifactPath string) ([]byte, error)
 	DownloadArtifactTo(ctx context.Context, buildID, artifactPath string, w io.Writer) (int64, error)
 
-	GetBuildQueue(opts QueueOptions) (*BuildQueue, error)
+	GetBuildQueue(opts QueueOptions) (*BuildQueue, bool, error)
 	RemoveFromQueue(id string) error
 	SetQueuedBuildPosition(buildID string, position int) error
 	MoveQueuedBuildToTop(buildID string) error
@@ -91,7 +91,7 @@ type ClientInterface interface {
 	DeleteBuildTypeParameter(buildTypeID, name string) error
 	GetParameterValue(path string) (string, error)
 
-	GetAgents(opts AgentsOptions) (*AgentList, error)
+	GetAgents(opts AgentsOptions) (*AgentList, bool, error)
 	GetAgent(id int) (*Agent, error)
 	GetAgentByName(name string) (*Agent, error)
 	AuthorizeAgent(id int, authorized bool) error
@@ -109,17 +109,17 @@ type ClientInterface interface {
 	RemoveProjectFromPool(poolID int, projectID string) error
 	SetAgentPool(agentID int, poolID int) error
 
-	GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList, error)
+	GetCloudProfiles(opts CloudProfilesOptions) (*CloudProfileList, bool, error)
 	GetCloudProfile(locator string) (*CloudProfile, error)
-	GetCloudImages(opts CloudImagesOptions) (*CloudImageList, error)
+	GetCloudImages(opts CloudImagesOptions) (*CloudImageList, bool, error)
 	GetCloudImage(locator string) (*CloudImage, error)
-	GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceList, error)
+	GetCloudInstances(opts CloudInstancesOptions) (*CloudInstanceList, bool, error)
 	GetCloudInstance(locator string) (*CloudInstance, error)
 	StartCloudInstance(imageID string) (*CloudInstance, error)
 	StopCloudInstance(locator string, force bool) error
 
 	GetBuildPipelineRun(buildID string) (*PipelineRun, error)
-	GetPipelines(opts PipelinesOptions) (*PipelineList, error)
+	GetPipelines(opts PipelinesOptions) (*PipelineList, bool, error)
 	GetPipeline(id string) (*Pipeline, error)
 	GetPipelineYAML(id string) (string, error)
 	CreatePipeline(parentProjectID, name, yaml, vcsRootID string) (*Pipeline, error)
@@ -127,7 +127,7 @@ type ClientInterface interface {
 	DeletePipeline(id string) error
 	GetPipelineSchema() ([]byte, error)
 
-	GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error)
+	GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, bool, error)
 	GetVcsRoot(id string) (*VcsRoot, error)
 	CreateVcsRoot(root VcsRoot) (*VcsRoot, error)
 	DeleteVcsRoot(id string) error

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -18,11 +18,11 @@ type BuildTypesOptions struct {
 	Fields     []string
 }
 
-// GetBuildTypes returns a list of build configurations, automatically following pagination.
-func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
+// GetBuildTypes returns a list of build configurations, following pagination; the bool is true when a finite limit capped the result.
+func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, bool, error) {
 	locator := NewLocator().
 		Add("affectedProject", opts.Project).
-		AddIntDefault("count", opts.Limit, 30)
+		AddInt("count", pageCount(opts.Limit))
 	if opts.VcsRootURL != "" {
 		locator.AddLocator("vcsRoot", NewLocator().
 			AddLocator("property", NewLocator().
@@ -38,7 +38,7 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
 	fieldsParam := fmt.Sprintf("count,nextHref,buildType(%s)", ToAPIFields(fields))
 	path := fmt.Sprintf("/app/rest/buildTypes?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	buildTypes, err := collectPages(c, path, opts.Limit, func(p string) ([]BuildType, string, error) {
+	buildTypes, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]BuildType, string, error) {
 		var page BuildTypeList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -46,10 +46,10 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, error) {
 		return page.BuildTypes, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return &BuildTypeList{Count: len(buildTypes), BuildTypes: buildTypes}, nil
+	return &BuildTypeList{Count: len(buildTypes), BuildTypes: buildTypes}, truncated, nil
 }
 
 // GetBuildType returns a single build configuration by ID

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -21,7 +21,7 @@ func TestGetBuildTypes(t *testing.T) {
 		})
 	})
 
-	result, err := client.GetBuildTypes(BuildTypesOptions{Project: "MyProject"})
+	result, _, err := client.GetBuildTypes(BuildTypesOptions{Project: "MyProject"})
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Count)
 }
@@ -35,7 +35,7 @@ func TestGetBuildTypesVcsRootURLFilter(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(BuildTypeList{Count: 0})
 	})
 
-	_, err := client.GetBuildTypes(BuildTypesOptions{VcsRootURL: "acme/repo"})
+	_, _, err := client.GetBuildTypes(BuildTypesOptions{VcsRootURL: "acme/repo"})
 	require.NoError(t, err)
 	assert.Contains(t, seenLocator, "vcsRoot:(property:(name:url,value:acme/repo,matchType:contains))")
 }

--- a/api/paginate.go
+++ b/api/paginate.go
@@ -5,22 +5,33 @@ import (
 	"strings"
 )
 
-// collectPages follows NextHref links to accumulate items up to the limit.
-// If limit is 0, all pages are collected.
-func collectPages[T any](c *Client, path string, limit int, fetch func(string) ([]T, string, error)) ([]T, error) {
+// allPageSize is the per-page count requested for an unbounded fetch; the server caps it and collectPages follows nextHref for the remainder, so a large value just trims round-trips.
+const allPageSize = 1000
+
+// pageCount returns the per-page item count to request: allPageSize when limit is unbounded (0), otherwise the limit.
+func pageCount(limit int) int {
+	if limit == 0 {
+		return allPageSize
+	}
+	return limit
+}
+
+// collectPages follows NextHref links to accumulate items up to the limit (0 collects all); the bool is true when a finite limit capped the result and more exist.
+func collectPages[T any](c *Client, path string, limit int, fetch func(string) ([]T, string, error)) ([]T, bool, error) {
 	var all []T
 	for path != "" {
 		items, nextHref, err := fetch(path)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		all = append(all, items...)
 		if limit > 0 && len(all) >= limit {
-			return all[:limit], nil
+			truncated := len(all) > limit || c.normalizePaginationPath(nextHref) != ""
+			return all[:limit], truncated, nil
 		}
 		path = c.normalizePaginationPath(nextHref)
 	}
-	return all, nil
+	return all, false, nil
 }
 
 // normalizePaginationPath converts a TeamCity NextHref value into a path

--- a/api/paginate_test.go
+++ b/api/paginate_test.go
@@ -14,7 +14,7 @@ func TestCollectPages(t *testing.T) {
 		t.Parallel()
 		c := &Client{BaseURL: "http://localhost"}
 		call := 0
-		items, err := collectPages(c, "/app/rest/builds?page=1", 0, func(path string) ([]int, string, error) {
+		items, truncated, err := collectPages(c, "/app/rest/builds?page=1", 0, func(path string) ([]int, string, error) {
 			call++
 			switch call {
 			case 1:
@@ -28,20 +28,92 @@ func TestCollectPages(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []int{1, 2, 3, 4, 5}, items)
 		assert.Equal(t, 3, call)
+		assert.False(t, truncated)
 	})
 
 	t.Run("stops at limit", func(t *testing.T) {
 		t.Parallel()
 		c := &Client{BaseURL: "http://localhost"}
 		call := 0
-		items, err := collectPages(c, "/app/rest/builds", 3, func(path string) ([]int, string, error) {
+		items, truncated, err := collectPages(c, "/app/rest/builds", 3, func(path string) ([]int, string, error) {
 			call++
 			return []int{call * 10, call*10 + 1}, "/app/rest/builds?next", nil
 		})
 		require.NoError(t, err)
 		assert.Equal(t, []int{10, 11, 20}, items)
 		assert.Equal(t, 2, call)
+		// Collected 4 items for a limit of 3 -> more exist.
+		assert.True(t, truncated)
 	})
+
+	t.Run("truncated at exact boundary with more pages", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{BaseURL: "http://localhost"}
+		call := 0
+		items, truncated, err := collectPages(c, "/app/rest/builds", 4, func(path string) ([]int, string, error) {
+			call++
+			return []int{call * 10, call*10 + 1}, "/app/rest/builds?next", nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{10, 11, 20, 21}, items)
+		assert.Equal(t, 2, call)
+		// Exactly at the limit but nextHref is non-empty -> more exist.
+		assert.True(t, truncated)
+	})
+
+	t.Run("exhausted exactly at limit reports not truncated", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{BaseURL: "http://localhost"}
+		call := 0
+		items, truncated, err := collectPages(c, "/app/rest/builds", 4, func(path string) ([]int, string, error) {
+			call++
+			next := "/app/rest/builds?next"
+			if call == 2 {
+				next = ""
+			}
+			return []int{call * 10, call*10 + 1}, next, nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{10, 11, 20, 21}, items)
+		assert.Equal(t, 2, call)
+		// Exactly at the limit and no more pages -> not truncated.
+		assert.False(t, truncated)
+	})
+
+	t.Run("unbounded fetch uses large page and collects all", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{BaseURL: "http://localhost"}
+		const total = 2500
+		pageSize := pageCount(0)
+		served, call := 0, 0
+		items, truncated, err := collectPages(c, "/app/rest/builds", 0, func(path string) ([]int, string, error) {
+			call++
+			n := min(pageSize, total-served)
+			page := make([]int, n)
+			for i := range page {
+				page[i] = served + i
+			}
+			served += n
+			next := "/app/rest/builds?next"
+			if served >= total {
+				next = ""
+			}
+			return page, next, nil
+		})
+		require.NoError(t, err)
+		assert.Len(t, items, total)
+		// 1000 + 1000 + 500 = 3 round-trips, vs 84 at the old page size of 30.
+		assert.Equal(t, 3, call)
+		// limit == 0 is always unbounded -> never truncated.
+		assert.False(t, truncated)
+	})
+}
+
+func TestPageCount(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, allPageSize, pageCount(0))
+	assert.Equal(t, 50, pageCount(50))
+	assert.Equal(t, 1, pageCount(1))
 }
 
 func TestNormalizePaginationPath(t *testing.T) {

--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 )
 
-// GetPipelines lists pipelines, optionally filtered by project. Automatically follows pagination.
-func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, error) {
+// GetPipelines lists pipelines, optionally filtered by project, following pagination; the bool is true when a finite limit capped the result.
+func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, bool, error) {
 	locator := NewLocator().
-		AddIntDefault("count", opts.Limit, 100)
+		AddInt("count", pageCount(opts.Limit))
 	if opts.Project != "" {
 		locator.AddLocator("parentProject", NewLocator().Add("id", opts.Project))
 	}
@@ -27,7 +27,7 @@ func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, error) {
 	path := fmt.Sprintf("/app/rest/pipelines?locator=%s&fields=%s",
 		locator.Encode(), url.QueryEscape(fieldsParam))
 
-	pipelines, err := collectPages(c, path, opts.Limit, func(p string) ([]Pipeline, string, error) {
+	pipelines, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]Pipeline, string, error) {
 		var page PipelineList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -35,9 +35,9 @@ func (c *Client) GetPipelines(opts PipelinesOptions) (*PipelineList, error) {
 		return page.Pipelines, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return &PipelineList{Count: len(pipelines), Pipelines: pipelines}, nil
+	return &PipelineList{Count: len(pipelines), Pipelines: pipelines}, truncated, nil
 }
 
 // GetPipeline retrieves a single pipeline by ID via the REST API.

--- a/api/pools.go
+++ b/api/pools.go
@@ -14,9 +14,10 @@ func (c *Client) GetAgentPools(requestedFields []string) (*PoolList, error) {
 		fields = PoolFields.Default
 	}
 	fieldsParam := fmt.Sprintf("count,nextHref,agentPool(%s)", ToAPIFields(fields))
-	path := "/app/rest/agentPools?fields=" + url.QueryEscape(fieldsParam)
+	locator := NewLocator().AddInt("count", pageCount(0))
+	path := fmt.Sprintf("/app/rest/agentPools?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	pools, err := collectPages(c, path, 0, func(p string) ([]Pool, string, error) {
+	pools, _, err := collectPages(c, path, 0, func(p string) ([]Pool, string, error) {
 		var page PoolList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err

--- a/api/projects.go
+++ b/api/projects.go
@@ -21,11 +21,11 @@ type ProjectsOptions struct {
 	ExcludeArchived bool
 }
 
-// GetProjects returns a list of projects, automatically following pagination.
-func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
+// GetProjects returns a list of projects, following pagination; the bool is true when a finite limit capped the result.
+func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, bool, error) {
 	locator := NewLocator().
 		Add("parentProject", opts.Parent).
-		AddIntDefault("count", opts.Limit, 30)
+		AddInt("count", pageCount(opts.Limit))
 	if opts.Permission != "" {
 		locator.AddLocator("userPermission", NewLocator().
 			Add("permission", opts.Permission).
@@ -42,7 +42,7 @@ func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
 	fieldsParam := fmt.Sprintf("count,nextHref,project(%s)", ToAPIFields(fields))
 	path := fmt.Sprintf("/app/rest/projects?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	projects, err := collectPages(c, path, opts.Limit, func(p string) ([]Project, string, error) {
+	projects, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]Project, string, error) {
 		var page ProjectList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -50,10 +50,10 @@ func (c *Client) GetProjects(opts ProjectsOptions) (*ProjectList, error) {
 		return page.Projects, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
-	return &ProjectList{Count: len(projects), Projects: projects}, nil
+	return &ProjectList{Count: len(projects), Projects: projects}, truncated, nil
 }
 
 // GetProject returns a single project by ID

--- a/api/projects_test.go
+++ b/api/projects_test.go
@@ -23,7 +23,7 @@ func TestGetProjectsLocator(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(ProjectList{Count: 0})
 	})
 
-	_, err := client.GetProjects(ProjectsOptions{
+	_, _, err := client.GetProjects(ProjectsOptions{
 		Permission:      PermissionEditProject,
 		ExcludeArchived: true,
 		Limit:           100,

--- a/api/terminal_pty_test.go
+++ b/api/terminal_pty_test.go
@@ -78,7 +78,7 @@ func pickAgentByOS(t *testing.T, osFamily string) (id, skip string) {
 		return "", "guest auth lacks CONNECT_TO_AGENT permission"
 	}
 
-	agents, err := testEnvRef.Client.GetAgents(api.AgentsOptions{})
+	agents, _, err := testEnvRef.Client.GetAgents(api.AgentsOptions{})
 	if err != nil {
 		return "", fmt.Sprintf("could not list agents: %v", err)
 	}

--- a/api/testenv_test.go
+++ b/api/testenv_test.go
@@ -52,7 +52,7 @@ func (e *testEnv) Cleanup() {
 		return
 	}
 	if e.Client != nil {
-		agents, err := e.Client.GetAgents(api.AgentsOptions{})
+		agents, _, err := e.Client.GetAgents(api.AgentsOptions{})
 		if err == nil && len(agents.Agents) > 0 {
 			_ = e.Client.RebootAgent(e.ctx, agents.Agents[0].ID, true)
 		}
@@ -116,7 +116,7 @@ func setupTestEnv() (*testEnv, error) {
 }
 
 func (e *testEnv) discoverTestData() error {
-	projects, err := e.Client.GetProjects(api.ProjectsOptions{Parent: "_Root", Limit: 5})
+	projects, _, err := e.Client.GetProjects(api.ProjectsOptions{Parent: "_Root", Limit: 5})
 	if err != nil {
 		return fmt.Errorf("list projects: %w", err)
 	}
@@ -128,7 +128,7 @@ func (e *testEnv) discoverTestData() error {
 	}
 
 	if e.ProjectID != "" {
-		configs, err := e.Client.GetBuildTypes(api.BuildTypesOptions{Project: e.ProjectID, Limit: 5})
+		configs, _, err := e.Client.GetBuildTypes(api.BuildTypesOptions{Project: e.ProjectID, Limit: 5})
 		if err == nil && len(configs.BuildTypes) > 0 {
 			e.ConfigID = configs.BuildTypes[0].ID
 		}
@@ -314,7 +314,7 @@ func (e *testEnv) ensureBuild() error {
 		return fmt.Errorf("config ID not set")
 	}
 
-	builds, err := e.Client.GetBuilds(context.Background(), api.BuildsOptions{BuildTypeID: e.ConfigID, State: "finished", Limit: 1})
+	builds, _, err := e.Client.GetBuilds(context.Background(), api.BuildsOptions{BuildTypeID: e.ConfigID, State: "finished", Limit: 1})
 	if err != nil {
 		return err
 	}
@@ -437,7 +437,7 @@ func waitForAgents(client *api.Client, count int) error {
 	authorized := map[int]bool{}
 	deadline := time.Now().Add(3 * time.Minute)
 	for time.Now().Before(deadline) {
-		agents, err := client.GetAgents(api.AgentsOptions{})
+		agents, _, err := client.GetAgents(api.AgentsOptions{})
 		if err != nil {
 			time.Sleep(5 * time.Second)
 			continue

--- a/api/vcs_roots.go
+++ b/api/vcs_roots.go
@@ -9,11 +9,11 @@ import (
 	"net/url"
 )
 
-// GetVcsRoots returns a list of VCS roots, automatically following pagination.
-func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
+// GetVcsRoots returns a list of VCS roots, following pagination; the bool is true when a finite limit capped the result.
+func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, bool, error) {
 	locator := NewLocator().
 		Add("affectedProject", opts.Project).
-		AddIntDefault("count", opts.Limit, 100)
+		AddInt("count", pageCount(opts.Limit))
 
 	fields := opts.Fields
 	if len(fields) == 0 {
@@ -22,7 +22,7 @@ func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
 	fieldsParam := fmt.Sprintf("count,nextHref,vcs-root(%s)", ToAPIFields(fields))
 	path := fmt.Sprintf("/app/rest/vcs-roots?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(fieldsParam))
 
-	roots, err := collectPages(c, path, opts.Limit, func(p string) ([]VcsRoot, string, error) {
+	roots, truncated, err := collectPages(c, path, opts.Limit, func(p string) ([]VcsRoot, string, error) {
 		var page VcsRootList
 		if err := c.get(c.ctx(), p, &page); err != nil {
 			return nil, "", err
@@ -30,9 +30,9 @@ func (c *Client) GetVcsRoots(opts VcsRootsOptions) (*VcsRootList, error) {
 		return page.VcsRoot, page.NextHref, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return &VcsRootList{Count: len(roots), VcsRoot: roots}, nil
+	return &VcsRootList{Count: len(roots), VcsRoot: roots}, truncated, nil
 }
 
 // GetVcsRoot returns a VCS root by ID

--- a/api/vcs_roots_test.go
+++ b/api/vcs_roots_test.go
@@ -24,7 +24,7 @@ func TestGetVcsRoots(t *testing.T) {
 		})
 	})
 
-	result, err := client.GetVcsRoots(VcsRootsOptions{Project: "MyProject"})
+	result, _, err := client.GetVcsRoots(VcsRootsOptions{Project: "MyProject"})
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.Count)
 	assert.Equal(t, "vcs1", result.VcsRoot[0].ID)

--- a/docs/topics/teamcity-cli-managing-agents.md
+++ b/docs/topics/teamcity-cli-managing-agents.md
@@ -112,7 +112,7 @@ Filter by agent pool name
 </td>
 <td>
 
-Maximum number of agents to display
+Maximum number of agents to display (use 0 for all)
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-build-queue.md
+++ b/docs/topics/teamcity-cli-managing-build-queue.md
@@ -61,7 +61,7 @@ Filter by job (build configuration) ID
 </td>
 <td>
 
-Maximum number of queued runs to display
+Maximum number of queued runs to display (use 0 for all)
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-cloud-agents.md
+++ b/docs/topics/teamcity-cli-managing-cloud-agents.md
@@ -62,7 +62,7 @@ Filter by project ID
 </td>
 <td>
 
-Maximum number of profiles to display
+Maximum number of profiles to display (use 0 for all)
 
 </td>
 </tr>
@@ -152,7 +152,7 @@ Filter images by cloud profile ID
 </td>
 <td>
 
-Maximum number of images to display
+Maximum number of images to display (use 0 for all)
 
 </td>
 </tr>
@@ -251,7 +251,7 @@ Filter instances by cloud image name or explicit ID locator
 </td>
 <td>
 
-Maximum number of instances to display
+Maximum number of instances to display (use 0 for all)
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-jobs.md
+++ b/docs/topics/teamcity-cli-managing-jobs.md
@@ -22,10 +22,11 @@ Filter by project:
 teamcity job list --project MyProject
 ```
 
-Limit the number of results:
+Limit the number of results (use `--limit 0` to fetch all):
 
 ```Shell
 teamcity job list --limit 20
+teamcity job list --limit 0
 ```
 
 Output as JSON:
@@ -70,7 +71,7 @@ Filter by project ID
 </td>
 <td>
 
-Maximum number of jobs to display
+Maximum number of jobs to display (use 0 for all)
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-pipelines.md
+++ b/docs/topics/teamcity-cli-managing-pipelines.md
@@ -60,7 +60,7 @@ Filter by project ID
 </td>
 <td>
 
-Maximum number of pipelines to display (default 30)
+Maximum number of pipelines to display (default 30, use 0 for all)
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-projects.md
+++ b/docs/topics/teamcity-cli-managing-projects.md
@@ -63,7 +63,7 @@ Filter by parent project ID
 </td>
 <td>
 
-Maximum number of projects to display
+Maximum number of projects to display (use 0 for all)
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -107,7 +107,12 @@ teamcity run list --since 2026-01-15 --until 2026-01-20
 
 ```Shell
 teamcity run list --limit 20
+teamcity run list --limit 0
 ```
+
+Use `--limit 0` to fetch every matching run. When a finite `--limit` hides
+additional results, the CLI prints a hint on stderr (stdout and `--json` stay
+unchanged).
 
 ### Output options
 
@@ -252,7 +257,7 @@ Show builds finished before this time
 </td>
 <td>
 
-Maximum number of runs to display
+Maximum number of runs to display (use 0 for all)
 
 </td>
 </tr>

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -108,7 +108,7 @@ func newAgentListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *agentListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	agents, err := client.GetAgents(api.AgentsOptions{
+	agents, truncated, err := client.GetAgents(api.AgentsOptions{
 		Pool:       opts.pool,
 		Connected:  opts.connected,
 		Enabled:    opts.enabled,
@@ -139,10 +139,11 @@ func (opts *agentListOptions) fetch(client api.ClientInterface, fields []string)
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     agents,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1, 2}},
-		EmptyMsg: "No agents found",
-		EmptyTip: output.TipNoAgents,
+		JSON:      agents,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1, 2}},
+		EmptyMsg:  "No agents found",
+		EmptyTip:  output.TipNoAgents,
+		Truncated: truncated,
 	}, nil
 }
 

--- a/internal/cmd/cmd_test.go
+++ b/internal/cmd/cmd_test.go
@@ -23,10 +23,10 @@ func TestListLimitValidation(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	f := ts.Factory
 
-	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must be a positive number", "project", "list", "--limit", "0")
-	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must be a positive number", "run", "list", "--limit", "-1")
-	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must be a positive number", "job", "list", "--limit", "0")
-	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must be a positive number", "agent", "list", "--limit", "-5")
+	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must not be negative", "project", "list", "--limit", "-1")
+	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must not be negative", "run", "list", "--limit", "-1")
+	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must not be negative", "job", "list", "--limit", "-2")
+	cmdtest.RunCmdWithFactoryExpectErr(T, f, "--limit must not be negative", "agent", "list", "--limit", "-5")
 }
 
 func TestHelpCommands(T *testing.T) {

--- a/internal/cmd/job/job_test.go
+++ b/internal/cmd/job/job_test.go
@@ -1,9 +1,13 @@
 package job_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
@@ -18,6 +22,26 @@ func TestJobList(T *testing.T) {
 	cmdtest.RunCmdWithFactory(T, f, "job", "list", "--limit", "5")
 	cmdtest.RunCmdWithFactory(T, f, "job", "list", "--project", "TestProject")
 	cmdtest.RunCmdWithFactory(T, f, "job", "list", "--json", "--limit", "2")
+}
+
+// TestJobListLimitZero guards the post-filter bug where `--limit 0` sliced the result to [:0] instead of fetching all.
+func TestJobListLimitZero(T *testing.T) {
+	ts := cmdtest.NewTestServer(T)
+	ts.Handle("GET /app/rest/buildTypes", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.BuildTypeList{
+			Count: 3,
+			BuildTypes: []api.BuildType{
+				{ID: "P_A", Name: "A", ProjectID: "P"},
+				{ID: "P_B", Name: "B", ProjectID: "P"},
+				{ID: "P_C", Name: "C", ProjectID: "P"},
+			},
+		})
+	})
+
+	out := cmdtest.CaptureOutput(T, ts.Factory, "job", "list", "--limit", "0", "--json")
+	var list api.BuildTypeList
+	require.NoError(T, json.Unmarshal([]byte(out), &list))
+	assert.Equal(T, 3, list.Count)
 }
 
 func TestJobView(T *testing.T) {

--- a/internal/cmd/job/list.go
+++ b/internal/cmd/job/list.go
@@ -52,7 +52,7 @@ them alongside classic build configurations.`,
 func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
 	pipelineProjectIDs := map[string]bool{}
 	if !opts.all && client.SupportsFeature("pipelines") {
-		if pipelines, err := client.GetPipelines(api.PipelinesOptions{Limit: 10000}); err == nil {
+		if pipelines, _, err := client.GetPipelines(api.PipelinesOptions{Limit: 10000}); err == nil {
 			for _, p := range pipelines.Pipelines {
 				pipelineProjectIDs[p.ID] = true
 			}
@@ -69,7 +69,7 @@ func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (
 		fetchFields = append(slices.Clone(fields), "projectId")
 	}
 
-	jobs, err := client.GetBuildTypes(api.BuildTypesOptions{
+	jobs, truncated, err := client.GetBuildTypes(api.BuildTypesOptions{
 		Project: opts.project,
 		Limit:   limit,
 		Fields:  fetchFields,
@@ -88,9 +88,10 @@ func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (
 		jobs.BuildTypes = filtered
 		jobs.Count = len(filtered)
 	}
-	if len(jobs.BuildTypes) > opts.Limit {
+	if opts.Limit > 0 && len(jobs.BuildTypes) > opts.Limit {
 		jobs.BuildTypes = jobs.BuildTypes[:opts.Limit]
 		jobs.Count = opts.Limit
+		truncated = true
 	}
 
 	headers := []string{"ID", "NAME", "PROJECT", "STATUS"}
@@ -111,10 +112,11 @@ func (opts *jobListOptions) fetch(client api.ClientInterface, fields []string) (
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     jobs,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
-		EmptyMsg: "No jobs found",
-		EmptyTip: output.TipNoJobs,
+		JSON:      jobs,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
+		EmptyMsg:  "No jobs found",
+		EmptyTip:  output.TipNoJobs,
+		Truncated: truncated,
 	}, nil
 }
 

--- a/internal/cmd/link/discover.go
+++ b/internal/cmd/link/discover.go
@@ -94,7 +94,7 @@ func discoverProjects(client api.ClientInterface, remoteURLs []string) (*discove
 
 	pipelineMetaByHead := map[string]pipelineMeta{}
 	if client.SupportsFeature("pipelines") {
-		pipelines, err := client.GetPipelines(api.PipelinesOptions{Limit: 0})
+		pipelines, _, err := client.GetPipelines(api.PipelinesOptions{Limit: 0})
 		if err == nil && pipelines != nil {
 			for _, p := range pipelines.Pipelines {
 				if p.HeadBuildType == nil || p.HeadBuildType.ID == "" {
@@ -113,7 +113,7 @@ func discoverProjects(client api.ClientInterface, remoteURLs []string) (*discove
 	seenBuildTypes := map[string]bool{}
 	var matched []api.BuildType
 	for _, frag := range fragments {
-		page, err := client.GetBuildTypes(api.BuildTypesOptions{
+		page, _, err := client.GetBuildTypes(api.BuildTypesOptions{
 			VcsRootURL: frag,
 			Limit:      0,
 			Fields:     discoveryBuildTypeFields,

--- a/internal/cmd/link/discover_test.go
+++ b/internal/cmd/link/discover_test.go
@@ -21,17 +21,17 @@ func (f *fakeClient) SupportsFeature(name string) bool {
 	return name == "pipelines" && f.pipelinesSupported
 }
 
-func (f *fakeClient) GetPipelines(api.PipelinesOptions) (*api.PipelineList, error) {
+func (f *fakeClient) GetPipelines(api.PipelinesOptions) (*api.PipelineList, bool, error) {
 	if f.pipelines == nil {
-		return &api.PipelineList{}, nil
+		return &api.PipelineList{}, false, nil
 	}
-	return f.pipelines, nil
+	return f.pipelines, false, nil
 }
 
-func (f *fakeClient) GetBuildTypes(opts api.BuildTypesOptions) (*api.BuildTypeList, error) {
+func (f *fakeClient) GetBuildTypes(opts api.BuildTypesOptions) (*api.BuildTypeList, bool, error) {
 	f.gotFragments = append(f.gotFragments, opts.VcsRootURL)
 	bts := f.buildTypesByFrag[opts.VcsRootURL]
-	return &api.BuildTypeList{Count: len(bts), BuildTypes: bts}, nil
+	return &api.BuildTypeList{Count: len(bts), BuildTypes: bts}, false, nil
 }
 
 func vcsEntries(urls ...string) *api.VcsRootEntries {

--- a/internal/cmd/pipeline/create.go
+++ b/internal/cmd/pipeline/create.go
@@ -84,7 +84,7 @@ func selectVcsRoot(f *cmdutil.Factory, client api.ClientInterface, projectID str
 		return "", errors.New("--vcs-root is required (or use interactive mode)")
 	}
 
-	roots, err := client.GetVcsRoots(api.VcsRootsOptions{Project: projectID, Limit: 100})
+	roots, _, err := client.GetVcsRoots(api.VcsRootsOptions{Project: projectID, Limit: 100})
 	if err != nil {
 		return "", fmt.Errorf("failed to list VCS roots: %w", err)
 	}

--- a/internal/cmd/pipeline/list.go
+++ b/internal/cmd/pipeline/list.go
@@ -41,7 +41,7 @@ func newPipelineListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *pipelineListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	pipelines, err := client.GetPipelines(api.PipelinesOptions{
+	pipelines, truncated, err := client.GetPipelines(api.PipelinesOptions{
 		Project: opts.project,
 		Limit:   opts.Limit,
 		Fields:  fields,
@@ -72,9 +72,10 @@ func (opts *pipelineListOptions) fetch(client api.ClientInterface, fields []stri
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     pipelines,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
-		EmptyMsg: "No pipelines found",
-		EmptyTip: output.TipNoPipelines,
+		JSON:      pipelines,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
+		EmptyMsg:  "No pipelines found",
+		EmptyTip:  output.TipNoPipelines,
+		Truncated: truncated,
 	}, nil
 }

--- a/internal/cmd/project/cloud.go
+++ b/internal/cmd/project/cloud.go
@@ -77,7 +77,7 @@ func newCloudProfileListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *cloudProfileListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	profiles, err := client.GetCloudProfiles(api.CloudProfilesOptions{
+	profiles, truncated, err := client.GetCloudProfiles(api.CloudProfilesOptions{
 		ProjectID: opts.project,
 		Limit:     opts.Limit,
 		Fields:    fields,
@@ -98,9 +98,10 @@ func (opts *cloudProfileListOptions) fetch(client api.ClientInterface, fields []
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     profiles,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1}},
-		EmptyMsg: "No cloud profiles found",
+		JSON:      profiles,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1}},
+		EmptyMsg:  "No cloud profiles found",
+		Truncated: truncated,
 	}, nil
 }
 
@@ -210,7 +211,7 @@ func newCloudImageListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *cloudImageListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	images, err := client.GetCloudImages(api.CloudImagesOptions{
+	images, truncated, err := client.GetCloudImages(api.CloudImagesOptions{
 		ProjectID: opts.project,
 		Profile:   opts.profile,
 		Limit:     opts.Limit,
@@ -237,9 +238,10 @@ func (opts *cloudImageListOptions) fetch(client api.ClientInterface, fields []st
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     images,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2}},
-		EmptyMsg: "No cloud images found",
+		JSON:      images,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2}},
+		EmptyMsg:  "No cloud images found",
+		Truncated: truncated,
 	}, nil
 }
 
@@ -386,7 +388,7 @@ func newCloudInstanceListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *cloudInstanceListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	instances, err := client.GetCloudInstances(api.CloudInstancesOptions{
+	instances, truncated, err := client.GetCloudInstances(api.CloudInstancesOptions{
 		ProjectID: opts.project,
 		Image:     opts.image,
 		Limit:     opts.Limit,
@@ -426,9 +428,10 @@ func (opts *cloudInstanceListOptions) fetch(client api.ClientInterface, fields [
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     instances,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2, 3, 5}},
-		EmptyMsg: "No cloud instances found",
+		JSON:      instances,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2, 3, 5}},
+		EmptyMsg:  "No cloud instances found",
+		Truncated: truncated,
 	}, nil
 }
 

--- a/internal/cmd/project/connection.go
+++ b/internal/cmd/project/connection.go
@@ -71,7 +71,8 @@ func (opts *connectionListOptions) fetch(client api.ClientInterface, fields []st
 	}
 
 	items := features.ProjectFeature
-	if opts.Limit > 0 && opts.Limit < len(items) {
+	truncated := opts.Limit > 0 && opts.Limit < len(items)
+	if truncated {
 		items = items[:opts.Limit]
 	}
 
@@ -83,10 +84,11 @@ func (opts *connectionListOptions) fetch(client api.ClientInterface, fields []st
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     filterJSONList(items, fields, connectionToMap),
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
-		EmptyMsg: "No connections found",
-		EmptyTip: output.TipNoConnections,
+		JSON:      filterJSONList(items, fields, connectionToMap),
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
+		EmptyMsg:  "No connections found",
+		EmptyTip:  output.TipNoConnections,
+		Truncated: truncated,
 	}, nil
 }
 

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -85,7 +85,7 @@ func newProjectListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *projectListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	projects, err := client.GetProjects(api.ProjectsOptions{
+	projects, truncated, err := client.GetProjects(api.ProjectsOptions{
 		Parent: opts.parent,
 		Limit:  opts.Limit,
 		Fields: fields,
@@ -111,10 +111,11 @@ func (opts *projectListOptions) fetch(client api.ClientInterface, fields []strin
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     projects,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
-		EmptyMsg: "No projects found",
-		EmptyTip: output.TipNoProjects,
+		JSON:      projects,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2}},
+		EmptyMsg:  "No projects found",
+		EmptyTip:  output.TipNoProjects,
+		Truncated: truncated,
 	}, nil
 }
 
@@ -391,7 +392,7 @@ func runProjectTree(f *cmdutil.Factory, rootID string, noJobs bool, depth int, j
 		return err
 	}
 
-	projects, err := client.GetProjects(api.ProjectsOptions{Limit: 10000})
+	projects, _, err := client.GetProjects(api.ProjectsOptions{Limit: 10000})
 	if err != nil {
 		return err
 	}
@@ -420,7 +421,7 @@ func runProjectTree(f *cmdutil.Factory, rootID string, noJobs bool, depth int, j
 	pipelineProjectIDs := map[string]bool{}
 	pipelineHeadJobIDs := map[string]bool{}
 
-	pipelines, pipelineErr := client.GetPipelines(api.PipelinesOptions{Limit: 10000})
+	pipelines, _, pipelineErr := client.GetPipelines(api.PipelinesOptions{Limit: 10000})
 	if pipelineErr == nil && len(pipelines.Pipelines) > 0 {
 		pipelinesByProject = map[string][]api.Pipeline{}
 		for _, p := range pipelines.Pipelines {
@@ -439,7 +440,7 @@ func runProjectTree(f *cmdutil.Factory, rootID string, noJobs bool, depth int, j
 	}
 
 	if !noJobs {
-		buildTypes, err := client.GetBuildTypes(api.BuildTypesOptions{Limit: 10000})
+		buildTypes, _, err := client.GetBuildTypes(api.BuildTypesOptions{Limit: 10000})
 		if err != nil {
 			return err
 		}
@@ -545,7 +546,7 @@ func projectPickerOptions(f *cmdutil.Factory, permission string) []huh.Option[st
 	if err != nil {
 		return nil
 	}
-	list, err := client.GetProjects(api.ProjectsOptions{
+	list, _, err := client.GetProjects(api.ProjectsOptions{
 		Limit:           10000,
 		Fields:          []string{"id", "name", "parentProjectId"},
 		Permission:      permission,

--- a/internal/cmd/project/project_test.go
+++ b/internal/cmd/project/project_test.go
@@ -2,7 +2,10 @@ package project_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -10,6 +13,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -206,4 +210,80 @@ func TestProjectTreeNotFound(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 
 	cmdtest.RunCmdWithFactoryExpectErr(T, ts.Factory, "not found", "project", "tree", "NonExistentProject123456")
+}
+
+// runListSplit executes a command with separate stdout/stderr buffers so the truncation hint can be distinguished from list output.
+func runListSplit(t *testing.T, ts *cmdtest.TestServer, args ...string) (stdout, stderr string) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	f := ts.CloneFactory()
+	// NewCommand strips PersistentPreRun (and thus InitOutput), so mirror the
+	// --quiet → Printer.Quiet wiring that production does at runtime.
+	f.Printer = &output.Printer{Out: &out, ErrOut: &errBuf, Quiet: slices.Contains(args, "--quiet") || slices.Contains(args, "-q")}
+	rootCmd := cmd.NewCommand(f)
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&errBuf)
+	require.NoError(t, rootCmd.Execute())
+	return out.String(), errBuf.String()
+}
+
+func handleTruncatedProjects(ts *cmdtest.TestServer) {
+	ts.Handle("GET /app/rest/projects", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Query().Get("locator"), "count:1000") {
+			cmdtest.JSON(w, map[string]any{"count": 3, "project": []map[string]string{
+				{"id": "P1", "name": "P1"}, {"id": "P2", "name": "P2"}, {"id": "P3", "name": "P3"},
+			}})
+			return
+		}
+		cmdtest.JSON(w, map[string]any{
+			"count":    2,
+			"nextHref": "/app/rest/projects?locator=count:2,start:2",
+			"project":  []map[string]string{{"id": "P1", "name": "P1"}, {"id": "P2", "name": "P2"}},
+		})
+	})
+}
+
+const truncationHint = "use --limit 0 to fetch all"
+
+func TestProjectListTruncationHint(T *testing.T) {
+	T.Run("finite limit emits hint on stderr only", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedProjects(ts)
+
+		stdout, stderr := runListSplit(t, ts, "project", "list", "--limit", "2")
+		assert.Contains(t, stdout, "P1")
+		assert.Contains(t, stdout, "P2")
+		assert.NotContains(t, stdout, truncationHint)
+		assert.Contains(t, stderr, "Showing only the first 2 results")
+		assert.Contains(t, stderr, truncationHint)
+	})
+
+	T.Run("limit 0 fetches all without a hint", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedProjects(ts)
+
+		stdout, stderr := runListSplit(t, ts, "project", "list", "--limit", "0")
+		assert.Contains(t, stdout, "P3")
+		assert.NotContains(t, stderr, truncationHint)
+	})
+
+	T.Run("json output stays clean while hint goes to stderr", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedProjects(ts)
+
+		stdout, stderr := runListSplit(t, ts, "project", "list", "--limit", "2", "--json")
+		var list api.ProjectList
+		require.NoError(t, json.Unmarshal([]byte(stdout), &list))
+		assert.Equal(t, 2, list.Count)
+		assert.Contains(t, stderr, truncationHint)
+	})
+
+	T.Run("quiet suppresses the hint", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedProjects(ts)
+
+		_, stderr := runListSplit(t, ts, "project", "list", "--limit", "2", "--quiet")
+		assert.NotContains(t, stderr, truncationHint)
+	})
 }

--- a/internal/cmd/project/ssh.go
+++ b/internal/cmd/project/ssh.go
@@ -84,7 +84,8 @@ func (opts *sshListOptions) fetch(client api.ClientInterface, fields []string) (
 	}
 
 	items := keys.SSHKey
-	if opts.Limit > 0 && opts.Limit < len(items) {
+	truncated := opts.Limit > 0 && opts.Limit < len(items)
+	if truncated {
 		items = items[:opts.Limit]
 	}
 
@@ -99,9 +100,10 @@ func (opts *sshListOptions) fetch(client api.ClientInterface, fields []string) (
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     filterJSONList(items, fields, sshKeyToMap),
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2}},
-		EmptyMsg: "No SSH keys found",
+		JSON:      filterJSONList(items, fields, sshKeyToMap),
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 2}},
+		EmptyMsg:  "No SSH keys found",
+		Truncated: truncated,
 	}, nil
 }
 

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -84,7 +84,7 @@ func newVcsListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *vcsListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	roots, err := client.GetVcsRoots(api.VcsRootsOptions{
+	roots, truncated, err := client.GetVcsRoots(api.VcsRootsOptions{
 		Project: cmp.Or(opts.project, "_Root"),
 		Limit:   opts.Limit,
 		Fields:  fields,
@@ -111,9 +111,10 @@ func (opts *vcsListOptions) fetch(client api.ClientInterface, fields []string) (
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     roots,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2, 3}},
-		EmptyMsg: "No VCS roots found",
+		JSON:      roots,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{0, 1, 2, 3}},
+		EmptyMsg:  "No VCS roots found",
+		Truncated: truncated,
 	}, nil
 }
 

--- a/internal/cmd/queue/list.go
+++ b/internal/cmd/queue/list.go
@@ -54,7 +54,7 @@ func newQueueListCmd(f *cmdutil.Factory) *cobra.Command {
 }
 
 func (opts *queueListOptions) fetch(client api.ClientInterface, fields []string) (*cmdutil.ListResult, error) {
-	queue, err := client.GetBuildQueue(api.QueueOptions{
+	queue, truncated, err := client.GetBuildQueue(api.QueueOptions{
 		BuildTypeID: opts.job,
 		Limit:       opts.Limit,
 		Fields:      fields,
@@ -87,9 +87,10 @@ func (opts *queueListOptions) fetch(client api.ClientInterface, fields []string)
 	}
 
 	return &cmdutil.ListResult{
-		JSON:     queue,
-		Table:    cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1, 2, 4}},
-		EmptyMsg: "No runs in queue",
-		EmptyTip: output.TipNoQueue,
+		JSON:      queue,
+		Table:     cmdutil.ListTable{Headers: headers, Rows: rows, FlexCols: []int{1, 2, 4}},
+		EmptyMsg:  "No runs in queue",
+		EmptyTip:  output.TipNoQueue,
+		Truncated: truncated,
 	}, nil
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -86,6 +86,7 @@ Report issues:  https://jb.gg/tc/issues`,
 
 	cmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
 		f.InitOutput()
+		output.StartSpinner(f.Quiet)
 		if jsonOutputEnabled(cmd) {
 			f.JSONOutput = true
 		}
@@ -124,6 +125,7 @@ func Execute(ctx context.Context) error {
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
 	executedCmd, err := rootCmd.ExecuteC()
+	output.StopSpinner()
 	if f.UpdateNotice != nil {
 		f.UpdateNotice()
 	}

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -41,6 +42,81 @@ func TestRunListBackwardsDateRange(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 
 	cmdtest.RunCmdWithFactoryExpectErr(T, ts.Factory, "is more recent than", "run", "list", "--since", "2020-01-01", "--until", "2019-01-01")
+}
+
+func runListSplit(t *testing.T, ts *cmdtest.TestServer, args ...string) (stdout, stderr string) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	f := ts.CloneFactory()
+	// NewCommand strips PersistentPreRun (and thus InitOutput), so mirror the
+	// --quiet → Printer.Quiet wiring that production does at runtime.
+	f.Printer = &output.Printer{Out: &out, ErrOut: &errBuf, Quiet: slices.Contains(args, "--quiet") || slices.Contains(args, "-q")}
+	rootCmd := cmd.NewCommand(f)
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&errBuf)
+	require.NoError(t, rootCmd.Execute())
+	return out.String(), errBuf.String()
+}
+
+func handleTruncatedBuilds(ts *cmdtest.TestServer) {
+	ts.Handle("GET /app/rest/builds", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Query().Get("locator"), "count:1000") {
+			cmdtest.JSON(w, map[string]any{"count": 3, "build": []map[string]any{
+				{"id": 1, "buildTypeId": "B"}, {"id": 2, "buildTypeId": "B"}, {"id": 3, "buildTypeId": "B"},
+			}})
+			return
+		}
+		cmdtest.JSON(w, map[string]any{
+			"count":    2,
+			"nextHref": "/app/rest/builds?locator=count:2,start:2",
+			"build":    []map[string]any{{"id": 1, "buildTypeId": "B"}, {"id": 2, "buildTypeId": "B"}},
+		})
+	})
+}
+
+const runTruncationHint = "use --limit 0 to fetch all"
+
+func TestRunListTruncationHint(T *testing.T) {
+	T.Run("finite limit emits hint on stderr only", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedBuilds(ts)
+
+		stdout, stderr := runListSplit(t, ts, "run", "list", "--limit", "2")
+		assert.NotContains(t, stdout, runTruncationHint)
+		assert.Contains(t, stderr, "Showing only the first 2 results")
+		assert.Contains(t, stderr, runTruncationHint)
+	})
+
+	T.Run("limit 0 fetches all without a hint", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedBuilds(ts)
+
+		stdout, stderr := runListSplit(t, ts, "run", "list", "--limit", "0", "--json")
+		var list api.BuildList
+		require.NoError(t, json.Unmarshal([]byte(stdout), &list))
+		assert.Equal(t, 3, list.Count)
+		assert.NotContains(t, stderr, runTruncationHint)
+	})
+
+	T.Run("json output stays clean while hint goes to stderr", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedBuilds(ts)
+
+		stdout, stderr := runListSplit(t, ts, "run", "list", "--limit", "2", "--json")
+		var list api.BuildList
+		require.NoError(t, json.Unmarshal([]byte(stdout), &list))
+		assert.Equal(t, 2, list.Count)
+		assert.Contains(t, stderr, runTruncationHint)
+	})
+
+	T.Run("quiet suppresses the hint", func(t *testing.T) {
+		ts := cmdtest.NewTestServer(t)
+		handleTruncatedBuilds(ts)
+
+		_, stderr := runListSplit(t, ts, "run", "list", "--limit", "2", "--quiet")
+		assert.NotContains(t, stderr, runTruncationHint)
+	})
 }
 
 func TestRunListWeb(t *testing.T) {
@@ -726,6 +802,6 @@ func TestRunList_invalid_status(t *testing.T) {
 
 func TestRunList_invalid_limit(t *testing.T) {
 	ts := cmdtest.SetupMockClient(t)
-	err := cmdtest.CaptureErr(t, ts.Factory, "run", "list", "--limit", "0")
-	assert.Equal(t, "--limit must be a positive number, got 0", err.Error())
+	err := cmdtest.CaptureErr(t, ts.Factory, "run", "list", "--limit", "-1")
+	assert.Equal(t, "--limit must not be negative, got -1", err.Error())
 }

--- a/internal/cmd/run/diff.go
+++ b/internal/cmd/run/diff.go
@@ -137,7 +137,7 @@ func resolveDiffBuildIDs(ctx context.Context, client api.ClientInterface, args [
 		return "", "", fmt.Errorf("could not resolve: %w", err)
 	}
 
-	builds, err := client.GetBuilds(ctx, api.BuildsOptions{
+	builds, _, err := client.GetBuilds(ctx, api.BuildsOptions{
 		BuildTypeID: build.BuildTypeID,
 		Limit:       1,
 		State:       "finished",

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -149,16 +149,9 @@ func downloadArtifact(ctx context.Context, client api.ClientInterface, runID str
 
 	var w io.Writer = f
 	if output.IsTerminal() && !quiet && artifact.Size > 0 {
-		pw := &progressWriter{
-			w:         f,
-			out:       out,
-			name:      artifact.Name,
-			size:      humanize.IBytes(uint64(artifact.Size)),
-			total:     artifact.Size,
-			nameWidth: nameWidth,
-		}
+		pw := output.NewProgressWriter(f, out, artifact.Name, humanize.IBytes(uint64(artifact.Size)), artifact.Size, nameWidth)
 		w = pw
-		defer pw.clear()
+		defer pw.Clear()
 	}
 
 	written, err := client.DownloadArtifactTo(ctx, runID, artifact.Name, w)
@@ -175,32 +168,4 @@ func downloadArtifact(ctx context.Context, client api.ClientInterface, runID str
 	}
 
 	return f.Close()
-}
-
-type progressWriter struct {
-	w          io.Writer
-	out        io.Writer
-	name       string
-	size       string
-	total      int64
-	written    int64
-	nameWidth  int
-	lastUpdate time.Time
-}
-
-func (p *progressWriter) Write(b []byte) (int, error) {
-	n, err := p.w.Write(b)
-	p.written += int64(n)
-
-	now := time.Now()
-	if now.Sub(p.lastUpdate) >= 100*time.Millisecond {
-		p.lastUpdate = now
-		pct := int(float64(p.written) / float64(p.total) * 100)
-		_, _ = fmt.Fprintf(p.out, "\r%-*s  %10s  %3d%%", p.nameWidth, p.name, p.size, pct)
-	}
-	return n, err
-}
-
-func (p *progressWriter) clear() {
-	_, _ = fmt.Fprint(p.out, "\r\033[K")
 }

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -69,7 +69,7 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.revision, "revision", "", "Filter by VCS revision/commit SHA (or '@head' for current HEAD)")
 	cmd.Flags().BoolVar(&opts.favorites, "favorites", false, "Show favorites for the current user")
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
-	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number of items")
+	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number of items (0 for all)")
 	cmd.Flags().StringVar(&opts.since, "since", "", "Finished after this time (e.g., 24h, 7d, 2026-01-21)")
 	cmd.Flags().StringVar(&opts.until, "until", "", "Finished before this time (e.g., 12h, 7d, 2026-01-22)")
 	cmdutil.AddJSONFieldsFlag(cmd, &opts.jsonFields)
@@ -135,13 +135,17 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 		return err
 	}
 
-	runs, err := client.GetBuilds(f.Context(), request.builds)
+	runs, truncated, err := client.GetBuilds(f.Context(), request.builds)
 	if err != nil {
 		return err
 	}
 
 	if jsonResult.Enabled {
-		return f.Printer.PrintJSON(runs)
+		if err := f.Printer.PrintJSON(runs); err != nil {
+			return err
+		}
+		cmdutil.WarnListTruncated(f, truncated, opts.limit)
+		return nil
 	}
 
 	if runs.Count == 0 {
@@ -215,6 +219,7 @@ func runRunList(f *cmdutil.Factory, cmd *cobra.Command, opts *runListOptions) er
 		output.AutoSizeColumns(headers, rows, 2, 2, 3, 4)
 		p.PrintTable(headers, rows)
 	}
+	cmdutil.WarnListTruncated(f, truncated, opts.limit)
 	return nil
 }
 

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -77,7 +77,7 @@ See: https://www.jetbrains.com/help/teamcity/build-results-page.html`,
 // otherwise we return a Validation error pointing at the link path.
 func resolveRunID(ctx context.Context, client api.ClientInterface, runID, jobID, state string) (string, *api.Build, error) {
 	if jobID != "" {
-		runs, err := client.GetBuilds(ctx, api.BuildsOptions{
+		runs, _, err := client.GetBuilds(ctx, api.BuildsOptions{
 			BuildTypeID: jobID,
 			State:       state,
 			Limit:       1,

--- a/internal/cmd/run/tui/tui.go
+++ b/internal/cmd/run/tui/tui.go
@@ -257,6 +257,7 @@ func (m watchModel) renderLogs(height int) string {
 // RunWatchTUI launches the interactive TUI for watching a build.
 func RunWatchTUI(ctx context.Context, client api.ClientInterface, runID string, interval int) error {
 	m := newWatchModel(ctx, client, runID, interval)
+	output.StopSpinner() // hand the terminal to bubbletea's alt screen
 	p := tea.NewProgram(m, tea.WithAltScreen())
 
 	finalModel, err := p.Run()

--- a/internal/cmdutil/helpers.go
+++ b/internal/cmdutil/helpers.go
@@ -65,10 +65,10 @@ func OpenURLOrWarn(p *output.Printer, url string) {
 	}
 }
 
-// ValidateLimit returns an error if limit is not positive.
+// ValidateLimit returns an error if limit is negative. Zero means "fetch all".
 func ValidateLimit(limit int) error {
-	if limit <= 0 {
-		return fmt.Errorf("--limit must be a positive number, got %d", limit)
+	if limit < 0 {
+		return fmt.Errorf("--limit must not be negative, got %d", limit)
 	}
 	return nil
 }

--- a/internal/cmdutil/helpers_test.go
+++ b/internal/cmdutil/helpers_test.go
@@ -18,9 +18,9 @@ import (
 func TestValidateLimit(t *testing.T) {
 	assert.NoError(t, ValidateLimit(1))
 	assert.NoError(t, ValidateLimit(100))
-	assert.Error(t, ValidateLimit(0))
+	assert.NoError(t, ValidateLimit(0))
 	assert.Error(t, ValidateLimit(-1))
-	assert.Contains(t, ValidateLimit(-5).Error(), "--limit must be a positive number")
+	assert.Contains(t, ValidateLimit(-5).Error(), "--limit must not be negative")
 }
 
 func TestParseID(t *testing.T) {

--- a/internal/cmdutil/list.go
+++ b/internal/cmdutil/list.go
@@ -2,6 +2,7 @@ package cmdutil
 
 import (
 	"cmp"
+	"fmt"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/output"
@@ -18,7 +19,7 @@ type ListFlags struct {
 
 // AddListFlags registers --limit, --json, --plain, and --no-header flags on a command.
 func AddListFlags(cmd *cobra.Command, flags *ListFlags, defaultLimit int) {
-	cmd.Flags().IntVarP(&flags.Limit, "limit", "n", defaultLimit, "Maximum number of items")
+	cmd.Flags().IntVarP(&flags.Limit, "limit", "n", defaultLimit, "Maximum number of items (0 for all)")
 	AddJSONFieldsFlag(cmd, &flags.JSONFields)
 	AddPlainFlags(cmd, flags)
 }
@@ -41,11 +42,13 @@ type ListTable struct {
 // ListResult is returned by a list command's fetch function.
 // Set either JSON (for JSON output) or Table (for table output).
 // EmptyTip is shown alongside EmptyMsg when the table is empty.
+// Truncated reports that a finite --limit capped the result; RunList turns it into a stderr hint.
 type ListResult struct {
-	JSON     any
-	Table    ListTable
-	EmptyMsg string
-	EmptyTip string
+	JSON      any
+	Table     ListTable
+	EmptyMsg  string
+	EmptyTip  string
+	Truncated bool
 }
 
 // RunList handles the shared boilerplate for list commands:
@@ -82,11 +85,19 @@ func RunList(
 	}
 
 	if jsonResult.Enabled {
-		return f.Printer.PrintJSON(result.JSON)
+		if err := f.Printer.PrintJSON(result.JSON); err != nil {
+			return err
+		}
+		WarnListTruncated(f, result.Truncated, flags.Limit)
+		return nil
 	}
 
 	if len(result.Table.Rows) == 0 {
-		f.Printer.Empty(cmp.Or(result.EmptyMsg, "No items found"), result.EmptyTip)
+		tip := result.EmptyTip
+		if result.Truncated && flags.Limit > 0 {
+			tip = fmt.Sprintf("Searched only the first %d results - use --limit 0 to fetch all", flags.Limit)
+		}
+		f.Printer.Empty(cmp.Or(result.EmptyMsg, "No items found"), tip)
 		return nil
 	}
 
@@ -98,5 +109,15 @@ func RunList(
 		}
 		f.Printer.PrintTable(result.Table.Headers, result.Table.Rows)
 	}
+	WarnListTruncated(f, result.Truncated, flags.Limit)
 	return nil
+}
+
+// WarnListTruncated emits a stderr hint, set off by a blank line, when a finite --limit capped the result; no-op for --limit <= 0 or under --quiet.
+func WarnListTruncated(f *Factory, truncated bool, limit int) {
+	if !truncated || limit <= 0 || f.Printer.Quiet {
+		return
+	}
+	_, _ = fmt.Fprintln(f.Printer.ErrOut)
+	f.Printer.Warn("Showing only the first %d results - use --limit 0 to fetch all", limit)
 }

--- a/internal/cmdutil/prompt.go
+++ b/internal/cmdutil/prompt.go
@@ -21,6 +21,7 @@ func RequireNonEmpty(s string) error {
 
 // Prompt runs a single huh field with the CLI theme; does not echo — use PromptString / Select / Confirm for that.
 func Prompt(field huh.Field) error {
+	output.StopSpinner() // hand the terminal to huh's prompt UI
 	if in, ok := field.(*huh.Input); ok {
 		in.Prompt("")
 	}
@@ -32,6 +33,7 @@ func Prompt(field huh.Field) error {
 
 // RunForm runs a multi-group huh form with shift+tab navigation; use it instead of chaining Prompt calls so groups can navigate between each other.
 func RunForm(groups ...*huh.Group) error {
+	output.StopSpinner() // hand the terminal to huh's form UI
 	return huh.NewForm(groups...).
 		WithTheme(promptTheme()).
 		WithShowHelp(true).

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -19,12 +19,20 @@ type Printer struct {
 	mu sync.Mutex
 }
 
-// DefaultPrinter returns a Printer that writes to os.Stdout/os.Stderr.
+// DefaultPrinter returns a Printer writing to os.Stdout/os.Stderr, wrapped so the activity spinner clears on the first byte of output.
 func DefaultPrinter() *Printer {
 	return &Printer{
-		Out:    os.Stdout,
-		ErrOut: os.Stderr,
+		Out:    stopWriter{os.Stdout},
+		ErrOut: stopWriter{os.Stderr},
 	}
+}
+
+// stopWriter halts the activity spinner before its first write; the spinner writes to the raw fd, not through this wrapper, so there is no feedback loop.
+type stopWriter struct{ w io.Writer }
+
+func (s stopWriter) Write(b []byte) (int, error) {
+	StopSpinner()
+	return s.w.Write(b)
 }
 
 // write atomically emits s to w, serializing concurrent calls across all Printer methods.

--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -1,0 +1,109 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+var spinnerFrames = []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
+
+// spin is the process-wide activity spinner; one CLI run drives one terminal.
+var spin spinner
+
+type spinner struct {
+	mu     sync.Mutex
+	active bool
+	stop   chan struct{}
+	done   chan struct{}
+}
+
+// StartSpinner shows a "Loading..." indicator on stdout until StopSpinner or the first byte of output; no-op when quiet, non-terminal, or already running, and the first frame waits one 80ms tick so fast work shows nothing.
+func StartSpinner(quiet bool) {
+	if quiet || !IsTerminal() {
+		return
+	}
+	spin.mu.Lock()
+	defer spin.mu.Unlock()
+	if spin.active {
+		return
+	}
+	spin.active = true
+	spin.stop = make(chan struct{})
+	spin.done = make(chan struct{})
+	stop, done := spin.stop, spin.done
+
+	frames := spinnerFrames
+	if ASCII {
+		frames = []rune(`|/-\`)
+	}
+	go func() {
+		defer close(done)
+		t := time.NewTicker(80 * time.Millisecond)
+		defer t.Stop()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			case <-t.C:
+				_, _ = fmt.Fprintf(os.Stdout, "\r%s Loading...", Faint(string(frames[i%len(frames)])))
+			}
+		}
+	}()
+}
+
+// StopSpinner halts the spinner and clears its line; safe to call repeatedly and when nothing is running, so it can guard pagers and raw-terminal takeovers.
+func StopSpinner() {
+	spin.mu.Lock()
+	if !spin.active {
+		spin.mu.Unlock()
+		return
+	}
+	spin.active = false
+	close(spin.stop)
+	done := spin.done
+	spin.mu.Unlock()
+
+	<-done
+	ClearLine(os.Stdout)
+}
+
+// ClearLine returns the cursor to column 0 and erases the line, wiping a transient spinner or progress line before final output.
+func ClearLine(w io.Writer) {
+	_, _ = fmt.Fprint(w, "\r\033[K")
+}
+
+// ProgressWriter wraps an io.Writer and renders a determinate "name  size  NN%" bar to out as bytes flow through, throttled to ~10 fps; callers gate it on output.IsTerminal() and a known total.
+type ProgressWriter struct {
+	w          io.Writer
+	out        io.Writer
+	name       string
+	size       string
+	total      int64
+	written    int64
+	nameWidth  int
+	lastUpdate time.Time
+}
+
+// NewProgressWriter copies to w while drawing progress for name/total to out; size is the human-readable total shown in the bar.
+func NewProgressWriter(w, out io.Writer, name, size string, total int64, nameWidth int) *ProgressWriter {
+	return &ProgressWriter{w: w, out: out, name: name, size: size, total: total, nameWidth: nameWidth}
+}
+
+func (p *ProgressWriter) Write(b []byte) (int, error) {
+	n, err := p.w.Write(b)
+	p.written += int64(n)
+
+	now := time.Now()
+	if now.Sub(p.lastUpdate) >= 100*time.Millisecond {
+		p.lastUpdate = now
+		pct := int(float64(p.written) / float64(p.total) * 100)
+		_, _ = fmt.Fprintf(p.out, "\r%-*s  %10s  %3d%%", p.nameWidth, p.name, p.size, pct)
+	}
+	return n, err
+}
+
+// Clear erases the progress line.
+func (p *ProgressWriter) Clear() { ClearLine(p.out) }

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -71,6 +71,7 @@ var pagerCmdFn = func() (*exec.Cmd, error) {
 // WithPager pipes output through less if it exceeds terminal height.
 // The out writer is used as a fallback when paging is not available.
 func WithPager(out io.Writer, fn func(w io.Writer)) {
+	StopSpinner() // paging writes straight to os.Stdout, bypassing the stopWriter
 	var buf bytes.Buffer
 	fn(&buf)
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -182,6 +182,8 @@ func (tc *Conn) RunInteractive(ctx context.Context) error {
 		return errors.New("terminal command requires an interactive terminal")
 	}
 
+	output.StopSpinner() // hand the terminal to raw-mode PTY I/O
+
 	defer tc.Close()
 
 	oldState, err := term.MakeRaw(fd)


### PR DESCRIPTION
## Summary

`--limit 0` now fetches every result across the list commands instead of being a silent no-op. And when a finite `--limit` actually cuts a longer result short, the command says so on stderr — so a capped list never looks like the whole thing.

Because unbounded fetches can take a while, every command now shows a lightweight activity spinner while it waits, and clears it the moment output appears.

## Changes

- `collectPages` requests a large page size for unbounded fetches and follows `nextHref` for the rest.
- It now also returns whether a finite limit truncated the result; that flag is threaded through every `Get*` list call and surfaced on `cmdutil.ListResult.Truncated`.
- `RunList` (and the custom `run list` path) print `Showing only the first N results - use --limit 0 to fetch all` on stderr, set off by a blank line, when truncated. Suppressed for `--limit 0` and under `--quiet`.
- When command-side filtering empties a truncated page (e.g. `job list` hiding pipeline-owned configs), the empty state shows the same hint instead of a bare "No items found".
- `--limit` help text now reads `Maximum number of items (0 for all)`; docs and `.txtar` coverage updated.
- Added a process-wide activity spinner (`output.StartSpinner`/`StopSpinner`): started once in the root `PersistentPreRun` and auto-cleared on the first byte written through the `Printer` (`stopWriter`). The first frame waits one 80ms tick, so fast commands show nothing and `--limit 0` multi-page fetches show one continuous spinner. Gated on a stdout TTY and `--quiet`, so piped/`--json` output stays clean. Pager, TUI, raw PTY, and interactive prompt (huh) paths stop it explicitly before taking the terminal.
- Relocated the download progress bar into `output.ProgressWriter` and extracted `output.ClearLine`, so the indeterminate spinner and determinate bar share one home and the line-clear primitive.

## Design Decisions

Truncation is decided where pagination already knows it (hit the limit with items or a `nextHref` left over), so callers don't recompute it. The hint goes to stderr, keeping stdout/JSON clean for piping.

The spinner is intentionally ambient rather than a per-command call: starting once and dismissing on first output makes it universal with no per-command plumbing, and ties "stop" to output rather than request count so multi-page fetches don't flicker. It reuses the `\r…\r\033[K` pattern already used by `run download` rather than pulling in a bubbletea-style program (which would need to own each command's control flow).

## Example

```bash
$ teamcity run list --limit 5
# ...5 rows...

! Showing only the first 5 results - use --limit 0 to fetch all

$ teamcity run list --limit 0   # everything, no hint (spinner shows while fetching)
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A locally; runs against live cli.teamcity.com in CI
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [x] If adding a data-producing command: includes `--json` support
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated `docs/` (no `skills`/`README` change needed)
- [ ] External contributors: links a `status:finalized` issue — N/A, internal change