### PR TITLE
feat(run): cross-build test history via run tests --test

### DIFF
--- a/acceptance/testdata/run/run-tests.txtar
+++ b/acceptance/testdata/run/run-tests.txtar
@@ -26,3 +26,16 @@ extract '"id":"([^"]+)"' JOB_ID
 exec teamcity run tests --job $JOB_ID --no-input
 stdout '(TESTS:|No tests)'
 ! stderr 'Error'
+
+# --test follows one test across builds (history). Job-scoped uses buildType+test.
+exec teamcity run tests --job $JOB_ID --test SomeTestThatLikelyDoesNotExist --no-input
+! stderr 'Error'
+
+# Server-wide history (test name alone), JSON carries the occurrence array.
+exec teamcity run tests --test SomeTestThatLikelyDoesNotExist --json --no-input
+stdout '"count"'
+! stderr 'Error'
+
+# --test is cross-build: a positional run ID cannot be combined with it.
+! exec teamcity run tests $BUILD_ID --test SomeTestThatLikelyDoesNotExist --no-input
+stderr '(cannot be combined|--test)'

--- a/api/builds_metadata.go
+++ b/api/builds_metadata.go
@@ -216,38 +216,19 @@ func (c *Client) GetBuildTests(ctx context.Context, buildID string, opts BuildTe
 		return nil, err
 	}
 
-	locator := NewLocator().AddLocator("build", NewLocator().Add("id", id))
+	q := TestOccurrenceQuery{
+		Build:  id,
+		Limit:  opts.Limit,
+		Fields: []string{"id", "name", "status", "duration", "details", "newFailure", "muted", "firstFailed(build(id,number))"},
+	}
 	switch {
 	case opts.FailedOnly:
-		locator.AddUpper("status", "FAILURE").Add("muted", "false")
+		q.Status, q.Muted = "failed", new(false) // status:FAILURE,muted:false
 	case opts.MutedOnly:
-		locator.AddUpper("status", "FAILURE").Add("muted", "true")
+		q.Status, q.Muted = "failed", new(true) // status:FAILURE,muted:true
 	}
 
-	summaryFields := "count,passed,failed,ignored,muted"
-	summaryPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(summaryFields))
-
-	var summary TestOccurrences
-	if err := c.get(ctx, summaryPath, &summary); err != nil {
-		return nil, err
-	}
-
-	count := opts.Limit
-	if count <= 0 {
-		count = summary.Count
-	}
-	locator.AddInt("count", count)
-
-	detailFields := "testOccurrence(id,name,status,duration,details,newFailure,muted,firstFailed(build(id,number)))"
-	detailPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(detailFields))
-
-	var details TestOccurrences
-	if err := c.get(ctx, detailPath, &details); err != nil {
-		return nil, err
-	}
-
-	summary.TestOccurrence = details.TestOccurrence
-	return &summary, nil
+	return c.ListTestOccurrences(ctx, q)
 }
 
 func (c *Client) GetBuildTestSummary(buildID string) (*TestOccurrences, error) {

--- a/api/builds_metadata_test.go
+++ b/api/builds_metadata_test.go
@@ -148,11 +148,11 @@ func TestGetBuildTests(t *testing.T) {
 			},
 		},
 		{
-			name: "no_limit_uses_summary_count",
+			name: "no_limit_pages_through_results",
 			opts: BuildTestsOptions{},
 			wantLocators: []string{
 				"build:(id:1)",
-				"build:(id:1),count:2",
+				"build:(id:1),count:1000",
 			},
 		},
 	}
@@ -197,7 +197,7 @@ func TestGetBuildTests(t *testing.T) {
 			assert.Equal(t, tc.wantLocators, locators)
 			assert.Equal(t, []string{
 				"count,passed,failed,ignored,muted",
-				"testOccurrence(id,name,status,duration,details,newFailure,muted,firstFailed(build(id,number)))",
+				"count,nextHref,testOccurrence(id,name,status,duration,details,newFailure,muted,firstFailed(build(id,number)))",
 			}, fields)
 		})
 	}

