### PR TITLE
fix(api): escape user-supplied values in request paths and locators

### DIFF
--- a/api/agents.go
+++ b/api/agents.go
@@ -40,7 +40,7 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, bool, error) {
 			locator.AddRaw("pool", "(id:"+opts.Pool+")")
 		} else if strings.ContainsAny(opts.Pool, ":,()$") {
 			// base64-encode the name: TeamCity ignores in-value escaping for these chars (matches cloud.go).
-			locator.AddRaw("pool", "("+cloudNameValueLocator(opts.Pool)+")")
+			locator.AddRaw("pool", "("+nameValueLocator(opts.Pool)+")")
 		} else {
 			locator.AddRaw("pool", "(name:"+opts.Pool+")")
 		}

--- a/api/agents.go
+++ b/api/agents.go
@@ -38,6 +38,9 @@ func (c *Client) GetAgents(opts AgentsOptions) (*AgentList, bool, error) {
 	if opts.Pool != "" {
 		if _, err := strconv.Atoi(opts.Pool); err == nil {
 			locator.AddRaw("pool", "(id:"+opts.Pool+")")
+		} else if strings.ContainsAny(opts.Pool, ":,()$") {
+			// base64-encode the name: TeamCity ignores in-value escaping for these chars (matches cloud.go).
+			locator.AddRaw("pool", "("+cloudNameValueLocator(opts.Pool)+")")
 		} else {
 			locator.AddRaw("pool", "(name:"+opts.Pool+")")
 		}

--- a/api/agents_test.go
+++ b/api/agents_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -65,6 +66,19 @@ func TestGetAgentsWithPoolFilter(t *testing.T) {
 			json.NewEncoder(w).Encode(AgentList{Count: 0})
 		})
 		_, _, err := client.GetAgents(AgentsOptions{Pool: "5"})
+		require.NoError(t, err)
+	})
+
+	t.Run("by name with special characters is base64-encoded", func(t *testing.T) {
+		t.Parallel()
+		// TeamCity does not honor in-value escaping for ()/,; base64 is the safe form.
+		want := "pool:(name:(value:($base64:" + base64.RawURLEncoding.EncodeToString([]byte("Build (Linux)")) + ")))"
+		client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Contains(t, r.URL.Query().Get("locator"), want)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(AgentList{Count: 0})
+		})
+		_, _, err := client.GetAgents(AgentsOptions{Pool: "Build (Linux)"})
 		require.NoError(t, err)
 	})
 }

