### PR TITLE
fix(api): serialize empty list results as [] not null

### DIFF
--- a/api/builds_artifacts.go
+++ b/api/builds_artifacts.go
@@ -53,6 +53,9 @@ func (c *Client) GetArtifacts(ctx context.Context, buildID string, subpath strin
 	if err := c.get(ctx, p, &artifacts); err != nil {
 		return nil, err
 	}
+	if artifacts.File == nil {
+		artifacts.File = []Artifact{} // non-nil so --json emits [] not null
+	}
 
 	return &artifacts, nil
 }

--- a/api/builds_artifacts_test.go
+++ b/api/builds_artifacts_test.go
@@ -51,6 +51,27 @@ func TestGetArtifactsWithSubpath(t *testing.T) {
 	assert.Equal(t, 1, artifacts.Count)
 }
 
+func TestGetArtifactsEmptyIsNonNil(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/rest/builds" || r.URL.Path == "/httpAuth/app/rest/builds" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
+			return
+		}
+		// Server omits the "file" key for a build with no artifacts.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":0}`))
+	})
+
+	artifacts, err := client.GetArtifacts(t.Context(), "1", "")
+	require.NoError(t, err)
+	assert.NotNil(t, artifacts.File)
+	b, err := json.Marshal(artifacts)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"file":[]`)
+}
+
 func TestDownloadArtifact(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/api/messages.go
+++ b/api/messages.go
@@ -71,6 +71,9 @@ func (c *Client) GetBuildMessages(ctx context.Context, buildID string, opts Buil
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("failed to decode build messages: %w", err)
 	}
+	if result.Messages == nil {
+		result.Messages = []BuildMessage{} // non-nil so --json emits [] not null
+	}
 
 	return &result, nil
 }

--- a/api/messages_test.go
+++ b/api/messages_test.go
@@ -76,6 +76,27 @@ func TestGetBuildMessages_head(t *testing.T) {
 	assert.Equal(t, "Build started", resp.Messages[0].Text)
 }
 
+func TestGetBuildMessagesEmptyIsNonNil(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/app/rest/builds" || r.URL.Path == "/httpAuth/app/rest/builds" {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 1}}})
+			return
+		}
+		// Server omits the "messages" key for a build with no log lines yet.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"lastMessageIndex":0}`))
+	})
+
+	resp, err := client.GetBuildMessages(t.Context(), "1", BuildMessagesOptions{Count: -10, Tail: true})
+	require.NoError(t, err)
+	assert.NotNil(t, resp.Messages)
+	b, err := json.Marshal(resp.Messages)
+	require.NoError(t, err)
+	assert.Equal(t, "[]", string(b))
+}
+
 func TestGetBuildMessages_withSinceID(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/api/paginate.go
+++ b/api/paginate.go
@@ -18,7 +18,7 @@ func pageCount(limit int) int {
 
 // collectPages follows NextHref links to accumulate items up to the limit (0 collects all); the bool is true when a finite limit capped the result and more exist.
 func collectPages[T any](c *Client, path string, limit int, fetch func(string) ([]T, string, error)) ([]T, bool, error) {
-	var all []T
+	all := []T{} // non-nil so an empty result serializes as JSON [] not null
 	for path != "" {
 		items, nextHref, err := fetch(path)
 		if err != nil {

--- a/api/paginate_test.go
+++ b/api/paginate_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -78,6 +79,20 @@ func TestCollectPages(t *testing.T) {
 		assert.Equal(t, 2, call)
 		// Exactly at the limit and no more pages -> not truncated.
 		assert.False(t, truncated)
+	})
+
+	t.Run("empty result is non-nil so it serializes as [] not null", func(t *testing.T) {
+		t.Parallel()
+		c := &Client{BaseURL: "http://localhost"}
+		items, truncated, err := collectPages(c, "/app/rest/builds", 0, func(path string) ([]int, string, error) {
+			return nil, "", nil
+		})
+		require.NoError(t, err)
+		assert.False(t, truncated)
+		assert.NotNil(t, items)
+		b, err := json.Marshal(items)
+		require.NoError(t, err)
+		assert.Equal(t, "[]", string(b))
 	})
 
 	t.Run("unbounded fetch uses large page and collects all", func(t *testing.T) {


### PR DESCRIPTION
## Summary

`collectPages` accumulated into `var all []T`, so a query that matched nothing returned a nil slice. Every list wrapper built from it (`BuildList.Builds`, `PoolList.Pools`, `AgentList`, jobs, projects, pipelines, VCS roots, queue, cloud, test occurrences) has no `omitempty`, so `--json` on an empty result emitted `"build": null` instead of `"build": []` — breaking the documented contract that slices reaching JSON serialize as `[]`, and any consumer doing `.build[]`. Two non-paginated list endpoints (`GetArtifacts`, `GetBuildMessages`) had the same nil-slice defect.

## Changes

- `collectPages` seeds the accumulator as `[]T{}`, fixing every paginated list endpoint at the source (builds, agents, jobs, projects, pipelines, VCS roots, queue, pools, cloud, test occurrences).
- `GetArtifacts` and `GetBuildMessages` normalize their slice fields to non-nil before returning.
- Tests: empty-result coverage in `collectPages`, `GetArtifacts`, and `GetBuildMessages` asserting `[]` not `null`.

## Design Decisions

Fixed at the source (the API client) rather than per-command, so all current and future consumers are correct without each command re-normalizing. `run tests` already routes through `collectPages` via `ListTestOccurrences`, so it is covered by the same change.

## Example

```bash
# before:
teamcity run list --status failure --json   # {"count":0,...,"build":null}
# after:
teamcity run list --status failure --json   # {"count":0,...,"build":[]}
```

## Test Plan

- [x] Unit tests pass (`just unit`) — plus `go test ./api/...`
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean on `api`
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched; no existing script asserted the old `null`
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [x] If modifying `--json` output: no field removals/renames (additive only) — value shape only (`null` → `[]`), no field changes
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — fixes output to match the already-documented `[]` contract
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member