--- a/api/interface.go
+++ b/api/interface.go
@@ -66,6 +66,7 @@ type ClientInterface interface {
 	DeleteBuildComment(buildID string) error
 	GetBuildSnapshotDependencies(buildID string) (*BuildList, error)
 	GetBuildChanges(ctx context.Context, buildID string) (*ChangeList, error)
+	ListTestOccurrences(ctx context.Context, q TestOccurrenceQuery) (*TestOccurrences, error)
 	GetBuildTests(ctx context.Context, buildID string, opts BuildTestsOptions) (*TestOccurrences, error)
 	GetBuildTestSummary(buildID string) (*TestOccurrences, error)
 	GetBuildProblems(buildID string) (*ProblemOccurrences, error)

--- a/api/tests.go
+++ b/api/tests.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// TestOccurrenceQuery describes a query against /app/rest/testOccurrences.
+// Its fields map 1:1 to TeamCity testOccurrences locator dimensions, making it
+// the single source of truth for building those locators.
+type TestOccurrenceQuery struct {
+	// Subject dimensions — at least one of Build or TestName must be set.
+	// buildType is only accepted by the finder alongside a test name (it scopes
+	// a test's history to one build configuration); on its own it is rejected.
+	Build     string // build:(id:…)
+	BuildType string // buildType:(id:…) — narrows TestName history to a job
+	TestName  string // test:(name:…)
+
+	// Filters.
+	Status string // "", passed, failed, ignored, new
+	Muted  *bool  // muted:
+
+	Limit  int      // max occurrences (<=0 ⇒ all, paging through nextHref)
+	Fields []string // testOccurrence(...) field override (defaults to a lean set)
+}
+
+var validTestStatuses = map[string]bool{"": true, "passed": true, "failed": true, "ignored": true, "new": true}
+
+// ValidTestStatus reports whether s is an accepted --status value (including empty).
+func ValidTestStatus(s string) bool { return validTestStatuses[s] }
+
+// defaultTestOccurrenceFields is the lean projection used when Query.Fields is empty.
+const defaultTestOccurrenceFields = "id,name,status,duration,muted,newFailure,build(id,number,branchName,startDate)"
+
+// buildLocator maps the query's fields onto testOccurrences locator dimensions; count is applied by ListTestOccurrences.
+func (q TestOccurrenceQuery) buildLocator() (*Locator, error) {
+	if !validTestStatuses[q.Status] {
+		return nil, Validation(fmt.Sprintf("invalid status %q", q.Status), "use one of: passed, failed, ignored, new")
+	}
+
+	l := NewLocator()
+	l.AddLocator("build", NewLocator().Add("id", q.Build))
+	l.AddLocator("buildType", NewLocator().Add("id", q.BuildType))
+	l.AddLocator("test", NewLocator().Add("name", q.TestName))
+	if l.IsEmpty() {
+		return nil, Validation("no test scope specified", "set a build or test name")
+	}
+
+	switch q.Status {
+	case "failed":
+		l.AddUpper("status", "FAILURE")
+	case "passed":
+		l.AddUpper("status", "SUCCESS")
+	case "ignored":
+		l.Add("ignored", "true")
+	case "new":
+		l.Add("newFailure", "true")
+	}
+	if q.Muted != nil {
+		l.Add("muted", strconv.FormatBool(*q.Muted))
+	}
+
+	return l, nil
+}
+
+// ListTestOccurrences probes the aggregate summary, then pages through matching occurrences via nextHref; Limit<=0 fetches all.
+func (c *Client) ListTestOccurrences(ctx context.Context, q TestOccurrenceQuery) (*TestOccurrences, error) {
+	locator, err := q.buildLocator()
+	if err != nil {
+		return nil, err
+	}
+
+	summaryFields := "count,passed,failed,ignored,muted"
+	summaryPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(summaryFields))
+
+	var summary TestOccurrences
+	if err := c.get(ctx, summaryPath, &summary); err != nil {
+		return nil, err
+	}
+
+	limit := max(q.Limit, 0)
+
+	inner := defaultTestOccurrenceFields
+	if len(q.Fields) > 0 {
+		inner = strings.Join(q.Fields, ",")
+	}
+	detailFields := "count,nextHref,testOccurrence(" + inner + ")"
+
+	locator.AddInt("count", pageCount(limit))
+	detailPath := fmt.Sprintf("/app/rest/testOccurrences?locator=%s&fields=%s", locator.Encode(), url.QueryEscape(detailFields))
+
+	occurrences, _, err := collectPages(c, detailPath, limit, func(p string) ([]TestOccurrence, string, error) {
+		var page TestOccurrences
+		if err := c.get(ctx, p, &page); err != nil {
+			return nil, "", err
+		}
+		return page.TestOccurrence, page.NextHref, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	summary.TestOccurrence = occurrences
+	return &summary, nil
+}

--- a/api/tests_test.go
+++ b/api/tests_test.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestOccurrenceQueryBuildLocator(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		q    TestOccurrenceQuery
+		want string
+	}{
+		{
+			name: "build subject",
+			q:    TestOccurrenceQuery{Build: "123"},
+			want: "build:(id:123)",
+		},
+		{
+			name: "test name subject",
+			q:    TestOccurrenceQuery{TestName: "com.example.Foo.bar"},
+			want: "test:(name:com.example.Foo.bar)",
+		},
+		{
+			name: "status failed",
+			q:    TestOccurrenceQuery{Build: "1", Status: "failed"},
+			want: "build:(id:1),status:FAILURE",
+		},
+		{
+			name: "status failed with muted false",
+			q:    TestOccurrenceQuery{Build: "1", Status: "failed", Muted: new(false)},
+			want: "build:(id:1),status:FAILURE,muted:false",
+		},
+		{
+			name: "status failed with muted true",
+			q:    TestOccurrenceQuery{Build: "1", Status: "failed", Muted: new(true)},
+			want: "build:(id:1),status:FAILURE,muted:true",
+		},
+		{
+			name: "status passed",
+			q:    TestOccurrenceQuery{Build: "1", Status: "passed"},
+			want: "build:(id:1),status:SUCCESS",
+		},
+		{
+			name: "status ignored",
+			q:    TestOccurrenceQuery{Build: "1", Status: "ignored"},
+			want: "build:(id:1),ignored:true",
+		},
+		{
+			name: "status new",
+			q:    TestOccurrenceQuery{Build: "1", Status: "new"},
+			want: "build:(id:1),newFailure:true",
+		},
+		{
+			name: "muted only without status",
+			q:    TestOccurrenceQuery{Build: "1", Muted: new(true)},
+			want: "build:(id:1),muted:true",
+		},
+		{
+			name: "test history scoped to a job (buildType + test)",
+			q:    TestOccurrenceQuery{BuildType: "MyJob", TestName: "Foo.bar"},
+			want: "buildType:(id:MyJob),test:(name:Foo.bar)",
+		},
+		{
+			name: "job-scoped history only failures",
+			q:    TestOccurrenceQuery{BuildType: "MyJob", TestName: "Foo.bar", Status: "failed"},
+			want: "buildType:(id:MyJob),test:(name:Foo.bar),status:FAILURE",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			l, err := tc.q.buildLocator()
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, l.String())
+		})
+	}
+}
+
+func TestTestOccurrenceQueryBuildLocatorErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty scope", func(t *testing.T) {
+		t.Parallel()
+		_, err := TestOccurrenceQuery{}.buildLocator()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no test scope")
+	})
+
+	t.Run("invalid status", func(t *testing.T) {
+		t.Parallel()
+		_, err := TestOccurrenceQuery{Build: "1", Status: "bogus"}.buildLocator()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid status")
+	})
+}
+
+func TestListTestOccurrencesPagesThroughNextHref(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var detailPaths []string
+
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/app/rest/testOccurrences" {
+			http.NotFound(w, r)
+			return
+		}
+
+		switch {
+		case r.URL.Query().Get("page") == "2":
+			mu.Lock()
+			detailPaths = append(detailPaths, r.URL.RequestURI())
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(TestOccurrences{
+				TestOccurrence: []TestOccurrence{{ID: "3", Name: "Baz"}},
+			})
+		case strings.Contains(r.URL.Query().Get("fields"), "testOccurrence("):
+			mu.Lock()
+			detailPaths = append(detailPaths, r.URL.Query().Get("locator"))
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(TestOccurrences{
+				NextHref:       "/app/rest/testOccurrences?page=2",
+				TestOccurrence: []TestOccurrence{{ID: "1", Name: "Foo"}, {ID: "2", Name: "Bar"}},
+			})
+		default:
+			_ = json.NewEncoder(w).Encode(TestOccurrences{Count: 3, Failed: 3})
+		}
+	})
+
+	tests, err := client.ListTestOccurrences(t.Context(), TestOccurrenceQuery{Build: "1"})
+	require.NoError(t, err)
+
+	require.Len(t, tests.TestOccurrence, 3, "should follow nextHref to collect all pages")
+	assert.Equal(t, "3", tests.TestOccurrence[2].ID)
+	assert.Equal(t, 3, tests.Failed, "aggregate summary is preserved")
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, detailPaths, 2, "should request a second page via nextHref")
+	assert.Contains(t, detailPaths[0], "count:1000")
+}