--- a/api/builds.go
+++ b/api/builds.go
@@ -36,10 +36,14 @@ func (opts BuildsOptions) Locator() *Locator {
 	locator := NewLocator().
 		Add("buildType", opts.BuildTypeID).
 		Add("defaultFilter", "false")
-	if opts.Branch != "" {
-		locator.Add("branch", opts.Branch)
-	} else {
+	switch {
+	case opts.Branch == "":
 		locator.AddLocator("branch", NewLocator().Add("default", "any"))
+	case strings.ContainsAny(opts.Branch, ":,()$"):
+		// branch's value is a nested locator, so the server re-parses even a base64-decoded bare value; route the name through the value condition (verified live against TeamCity 2026.1).
+		locator.AddRaw("branch", "("+nameValueLocator(opts.Branch)+")")
+	default:
+		locator.Add("branch", opts.Branch)
 	}
 	locator.
 		AddUpper("status", opts.Status).

--- a/api/builds_test.go
+++ b/api/builds_test.go
@@ -37,6 +37,19 @@ func TestBuildsOptionsLocator(T *testing.T) {
 			},
 		},
 		{
+			name: "branch with locator metacharacters goes through the base64 name condition",
+			opts: BuildsOptions{
+				Branch: "release(2024)",
+			},
+			want: []string{
+				"branch:(name:(value:($base64:cmVsZWFzZSgyMDI0KQ)))",
+			},
+			reject: []string{
+				"branch:(release",
+				"branch:(default:any)",
+			},
+		},
+		{
 			name: "favorites use current user star tag locator",
 			opts: BuildsOptions{
 				BuildTypeID: "MyBuild",

--- a/api/cloud.go
+++ b/api/cloud.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -42,11 +41,11 @@ func cloudNameLocator(value string) string {
 	case strings.HasPrefix(value, "name:(") && strings.HasSuffix(value, ")"):
 		return value
 	case strings.HasPrefix(value, "name:"):
-		return cloudNameValueLocator(strings.TrimPrefix(value, "name:"))
+		return nameValueLocator(strings.TrimPrefix(value, "name:"))
 	case isCloudIDLikeLocator(value):
 		return cloudIDLocator(value)
 	default:
-		return cloudNameValueLocator(value)
+		return nameValueLocator(value)
 	}
 }
 
@@ -57,7 +56,7 @@ func cloudIDLocator(value string) string {
 	case strings.HasPrefix(value, "name:(") && strings.HasSuffix(value, ")"):
 		return value
 	case strings.HasPrefix(value, "name:"):
-		return cloudNameValueLocator(strings.TrimPrefix(value, "name:"))
+		return nameValueLocator(strings.TrimPrefix(value, "name:"))
 	case strings.Contains(value, ","):
 		return "id:(" + value + ")"
 	case isCloudIDLikeLocator(value):
@@ -67,11 +66,6 @@ func cloudIDLocator(value string) string {
 	default:
 		return "id:" + value
 	}
-}
-
-func cloudNameValueLocator(value string) string {
-	encoded := base64.RawURLEncoding.EncodeToString([]byte(value))
-	return "name:(value:($base64:" + encoded + "))"
 }
 
 func isCloudIDLikeLocator(value string) bool {

--- a/api/connections.go
+++ b/api/connections.go
@@ -10,7 +10,7 @@ import (
 // GetProjectConnections returns OAuth/connection features for a project
 func (c *Client) GetProjectConnections(projectID string) (*ProjectFeatureList, error) {
 	fields := url.QueryEscape("projectFeature(id,type,properties(property(name,value)))")
-	path := fmt.Sprintf("/app/rest/projects/id:%s/projectFeatures?locator=type:OAuthProvider&fields=%s", projectID, fields)
+	path := fmt.Sprintf("/app/rest/projects/id:%s/projectFeatures?locator=type:OAuthProvider&fields=%s", url.PathEscape(projectID), fields)
 
 	var result ProjectFeatureList
 	if err := c.get(c.ctx(), path, &result); err != nil {
@@ -26,7 +26,7 @@ func (c *Client) CreateProjectFeature(projectID string, feat ProjectFeature) (*P
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	path := fmt.Sprintf("/app/rest/projects/id:%s/projectFeatures", projectID)
+	path := fmt.Sprintf("/app/rest/projects/id:%s/projectFeatures", url.PathEscape(projectID))
 	var result ProjectFeature
 	if err := c.post(c.ctx(), path, bytes.NewReader(body), &result); err != nil {
 		return nil, err
@@ -36,6 +36,6 @@ func (c *Client) CreateProjectFeature(projectID string, feat ProjectFeature) (*P
 
 // DeleteProjectFeature removes a project feature by id.
 func (c *Client) DeleteProjectFeature(projectID, featureID string) error {
-	path := fmt.Sprintf("/app/rest/projects/id:%s/projectFeatures/id:%s", projectID, featureID)
+	path := fmt.Sprintf("/app/rest/projects/id:%s/projectFeatures/id:%s", url.PathEscape(projectID), url.PathEscape(featureID))
 	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -145,7 +145,7 @@ func (c *Client) GetBuildSteps(buildTypeID string) (*BuildStepList, error) {
 
 // GetBuildStep returns a single build step by ID
 func (c *Client) GetBuildStep(buildTypeID, stepID string) (*BuildStep, error) {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps/%s", buildTypeID, stepID)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps/%s", url.PathEscape(buildTypeID), url.PathEscape(stepID))
 
 	var step BuildStep
 	if err := c.get(c.ctx(), path, &step); err != nil {
@@ -174,7 +174,7 @@ func (c *Client) CreateBuildStep(buildTypeID string, step BuildStep) (*BuildStep
 
 // DeleteBuildStep removes a build step from a build configuration
 func (c *Client) DeleteBuildStep(buildTypeID, stepID string) error {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps/%s", buildTypeID, stepID)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps/%s", url.PathEscape(buildTypeID), url.PathEscape(stepID))
 	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
@@ -216,6 +216,6 @@ func (c *Client) GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error) 
 
 // SetBuildTypeSetting sets a build configuration setting
 func (c *Client) SetBuildTypeSetting(buildTypeID, setting, value string) error {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings/%s", buildTypeID, setting)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings/%s", url.PathEscape(buildTypeID), url.PathEscape(setting))
 	return c.doNoContent(c.ctx(), "PUT", path, strings.NewReader(value), "text/plain")
 }

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -54,7 +54,7 @@ func (c *Client) GetBuildTypes(opts BuildTypesOptions) (*BuildTypeList, bool, er
 
 // GetBuildType returns a single build configuration by ID
 func (c *Client) GetBuildType(id string) (*BuildType, error) {
-	path := "/app/rest/buildTypes/id:" + id
+	path := "/app/rest/buildTypes/id:" + url.PathEscape(id)
 
 	var buildType BuildType
 	if err := c.get(c.ctx(), path, &buildType); err != nil {
@@ -66,7 +66,7 @@ func (c *Client) GetBuildType(id string) (*BuildType, error) {
 
 // SetBuildTypePaused sets the paused state of a build configuration
 func (c *Client) SetBuildTypePaused(id string, paused bool) error {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/paused", id)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/paused", url.PathEscape(id))
 
 	resp, err := c.doRequestFull(c.ctx(), "PUT", path, strings.NewReader(strconv.FormatBool(paused)), "text/plain", "text/plain")
 	if err != nil {
@@ -133,7 +133,7 @@ const buildStepFields = "count,step(id,name,type,disabled,properties(property(na
 
 // GetBuildSteps returns the build steps of a build configuration
 func (c *Client) GetBuildSteps(buildTypeID string) (*BuildStepList, error) {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps?fields=%s", buildTypeID, url.QueryEscape(buildStepFields))
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps?fields=%s", url.PathEscape(buildTypeID), url.QueryEscape(buildStepFields))
 
 	var result BuildStepList
 	if err := c.get(c.ctx(), path, &result); err != nil {
@@ -162,7 +162,7 @@ func (c *Client) CreateBuildStep(buildTypeID string, step BuildStep) (*BuildStep
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps", buildTypeID)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/steps", url.PathEscape(buildTypeID))
 
 	var created BuildStep
 	if err := c.post(c.ctx(), path, bytes.NewReader(body), &created); err != nil {
@@ -180,7 +180,7 @@ func (c *Client) DeleteBuildStep(buildTypeID, stepID string) error {
 
 // GetSnapshotDependencies returns the snapshot dependencies for a build configuration
 func (c *Client) GetSnapshotDependencies(buildTypeID string) (*SnapshotDependencyList, error) {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/snapshot-dependencies?fields=count,snapshot-dependency(id,source-buildType(id,name,projectId))", buildTypeID)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/snapshot-dependencies?fields=count,snapshot-dependency(id,source-buildType(id,name,projectId))", url.PathEscape(buildTypeID))
 
 	var result SnapshotDependencyList
 	if err := c.get(c.ctx(), path, &result); err != nil {
@@ -204,7 +204,7 @@ func (c *Client) GetDependentBuildTypes(buildTypeID string) (*BuildTypeList, err
 
 // GetVcsRootEntries returns the VCS root entries attached to a build configuration
 func (c *Client) GetVcsRootEntries(buildTypeID string) (*VcsRootEntries, error) {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/vcs-root-entries", buildTypeID)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/vcs-root-entries", url.PathEscape(buildTypeID))
 
 	var result VcsRootEntries
 	if err := c.get(c.ctx(), path, &result); err != nil {

--- a/api/locator.go
+++ b/api/locator.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/url"
 	"strings"
@@ -21,17 +22,20 @@ func (l *Locator) Add(key, value string) *Locator {
 	return l
 }
 
-// escapeLocatorValue wraps values containing special characters in parentheses.
-// TeamCity locator syntax uses : and , as delimiters, and $ as escape char
-// inside parenthesized values ($) for literal ), $$ for literal $).
+// escapeLocatorValue wraps values containing the : and , delimiters in parentheses and transports values containing ( ) $ as ($base64:<base64url>) — live servers reject the $)-style in-value escapes and name their decoder Base64url, so that is the only encoding that round-trips.
 func escapeLocatorValue(value string) string {
 	if !strings.ContainsAny(value, ":,()$") {
 		return value
 	}
-	// Escape $ first (so we don't double-escape), then )
-	escaped := strings.ReplaceAll(value, "$", "$$")
-	escaped = strings.ReplaceAll(escaped, ")", "$)")
-	return "(" + escaped + ")"
+	if !strings.ContainsAny(value, "()$") {
+		return "(" + value + ")"
+	}
+	return "($base64:" + base64.RawURLEncoding.EncodeToString([]byte(value)) + ")"
+}
+
+// nameValueLocator builds the name:(value:($base64:...)) condition form for dimensions whose value is itself a locator (branch, pool, cloud profile/image) — there the server re-parses even a base64-decoded bare value as locator syntax, so the name must sit in an explicit value condition.
+func nameValueLocator(value string) string {
+	return "name:(value:($base64:" + base64.RawURLEncoding.EncodeToString([]byte(value)) + "))"
 }
 
 // AddRaw adds a key:value pair without escaping the value.

--- a/api/locator_test.go
+++ b/api/locator_test.go
@@ -113,7 +113,7 @@ func TestLocator(T *testing.T) {
 				return NewLocator().
 					Add("branch", "feature(test)")
 			},
-			want: "branch:(feature(test$))",
+			want: "branch:($base64:ZmVhdHVyZSh0ZXN0KQ)",
 		},
 		{
 			name: "multiple special chars",
@@ -121,7 +121,7 @@ func TestLocator(T *testing.T) {
 				return NewLocator().
 					Add("branch", "a:b,c(d)")
 			},
-			want: "branch:(a:b,c(d$))",
+			want: "branch:($base64:YTpiLGMoZCk)",
 		},
 		{
 			name: "unicode characters",
@@ -145,7 +145,7 @@ func TestLocator(T *testing.T) {
 				return NewLocator().
 					Add("branch", ":,:()")
 			},
-			want: "branch:(:,:($))",
+			want: "branch:($base64:Oiw6KCk)",
 		},
 		{
 			name: "injection attempt via closing paren",
@@ -153,7 +153,7 @@ func TestLocator(T *testing.T) {
 				return NewLocator().
 					Add("project", "Foo),status:FAILURE,tag:(bar")
 			},
-			want: "project:(Foo$),status:FAILURE,tag:(bar)",
+			want: "project:($base64:Rm9vKSxzdGF0dXM6RkFJTFVSRSx0YWc6KGJhcg)",
 		},
 		{
 			name: "negative int value is skipped",

--- a/api/params.go
+++ b/api/params.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 // ParameterList represents a list of parameters
@@ -38,7 +39,7 @@ func (c *Client) getParameters(basePath string) (*ParameterList, error) {
 }
 
 func (c *Client) getParameter(basePath, name string) (*Parameter, error) {
-	path := fmt.Sprintf("%s/parameters/%s", basePath, name)
+	path := fmt.Sprintf("%s/parameters/%s", basePath, url.PathEscape(name))
 
 	var param Parameter
 	if err := c.get(c.ctx(), path, &param); err != nil {
@@ -49,7 +50,7 @@ func (c *Client) getParameter(basePath, name string) (*Parameter, error) {
 }
 
 func (c *Client) setParameter(basePath, name, value string, secure bool) error {
-	path := fmt.Sprintf("%s/parameters/%s", basePath, name)
+	path := fmt.Sprintf("%s/parameters/%s", basePath, url.PathEscape(name))
 
 	param := Parameter{
 		Name:  name,
@@ -69,48 +70,48 @@ func (c *Client) setParameter(basePath, name, value string, secure bool) error {
 }
 
 func (c *Client) deleteParameter(basePath, name string) error {
-	path := fmt.Sprintf("%s/parameters/%s", basePath, name)
+	path := fmt.Sprintf("%s/parameters/%s", basePath, url.PathEscape(name))
 	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 
 // GetProjectParameters returns parameters for a project
 func (c *Client) GetProjectParameters(projectID string) (*ParameterList, error) {
-	return c.getParameters("/app/rest/projects/id:" + projectID)
+	return c.getParameters("/app/rest/projects/id:" + url.PathEscape(projectID))
 }
 
 // GetProjectParameter returns a specific parameter for a project
 func (c *Client) GetProjectParameter(projectID, name string) (*Parameter, error) {
-	return c.getParameter("/app/rest/projects/id:"+projectID, name)
+	return c.getParameter("/app/rest/projects/id:"+url.PathEscape(projectID), name)
 }
 
 // SetProjectParameter sets a parameter for a project
 func (c *Client) SetProjectParameter(projectID, name, value string, secure bool) error {
-	return c.setParameter("/app/rest/projects/id:"+projectID, name, value, secure)
+	return c.setParameter("/app/rest/projects/id:"+url.PathEscape(projectID), name, value, secure)
 }
 
 // DeleteProjectParameter deletes a parameter from a project
 func (c *Client) DeleteProjectParameter(projectID, name string) error {
-	return c.deleteParameter("/app/rest/projects/id:"+projectID, name)
+	return c.deleteParameter("/app/rest/projects/id:"+url.PathEscape(projectID), name)
 }
 
 // GetBuildTypeParameters returns parameters for a build configuration
 func (c *Client) GetBuildTypeParameters(buildTypeID string) (*ParameterList, error) {
-	return c.getParameters("/app/rest/buildTypes/id:" + buildTypeID)
+	return c.getParameters("/app/rest/buildTypes/id:" + url.PathEscape(buildTypeID))
 }
 
 // GetBuildTypeParameter returns a specific parameter for a build configuration
 func (c *Client) GetBuildTypeParameter(buildTypeID, name string) (*Parameter, error) {
-	return c.getParameter("/app/rest/buildTypes/id:"+buildTypeID, name)
+	return c.getParameter("/app/rest/buildTypes/id:"+url.PathEscape(buildTypeID), name)
 }
 
 // SetBuildTypeParameter sets a parameter for a build configuration
 func (c *Client) SetBuildTypeParameter(buildTypeID, name, value string, secure bool) error {
-	return c.setParameter("/app/rest/buildTypes/id:"+buildTypeID, name, value, secure)
+	return c.setParameter("/app/rest/buildTypes/id:"+url.PathEscape(buildTypeID), name, value, secure)
 }
 
 // DeleteBuildTypeParameter deletes a parameter from a build configuration
 func (c *Client) DeleteBuildTypeParameter(buildTypeID, name string) error {
-	return c.deleteParameter("/app/rest/buildTypes/id:"+buildTypeID, name)
+	return c.deleteParameter("/app/rest/buildTypes/id:"+url.PathEscape(buildTypeID), name)
 }
 
 // GetParameterValue returns just the raw value of a parameter

--- a/api/params_test.go
+++ b/api/params_test.go
@@ -116,6 +116,19 @@ func TestSetBuildTypeParameter(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSetBuildTypeParameterEscapesName(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Unescaped, the "#" would start a fragment and truncate the path.
+		assert.Contains(t, r.URL.EscapedPath(), "/parameters/feature%23flag")
+		assert.Equal(t, "PUT", r.Method)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	err := client.SetBuildTypeParameter("MyBuild", "feature#flag", "v1", false)
+	require.NoError(t, err)
+}
+
 func TestDeleteBuildTypeParameter(t *testing.T) {
 	t.Parallel()
 	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/api/projects.go
+++ b/api/projects.go
@@ -100,7 +100,7 @@ func (c *Client) ProjectExists(id string) bool {
 // Returns the scrambled token that can be used in configuration files as credentialsJSON:<token>.
 // Requires EDIT_PROJECT permission.
 func (c *Client) CreateSecureToken(projectID, value string) (string, error) {
-	path := fmt.Sprintf("/app/rest/projects/%s/secure/tokens", projectID)
+	path := fmt.Sprintf("/app/rest/projects/%s/secure/tokens", url.PathEscape(projectID))
 
 	resp, err := c.doRequestFull(c.ctx(), "POST", path, strings.NewReader(value), "text/plain", "text/plain")
 	if err != nil {
@@ -123,7 +123,7 @@ func (c *Client) CreateSecureToken(projectID, value string) (string, error) {
 // GetSecureValue retrieves the original value for a secure token.
 // Requires CHANGE_SERVER_SETTINGS permission (System Administrator only).
 func (c *Client) GetSecureValue(projectID, token string) (string, error) {
-	path := fmt.Sprintf("/app/rest/projects/%s/secure/values/%s", projectID, token)
+	path := fmt.Sprintf("/app/rest/projects/%s/secure/values/%s", url.PathEscape(projectID), url.PathEscape(token))
 
 	resp, err := c.doRequestWithAccept(c.ctx(), "GET", path, nil, "text/plain")
 	if err != nil {
@@ -145,7 +145,7 @@ func (c *Client) GetSecureValue(projectID, token string) (string, error) {
 
 // GetVersionedSettingsStatus returns the sync status of versioned settings for a project.
 func (c *Client) GetVersionedSettingsStatus(projectID string) (*VersionedSettingsStatus, error) {
-	path := fmt.Sprintf("/app/rest/projects/%s/versionedSettings/status", projectID)
+	path := fmt.Sprintf("/app/rest/projects/%s/versionedSettings/status", url.PathEscape(projectID))
 
 	var status VersionedSettingsStatus
 	if err := c.get(c.ctx(), path, &status); err != nil {
@@ -157,7 +157,7 @@ func (c *Client) GetVersionedSettingsStatus(projectID string) (*VersionedSetting
 
 // GetVersionedSettingsConfig returns the versioned settings configuration for a project.
 func (c *Client) GetVersionedSettingsConfig(projectID string) (*VersionedSettingsConfig, error) {
-	path := fmt.Sprintf("/app/rest/projects/%s/versionedSettings/config", projectID)
+	path := fmt.Sprintf("/app/rest/projects/%s/versionedSettings/config", url.PathEscape(projectID))
 
 	var config VersionedSettingsConfig
 	if err := c.get(c.ctx(), path, &config); err != nil {

--- a/api/settings.go
+++ b/api/settings.go
@@ -21,7 +21,7 @@ type Setting struct {
 
 // GetBuildTypeSettings returns all settings for a build configuration
 func (c *Client) GetBuildTypeSettings(buildTypeID string) (*SettingsList, error) {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings", buildTypeID)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings", url.PathEscape(buildTypeID))
 
 	var result SettingsList
 	if err := c.get(c.ctx(), path, &result); err != nil {

--- a/api/settings.go
+++ b/api/settings.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 // SettingsList represents a list of build configuration settings
@@ -32,7 +33,7 @@ func (c *Client) GetBuildTypeSettings(buildTypeID string) (*SettingsList, error)
 
 // GetBuildTypeSetting returns the raw plain-text value of a single build configuration setting
 func (c *Client) GetBuildTypeSetting(buildTypeID, name string) (string, error) {
-	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings/%s", buildTypeID, name)
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/settings/%s", url.PathEscape(buildTypeID), url.PathEscape(name))
 
 	resp, err := c.doRequestWithAccept(c.ctx(), "GET", path, nil, "text/plain")
 	if err != nil {

--- a/api/ssh_keys.go
+++ b/api/ssh_keys.go
@@ -8,7 +8,7 @@ import (
 
 // GetSSHKeys returns SSH keys uploaded to a project
 func (c *Client) GetSSHKeys(projectID string) (*SSHKeyList, error) {
-	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys", projectID)
+	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys", url.PathEscape(projectID))
 
 	var result SSHKeyList
 	if err := c.get(c.ctx(), path, &result); err != nil {
@@ -19,13 +19,13 @@ func (c *Client) GetSSHKeys(projectID string) (*SSHKeyList, error) {
 
 // UploadSSHKey uploads a private SSH key to a project
 func (c *Client) UploadSSHKey(projectID, name string, privateKey []byte) error {
-	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/?fileName=%s", projectID, url.QueryEscape(name))
+	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/?fileName=%s", url.PathEscape(projectID), url.QueryEscape(name))
 	return c.doNoContent(c.ctx(), "POST", path, bytes.NewReader(privateKey), "text/plain")
 }
 
 // GenerateSSHKey generates an SSH key pair in a project and returns the key with public key
 func (c *Client) GenerateSSHKey(projectID, name, keyType string) (*SSHKey, error) {
-	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/generated?keyName=%s&keyType=%s", projectID, url.QueryEscape(name), url.QueryEscape(keyType))
+	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/generated?keyName=%s&keyType=%s", url.PathEscape(projectID), url.QueryEscape(name), url.QueryEscape(keyType))
 
 	var result SSHKey
 	if err := c.post(c.ctx(), path, nil, &result); err != nil {
@@ -36,6 +36,6 @@ func (c *Client) GenerateSSHKey(projectID, name, keyType string) (*SSHKey, error
 
 // DeleteSSHKey deletes an SSH key from a project
 func (c *Client) DeleteSSHKey(projectID, name string) error {
-	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/%s", projectID, url.PathEscape(name))
+	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/%s", url.PathEscape(projectID), url.PathEscape(name))
 	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }

--- a/api/users.go
+++ b/api/users.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 )
 
 // GetCurrentUser returns the authenticated user
@@ -17,7 +18,7 @@ func (c *Client) GetCurrentUser() (*User, error) {
 
 // GetUser returns a user by username
 func (c *Client) GetUser(username string) (*User, error) {
-	path := "/app/rest/users/username:" + username
+	path := "/app/rest/users/username:" + url.PathEscape(username)
 
 	var user User
 	if err := c.get(c.ctx(), path, &user); err != nil {
@@ -75,7 +76,7 @@ type Token struct {
 
 // CreateAPIToken creates an API token for the current user
 func (c *Client) CreateAPIToken(name string) (*Token, error) {
-	path := "/app/rest/users/current/tokens/" + name
+	path := "/app/rest/users/current/tokens/" + url.PathEscape(name)
 
 	var token Token
 	if err := c.post(c.ctx(), path, nil, &token); err != nil {
@@ -87,7 +88,7 @@ func (c *Client) CreateAPIToken(name string) (*Token, error) {
 
 // DeleteAPIToken deletes an API token for the current user
 func (c *Client) DeleteAPIToken(name string) error {
-	path := "/app/rest/users/current/tokens/" + name
+	path := "/app/rest/users/current/tokens/" + url.PathEscape(name)
 	return c.doNoContent(c.ctx(), "DELETE", path, nil, "")
 }
 


### PR DESCRIPTION
## Summary

Several API client methods interpolated user-supplied values into request paths and locators without escaping. The clearest bug: `agent list --pool 'Build (Linux)'` built `pool:(name:Build (Linux))`, whose `)` corrupts the locator — verified against a live server, which returns `400 Bad locator syntax`. Path segments (build steps, settings, parameters, secure tokens/values, API tokens, usernames) were interpolated raw the same way.

## Changes

- `ListAgents` base64-encodes a pool name containing locator metacharacters (`:,()$`) using the same `$base64:` form as `cloud.go`; simple names stay readable as `name:<value>`.
- `url.PathEscape` applied to user-supplied path segments across `jobs.go`, `params.go`, `settings.go`, `projects.go`, and `users.go`.
- Tests: pool-name base64 encoding and parameter-name path escaping (`#`).

## Design Decisions

`($base64:...)` (not in-value escaping) for every special locator value: live servers reject the `$)`-style escapes (`Bad locator syntax`; the server's decode error names Base64url, hence `RawURLEncoding`), so `escapeLocatorValue` emits `($base64:...)` for values containing `()$` and keeps the plain paren wrap for `:`/`,`-only values. `branch:` values are nested locators — the server re-parses even a decoded bare value — so branch names with metacharacters route through `branch:(name:(value:($base64:...)))`; both forms verified live against TeamCity 2026.1 (cli.teamcity.com) and 2026.2 (teamcity-nightly). `url.PathEscape` for the `id:`/`name:`/`username:` path segments matches `GetAgentByName` — TeamCity prohibits `:`/`,` in those identifiers, so only path-unsafe characters need escaping.

## Example

```bash
teamcity agent list --pool 'Build (Linux)'   # locator now parses server-side
```

## Test Plan

- [x] Unit tests pass (`just unit`) — plus `go test ./api/...`; pool locators verified against cli.teamcity.com
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean on `api`
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [ ] If modifying `--json` output: no field removals/renames — N/A — request-path change only, no output shape change
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — no docs-visible behavior change
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member
