### PR TITLE
fix(job): detect cycles by ancestor path so diamond deps aren't dropped

### DIFF
--- a/internal/cmd/job/tree.go
+++ b/internal/cmd/job/tree.go
@@ -156,8 +156,12 @@ func buildJobTreeNodes(client api.ClientInterface, jobID string, depth int, reve
 			nodes = append(nodes, node)
 			continue
 		}
+		// Track only the current ancestor path so a node is "circular" solely when
+		// it is its own ancestor; deleting on backtrack lets a re-convergent
+		// (diamond) dependency expand under each parent instead of being dropped.
 		visited[bt.ID] = true
 		kids := buildJobTreeNodes(client, bt.ID, next, reverse, visited)
+		delete(visited, bt.ID)
 		if reverse {
 			node.Dependents = kids
 		} else {

--- a/internal/cmd/job/tree_test.go
+++ b/internal/cmd/job/tree_test.go
@@ -1,0 +1,59 @@
+package job
+
+import (
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeTreeClient serves a fixed snapshot-dependency graph; all other client
+// methods are unused and will panic via the embedded nil interface if called.
+type fakeTreeClient struct {
+	api.ClientInterface
+	deps map[string][]api.BuildType
+}
+
+func (f *fakeTreeClient) GetSnapshotDependencies(buildTypeID string) (*api.SnapshotDependencyList, error) {
+	children := f.deps[buildTypeID]
+	sd := make([]api.SnapshotDependency, 0, len(children))
+	for i := range children {
+		sd = append(sd, api.SnapshotDependency{SourceBuildType: &children[i]})
+	}
+	return &api.SnapshotDependencyList{Count: len(sd), SnapshotDependency: sd}, nil
+}
+
+func TestBuildJobTreeNodesDiamondNotCircular(t *testing.T) {
+	// A depends on B and C; both depend on D (a re-convergent diamond).
+	client := &fakeTreeClient{deps: map[string][]api.BuildType{
+		"A": {{ID: "B", Name: "B"}, {ID: "C", Name: "C"}},
+		"B": {{ID: "D", Name: "D"}},
+		"C": {{ID: "D", Name: "D"}},
+	}}
+
+	nodes := buildJobTreeNodes(client, "A", 0, false, map[string]bool{"A": true})
+
+	require.Len(t, nodes, 2)
+	for _, n := range nodes {
+		require.Len(t, n.Dependencies, 1, "%s should expand its dependency", n.ID)
+		d := n.Dependencies[0]
+		assert.Equal(t, "D", d.ID)
+		assert.False(t, d.circular, "shared dependency D under %s must not be flagged circular", n.ID)
+	}
+}
+
+func TestBuildJobTreeNodesDetectsRealCycle(t *testing.T) {
+	// A -> B -> A is a genuine cycle.
+	client := &fakeTreeClient{deps: map[string][]api.BuildType{
+		"A": {{ID: "B", Name: "B"}},
+		"B": {{ID: "A", Name: "A"}},
+	}}
+
+	nodes := buildJobTreeNodes(client, "A", 0, false, map[string]bool{"A": true})
+
+	require.Len(t, nodes, 1)
+	require.Len(t, nodes[0].Dependencies, 1)
+	assert.Equal(t, "A", nodes[0].Dependencies[0].ID)
+	assert.True(t, nodes[0].Dependencies[0].circular, "A revisited as its own ancestor must be circular")
+}


### PR DESCRIPTION
## Summary

`buildJobTreeNodes` used a single `visited` map shared across the whole traversal and never unmarked IDs on backtrack, so it detected *global* re-visits rather than cycles along the current path. In a diamond dependency graph (A depends on B and C, both of which depend on D), D is marked visited while walking B's subtree; when C's subtree reaches D it is wrongly labelled `(circular)` and, because of the `continue`, D's own dependencies are omitted. The label claims a cycle that does not exist and hides a legitimate shared dependency's subtree.

## Changes

- `buildJobTreeNodes` deletes each node from `visited` after its subtree returns, so `visited` represents the current ancestor path. A node is now flagged circular only when it is its own ancestor (a real cycle).
- Tests: a diamond graph (shared dependency expands under both parents, neither circular) and a genuine `A → B → A` cycle (still flagged circular).

## Design Decisions

Cycle detection should key on the ancestor path, not on global visitation. Re-convergent subtrees may now render more than once, bounded by `--depth`; that is correct tree behavior and distinct from cycle detection (a separate already-rendered set could dedupe shared subtrees later if desired).

## Example

```bash
teamcity job tree MyProject_Deploy   # a shared dependency no longer shows "(circular)"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — `job tree` already supports `--json`
- [ ] If modifying `--json` output: no field removals/renames — additive only; shared subtrees now populated instead of being dropped
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — fixes incorrect output, no documented behavior change
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member