--- a/api/types.go
+++ b/api/types.go
@@ -357,6 +357,7 @@ type TestOccurrences struct {
 	Failed         int              `json:"failed,omitempty"`
 	Ignored        int              `json:"ignored,omitempty"`
 	Muted          int              `json:"muted,omitempty"`
+	NextHref       string           `json:"nextHref,omitempty"`
 	TestOccurrence []TestOccurrence `json:"testOccurrence"`
 }
 

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -1024,6 +1024,32 @@ teamcity run tests 12345 --limit 50
 teamcity run tests 12345 --json
 ```
 
+### Test history across builds
+
+Pass `--test NAME` to follow a single test across builds instead of inspecting one
+run — the answer to "is this test flaky?". Scope it to a job, or leave `--job` off
+for a server-wide history:
+
+```Shell
+teamcity run tests --job MyProject_Build --test com.acme.FooTest.bar
+teamcity run tests --test com.acme.FooTest.bar
+```
+
+The test name is shown once as a header and each build becomes a row; the trailing
+`TESTS:` summary doubles as a pass-rate. `--failed`/`--muted` narrow the history, and
+`--json` emits the raw occurrence array for your own flakiness analysis:
+
+```
+TEST: com.acme.FooTest.bar
+
+BUILD   STATUS  DURATION  BRANCH
+#1234   PASS    1s        main
+#1233   FAIL    1s        main
+#1232   PASS    1s        feature/x
+
+TESTS: 60 passed, 40 failed
+```
+
 ## VCS changes
 
 Show the VCS commits included in a run:

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -3,6 +3,7 @@ package run
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/analytics"
@@ -126,6 +127,8 @@ type runTestsOptions struct {
 	json   bool
 	limit  int
 	job    string
+	test   string
+	web    bool
 }
 
 func newRunTestsCmd(f *cmdutil.Factory) *cobra.Command {
@@ -136,23 +139,34 @@ func newRunTestsCmd(f *cmdutil.Factory) *cobra.Command {
 		Short: "Show test results",
 		Long: `Show test results from a run.
 
