### PR TITLE
fix(git): end option parsing before user-supplied revisions

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -57,7 +57,8 @@ func HeadRevision() (string, error) { return ResolveRevision("HEAD") }
 
 // ResolveRevision returns the SHA for rev (full or short).
 func ResolveRevision(rev string) (string, error) {
-	out, err := exec.Command("git", "rev-parse", rev).Output()
+	// --end-of-options stops a leading-dash rev being read as a flag; --verify yields just the SHA.
+	out, err := exec.Command("git", "rev-parse", "--verify", "--end-of-options", rev).Output()
 	if err != nil {
 		return "", fmt.Errorf("git rev-parse %s: %w", rev, err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -161,6 +162,28 @@ func TestBranchExistsOnRemote(t *testing.T) {
 	runGit(t, dir, "commit", "-m", "initial")
 
 	assert.False(t, BranchExistsOnRemote("master"))
+}
+
+func TestResolveRevision(t *testing.T) {
+	dir := setupRepo(t)
+	t.Chdir(dir)
+	writeFile(t, dir, "test.txt", "content")
+	runGit(t, dir, "add", ".")
+	runGit(t, dir, "commit", "-m", "initial")
+	full := strings.TrimSpace(runGit(t, dir, "rev-parse", "HEAD"))
+
+	t.Run("resolves short SHA to full SHA", func(t *testing.T) {
+		got, err := ResolveRevision(full[:8])
+		require.NoError(t, err)
+		assert.Equal(t, full, got)
+	})
+
+	t.Run("rejects a leading-dash rev instead of passing it through", func(t *testing.T) {
+		// Plain rev-parse echoes an unknown option back, so this would return verbatim as a "SHA".
+		got, err := ResolveRevision("--output=/tmp/teamcity-cli-pwned")
+		assert.Error(t, err)
+		assert.Empty(t, got)
+	})
 }
 
 func TestUntrackedFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

`git.ResolveRevision` ran `git rev-parse <rev>` with the user-supplied revision (from `run start --revision` / `@head`) as the first operand. A revision beginning with `-` is parsed as an option: `git rev-parse` doesn't recognize it, echoes it back on stdout, and exits 0 — so `ResolveRevision("--foo")` returns the literal `--foo` as a resolved SHA instead of failing.

## Changes

- `ResolveRevision` now runs `git rev-parse --verify --end-of-options <rev>`.
- `TestResolveRevision` covers short-SHA resolution and rejection of a leading-dash revision.

## Design Decisions

Scoped to `rev-parse`. `ls-remote` and `push` take the user value as a *trailing* operand (after the remote), where git treats it as a ref rather than an option (verified against git 2.54), so they are unaffected. `--verify` guarantees a single object id, matching the existing single-SHA expectation.

## Example

```bash
# before: returned the string "--output=x" as a bogus SHA
# after:
teamcity run start MyJob --revision='--output=x'
Error: failed to resolve revision '--output=x'
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean on `internal/git`
- [ ] Acceptance tests pass (`just acceptance`) — N/A — internal git helper, not a command surface
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no command change
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A — no `--json` change
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — no user-visible output/flag change
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member