### PR TITLE
fix(alias): preserve positional args containing spaces or quotes

### DIFF
--- a/internal/cmd/alias/expand.go
+++ b/internal/cmd/alias/expand.go
@@ -103,17 +103,12 @@ func newShellAliasCmd(f *cmdutil.Factory, name, expansion string) *cobra.Command
 }
 
 func expandArgs(expansion string, args []string) ([]string, error) {
-	// Tokenize the template first, then substitute each arg into the token that holds
-	// its placeholder. Substituting into a single token can't re-split or unbalance
-	// quotes, so an arg with spaces/quotes stays one argument whether the placeholder
-	// was written bare ($1) or quoted ("$1").
 	tokens, err := shellwords.Split(expansion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse alias expansion: %w", err)
 	}
 	used := make([]bool, len(args))
 	for i, tok := range tokens {
-		// Replace highest-index first so $1 doesn't shadow $10.
 		for j := len(args) - 1; j >= 0; j-- {
 			placeholder := fmt.Sprintf("$%d", j+1)
 			if strings.Contains(tok, placeholder) {

--- a/internal/cmd/alias/expand.go
+++ b/internal/cmd/alias/expand.go
@@ -103,21 +103,32 @@ func newShellAliasCmd(f *cmdutil.Factory, name, expansion string) *cobra.Command
 }
 
 func expandArgs(expansion string, args []string) ([]string, error) {
-	var extraArgs []string
-	for i := len(args) - 1; i >= 0; i-- {
-		placeholder := fmt.Sprintf("$%d", i+1)
-		if strings.Contains(expansion, placeholder) {
-			expansion = strings.ReplaceAll(expansion, placeholder, args[i])
-		} else {
-			extraArgs = append(extraArgs, args[i])
-		}
-	}
-	slices.Reverse(extraArgs)
-	parts, err := shellwords.Split(expansion)
+	// Tokenize the template first, then substitute each arg into the token that holds
+	// its placeholder. Substituting into a single token can't re-split or unbalance
+	// quotes, so an arg with spaces/quotes stays one argument whether the placeholder
+	// was written bare ($1) or quoted ("$1").
+	tokens, err := shellwords.Split(expansion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse alias expansion: %w", err)
 	}
-	return append(parts, extraArgs...), nil
+	used := make([]bool, len(args))
+	for i, tok := range tokens {
+		// Replace highest-index first so $1 doesn't shadow $10.
+		for j := len(args) - 1; j >= 0; j-- {
+			placeholder := fmt.Sprintf("$%d", j+1)
+			if strings.Contains(tok, placeholder) {
+				tok = strings.ReplaceAll(tok, placeholder, args[j])
+				used[j] = true
+			}
+		}
+		tokens[i] = tok
+	}
+	for j, u := range used {
+		if !u {
+			tokens = append(tokens, args[j])
+		}
+	}
+	return tokens, nil
 }
 
 func expandShellArgs(expansion string, args []string) string {

--- a/internal/cmd/alias/expand_test.go
+++ b/internal/cmd/alias/expand_test.go
@@ -21,6 +21,10 @@ func TestExpandPositionalArgs(t *testing.T) {
 		{"positional plus extra args", "run list --user=$1", []string{"@me", "--limit=5"}, []string{"run", "list", "--user=@me", "--limit=5"}},
 		{"unused positional placeholder", "run list --user=$1 --branch=$2", []string{"@me"}, []string{"run", "list", "--user=@me", "--branch=$2"}},
 		{"double-digit placeholder not clobbered by single-digit", "$1 $10", []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}, []string{"A", "J", "B", "C", "D", "E", "F", "G", "H", "I"}},
+		{"arg with spaces stays one token", "run view $1", []string{"my build"}, []string{"run", "view", "my build"}},
+		{"arg with spaces embedded in flag", "run list --user=$1", []string{"a b"}, []string{"run", "list", "--user=a b"}},
+		{"arg with single quote does not break parsing", "run view $1", []string{"O'Brien"}, []string{"run", "view", "O'Brien"}},
+		{"quoted placeholder keeps arg as one token", `run view "$1"`, []string{"my build"}, []string{"run", "view", "my build"}},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`expandArgs` substituted each raw positional arg into the alias expansion *string* and then ran `shellwords.Split` over the whole result. An arg containing whitespace was re-tokenized into multiple arguments, and an arg containing a quote made `Split` mis-parse or fail. With `alias rv='run view $1'`, `tc rv "my build"` expanded to four tokens and `tc rv "O'Brien"` errored.

## Changes

- `expandArgs` tokenizes the template first, then substitutes each arg into the token holding its placeholder, so a value with spaces or quotes stays one argument — for both bare (`$1`) and quoted (`"$1"`) placeholders.
- Tests: args with spaces (standalone and embedded in a flag), a single quote, and a quoted placeholder.

## Design Decisions

Substituting into an already-split token can't re-split or unbalance quotes. This also fixes quoted-placeholder templates (`"$1"`), which a substitute-then-resplit approach corrupts.

## Example

```bash
teamcity alias set rv 'run view $1'
teamcity rv "my build"   # passes "my build" as one argument
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [ ] If modifying `--json` output: no field removals/renames — N/A — no `--json` change
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — bug fix, no documented behavior change
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member