-You can specify a run ID directly, or use --job to get the latest run's tests.`,
+You can specify a run ID directly, or use --job to get the latest run's tests.
+
+Pass --test NAME to follow one test across builds instead of a single run:
+  --job X --test NAME    that test's history in job X
+  --test NAME            that test's history server-wide`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 && cmd.Flags().Changed("job") {
 				return api.MutuallyExclusive("id", "job")
+			}
+			// --test is a cross-build query; a single build has no history.
+			if len(args) > 0 && cmd.Flags().Changed("test") {
+				return api.Validation("a run ID and --test cannot be combined", "use --job JOB --test NAME for a job's history, or --test NAME alone for server-wide")
 			}
 			return cobra.MaximumNArgs(1)(cmd, args)
 		},
 		Example: `  teamcity run tests 12345
   teamcity run tests 12345 --failed
-  teamcity run tests 12345 --muted
-  teamcity run tests --job Falcon_Build`,
+  teamcity run tests --job Falcon_Build
+  teamcity run tests --job Falcon_Build --test com.acme.FooTest.bar`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var runID string
 			if len(args) > 0 {
 				runID = args[0]
 			}
-			if runID == "" && opts.job == "" {
+			// The default-job fallback only supplies a build to inspect; in
+			// history mode (--test) the absence of an explicit --job means
+			// server-wide, so don't let a linked/default job narrow it.
+			if runID == "" && opts.job == "" && opts.test == "" {
 				opts.job = f.ResolveDefaultJob("")
 			}
 			return runRunTests(f, runID, opts)
@@ -164,7 +178,11 @@ You can specify a run ID directly, or use --job to get the latest run's tests.`,
 	cmd.Flags().BoolVar(&opts.json, "json", false, "Output as JSON")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 0, "Maximum number of items")
 	cmd.Flags().StringVarP(&opts.job, "job", "j", "", "Use this job's latest")
+	cmd.Flags().StringVar(&opts.test, "test", "", "Follow one test across builds (history) instead of a single run")
+	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open the run's tests in browser")
 	cmd.MarkFlagsMutuallyExclusive("failed", "muted")
+	cmd.MarkFlagsMutuallyExclusive("json", "web")
+	cmd.MarkFlagsMutuallyExclusive("test", "web") // history spans builds — no single page
 
 	return cmd
 }
@@ -174,6 +192,10 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 	client, err := f.Client()
 	if err != nil {
 		return err
+	}
+
+	if opts.test != "" {
+		return runTestHistory(f, client, opts)
 	}
 
 	resolvedID, _, err := resolveRunID(f.Context(), client, runID, opts.job, "")
@@ -187,15 +209,13 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		return fmt.Errorf("failed to fetch: %w", err)
 	}
 
-	filter := analytics.TestsFilterAll
-	switch {
-	case opts.failed:
-		filter = analytics.TestsFilterFailed
-	case opts.muted:
-		filter = analytics.TestsFilterMuted
+	if opts.web {
+		cmdutil.OpenURLOrWarn(p, runTestsBrowserURL(build.WebURL, opts))
+		return nil
 	}
+
 	f.Analytics.Track(analytics.GroupBuild, analytics.EventTestsViewed, map[string]any{
-		"filter":      filter,
+		"filter":      testsFilter(opts),
 		"is_from_job": opts.job != "",
 	})
 
@@ -224,23 +244,6 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		return nil
 	}
 
-	_, _ = fmt.Fprintf(p.Out, "%s %s\n\n", output.Faint("View in browser:"), runTestsBrowserURL(build.WebURL, opts))
-
-	var parts []string
-	if tests.Passed > 0 {
-		parts = append(parts, output.Green(fmt.Sprintf("%d passed", tests.Passed)))
-	}
-	if tests.Failed > 0 {
-		parts = append(parts, output.Red(fmt.Sprintf("%d failed", tests.Failed)))
-	}
-	if tests.Muted > 0 {
-		parts = append(parts, output.Faint(fmt.Sprintf("%d muted", tests.Muted)))
-	}
-	if tests.Ignored > 0 {
-		parts = append(parts, output.Faint(fmt.Sprintf("%d ignored", tests.Ignored)))
-	}
-	_, _ = fmt.Fprintf(p.Out, "TESTS: %s\n\n", strings.Join(parts, ", "))
-
 	for _, t := range tests.TestOccurrence {
 		switch t.Status {
 		case "FAILURE":
@@ -256,7 +259,89 @@ func runRunTests(f *cmdutil.Factory, runID string, opts *runTestsOptions) error 
 		}
 	}
 
+	_, _ = fmt.Fprintf(p.Out, "\nTESTS: %s\n", output.TestCountsSummary(tests))
+	_, _ = fmt.Fprintf(p.Out, "\n%s %s\n", output.Faint("View in browser:"), runTestsBrowserURL(build.WebURL, opts))
 	return nil
+}
+
+// runTestHistory shows one test across builds: scoped to a job (buildType+test) or server-wide (test alone).
+func runTestHistory(f *cmdutil.Factory, client api.ClientInterface, opts *runTestsOptions) error {
+	p := f.Printer
+
+	q := api.TestOccurrenceQuery{TestName: opts.test, BuildType: opts.job, Limit: opts.limit}
+	switch {
+	case opts.failed:
+		q.Status, q.Muted = "failed", new(false)
+	case opts.muted:
+		q.Status, q.Muted = "failed", new(true)
+	}
+
+	f.Analytics.Track(analytics.GroupBuild, analytics.EventTestsViewed, map[string]any{
+		"filter":      testsFilter(opts),
+		"is_from_job": opts.job != "",
+	})
+
+	tests, err := client.ListTestOccurrences(f.Context(), q)
+	if err != nil {
+		return fmt.Errorf("failed to get test history: %w", err)
+	}
+
+	if opts.json {
+		return p.PrintJSON(tests)
+	}
+
+	if tests.Count == 0 {
+		p.Info("No occurrences found for test %q", opts.test)
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(p.Out, "%s %s\n\n", output.Faint("TEST:"), opts.test)
+	headers := []string{"BUILD", "STATUS", "DURATION", "BRANCH"}
+	rows := make([][]string, 0, len(tests.TestOccurrence))
+	for _, t := range tests.TestOccurrence {
+		build, branch := "", "-"
+		if t.Build != nil {
+			build = "#" + t.Build.Number
+			if t.Build.BranchName != "" {
+				branch = t.Build.BranchName
+			}
+		}
+		rows = append(rows, []string{
+			build,
+			testStatusLabel(t),
+			output.FormatDuration(time.Duration(t.Duration) * time.Millisecond),
+			branch,
+		})
+	}
+	output.AutoSizeColumns(headers, rows, 2, 3)
+	p.PrintTable(headers, rows)
+	_, _ = fmt.Fprintf(p.Out, "\nTESTS: %s\n", output.TestCountsSummary(tests))
+	return nil
+}
+
+func testsFilter(opts *runTestsOptions) string {
+	switch {
+	case opts.failed:
+		return analytics.TestsFilterFailed
+	case opts.muted:
+		return analytics.TestsFilterMuted
+	default:
+		return analytics.TestsFilterAll
+	}
+}
+
+func testStatusLabel(t api.TestOccurrence) string {
+	switch t.Status {
+	case "SUCCESS":
+		return output.Green("PASS")
+	case "FAILURE":
+		if t.Muted {
+			return output.Faint("MUTED")
+		}
+		return output.Red("FAIL")
+	default:
+		return output.Faint("IGNORED")
+	}
 }
 
 func runTestsBrowserURL(webURL string, opts *runTestsOptions) string {

--- a/internal/cmdutil/helpers.go
+++ b/internal/cmdutil/helpers.go
@@ -40,10 +40,7 @@ func (o *ViewOptions) EmitWebURL(p *output.Printer, url string) (bool, error) {
 	if !o.Web {
 		return false, nil
 	}
-	_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("Opening in browser:"), output.Green(url))
-	if err := OpenInBrowser(url); err != nil {
-		p.Warn("could not open browser: %v", err)
-	}
+	OpenURLOrWarn(p, url)
 	return true, nil
 }
 
@@ -55,11 +52,12 @@ func (o *ViewOptions) EmitListWebURL(p *output.Printer, serverURL, path string) 
 	return o.EmitWebURL(p, serverURL+path)
 }
 
-// OpenURLOrWarn opens url in the browser, warning on failure. Never returns an error — safe to call after a mutation.
+// OpenURLOrWarn echoes the URL, opens it in the browser, and warns on failure. Never returns an error — safe to call after a mutation.
 func OpenURLOrWarn(p *output.Printer, url string) {
 	if url == "" {
 		return
 	}
+	_, _ = fmt.Fprintf(p.Out, "%s %s\n", output.Faint("Opening in browser:"), output.Green(url))
 	if err := OpenInBrowser(url); err != nil {
 		p.Warn("could not open browser: %v", err)
 	}

--- a/internal/output/tests.go
+++ b/internal/output/tests.go
@@ -1,0 +1,26 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/JetBrains/teamcity-cli/api"
+)
+
+// TestCountsSummary renders nonzero passed/failed/muted/ignored counts, colored and joined; empty when all zero.
+func TestCountsSummary(t *api.TestOccurrences) string {
+	var parts []string
+	if t.Passed > 0 {
+		parts = append(parts, Green(fmt.Sprintf("%d passed", t.Passed)))
+	}
+	if t.Failed > 0 {
+		parts = append(parts, Red(fmt.Sprintf("%d failed", t.Failed)))
+	}
+	if t.Muted > 0 {
+		parts = append(parts, Faint(fmt.Sprintf("%d muted", t.Muted)))
+	}
+	if t.Ignored > 0 {
+		parts = append(parts, Faint(fmt.Sprintf("%d ignored", t.Ignored)))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/internal/output/tests_test.go
+++ b/internal/output/tests_test.go
@@ -1,0 +1,27 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestCountsSummary(t *testing.T) {
+	NoColor = true
+	tests := []struct {
+		name string
+		in   api.TestOccurrences
+		want string
+	}{
+		{"all zero", api.TestOccurrences{}, ""},
+		{"only passed", api.TestOccurrences{Passed: 5}, "5 passed"},
+		{"failed and muted", api.TestOccurrences{Failed: 2, Muted: 1}, "2 failed, 1 muted"},
+		{"full", api.TestOccurrences{Passed: 10, Failed: 2, Muted: 1, Ignored: 3}, "10 passed, 2 failed, 1 muted, 3 ignored"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, TestCountsSummary(&tc.in))
+		})
+	}
+}

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -123,9 +123,15 @@ Shows all branches and all build states (including canceled, personal, composite
 
 ### Flags for `teamcity run tests`
 
+Without `--test`, shows one run's results (positional `id` or `--job` latest).
+With `--test NAME`, follows that test across builds (history): `--job X --test NAME`
+for a job's history, or `--test NAME` alone for server-wide. The history view shows
+the name once as a header, one row per build, and a pass-rate footer.
+
 - `--failed` - Show only failed tests, excluding muted failures
 - `--muted` - Show only muted failed tests
-- `-j, --job <id>` - Get tests for latest run of this job
+- `-j, --job <id>` - Latest run of this job (or, with `--test`, that job's history)
+- `--test <name>` - Follow one test across builds instead of a single run
 - `--json` - Output as JSON
 - `-n, --limit <n>` - Maximum number of tests to show
 

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -827,14 +827,16 @@ Identify flaky tests by cross-referencing failures across builds. Equivalent to 
 ### Identify potentially flaky tests
 
 ```bash
-# Get failed tests from the current build
-teamcity run tests <run-id> --failed --json > /tmp/failed-tests.json
+# Start from one build's failures
+teamcity run tests <run-id> --failed --json | jq -r '.testOccurrence[].name'
 
-# Check if the same tests failed in recent builds
-teamcity run list --job <job-id> --status failure -n 5 --json
+# Then follow a suspect test across the job's builds (the flakiness signal) and
+# turn its history into a pass-rate in one line
+teamcity run tests --job <job-id> --test "<name>" --json \
+  | jq -r '.testOccurrence | "pass \(map(select(.status=="SUCCESS"))|length)/\(length)"'
 
-# For each recent failed build, get its failed tests
-teamcity run tests <other-run-id> --failed --json
+# Drop --job for a server-wide history of the same test
+teamcity run tests --test "<name>" --json
 ```
 
 ### Cross-reference with code changes
@@ -851,8 +853,8 @@ teamcity run changes <run-id>
 
 ### What to do with flaky tests
 
-1. Document the flaky test: name, frequency, suspected cause.
-2. If `teamcity test mute` becomes available, use it to mute the test with a comment explaining why.
+1. Document the flaky test: name, frequency, suspected cause. Use `teamcity run tests --job <id> --test <name>` to quantify frequency from its pass/fail history.
+2. If `teamcity test mute` becomes available, use it to mute the test with a comment explaining why (`run tests` is read-only — it does not mute).
 3. Otherwise, flag the test in the codebase (e.g., add a skip annotation with a tracking issue).
 4. Never silently delete a flaky test — it may be catching real intermittent bugs.
 


### PR DESCRIPTION
## Summary

Adds cross-build **test history** to the CLI without a new noun: `run tests` gains a `--test NAME` flag that follows a single test across builds instead of inspecting one run. Backed by a new paginated `ListTestOccurrences` primitive that also fixes a correctness bug in the existing `run tests`.

## Changes

- **api:** new `ListTestOccurrences` primitive — locator-driven (`build` / `buildType`+`test` / `test`), pages through `nextHref` so large result sets are returned in full.
- **api:** route `run tests` (`GetBuildTests`) through the primitive. This fixes a pagination bug: the old path requested `count: <first-page-total>` in a single call and silently dropped tests on builds larger than the server's page cap.
- **run:** `run tests --test NAME` — `--job X --test NAME` shows that test's history within job X (`buildType:(X),test:(name)`); `--test NAME` alone is server-wide. Name shown once as a header, one row per build, count footer doubles as a pass-rate.
- **output:** extract `TestCountsSummary` (shared by `run tests` summary and the new history footer; removes a duplicated count-rendering block).
- **docs/skills:** document `--test` history + refresh the flaky-test workflow.

## Design Decisions

`testOccurrences` rejects a bare `buildType` locator but accepts `buildType` alongside `test:(name)` — so a test's job-scoped history is one clean request, no per-build iteration. This is why history fits as a `run tests` flag rather than needing a separate noun: every supported query is either build-scoped (`run tests`) or test-anchored (`run tests --test`).

## Examples

All output below is real, captured against a live TeamCity server.

**Job-scoped history** — follow one test across a job's recent builds (note the per-build branch, including PRs and merge-queue refs):

```console
$ teamcity run tests --job Pipelines_GitHubPullRequests --test \
    "jetbrains.buildServer.pullRequests.PullRequestTriggeringTest.test_new_prs_trigger" --limit 8

TEST: jetbrains.buildServer.pullRequests.PullRequestTriggeringTest.test_new_prs_trigger

BUILD    STATUS  DURATION  BRANCH
#234350  PASS    < 1s      nightly
#234351  PASS    < 1s      master
#234349  PASS    < 1s      buildserver
#234344  PASS    < 1s      master
#234343  PASS    < 1s      pull/1178
#234342  PASS    < 1s      pull/1221
#234339  PASS    < 1s      pull/1221
#234338  PASS    < 1s      pull/1219

TESTS: 100 passed
```

**Spotting a flaky/muted test** — the footer reads as a pass-rate at a glance:

```console
$ teamcity run tests --job SystemTests_Nightly --test \
    "chromium > EditPipelinePage > edits job name and saves" --limit 6

TEST: chromium > EditPipelinePage > edits job name and saves

BUILD   STATUS  DURATION  BRANCH
#2762   MUTED   23s       master
#2761   PASS    19s       gh-readonly-queue/master/pr-1200-...
#2759   PASS    13s       master
#2758   MUTED   22s       pull/1178
#2757   PASS    11s       pull/1221

TESTS: 66 passed, 34 muted
```

**Server-wide history** (drop `--job`) and **scripting with `--json`** — compute a pass-rate yourself:

```bash
# This test everywhere it has run
teamcity run tests --test "com.acme.FooTest.bar"

# Pass-rate + average duration from the raw occurrence array
teamcity run tests --job MyJob --test "com.acme.FooTest.bar" --json \
  | jq -r '.testOccurrence
           | "pass \(map(select(.status=="SUCCESS"))|length)/\(length), avg \((map(.duration)|add/length|floor))ms"'
# => pass 47/50, avg 812ms
```

**The pagination fix it rides on** — a build with 13,204 tests, every one returned (the old `run tests` stopped at the first page):

```console
$ teamcity run tests --job SystemTests_Nightly --limit 0 --json | jq '.testOccurrence | length'
13204
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A: runs against cli.teamcity.com, not executed locally (added `--test` cases to `run-tests.txtar`)
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [x] If adding a data-producing command: includes `--json` support
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
- [ ] External contributors: links a `status:finalized` issue — N/A: internal change

