### PR TITLE
fix(run): keep run start --json output free of progress text

### DIFF
--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -169,6 +169,25 @@ func TestRunStartDryRun(T *testing.T) {
 	assert.Contains(T, got, testJob)
 }
 
+func TestRunStartDryRunJSON(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "start", testJob,
+		"--branch", "main", "--rebuild-failed-deps", "--dry-run", "--json")
+
+	var plan struct {
+		DryRun            bool   `json:"dry_run"`
+		Job               string `json:"job"`
+		Branch            string `json:"branch"`
+		RebuildFailedDeps bool   `json:"rebuild_failed_deps"`
+	}
+	require.NoError(T, json.Unmarshal([]byte(got), &plan), "dry-run --json must emit valid JSON, got: %s", got)
+	assert.True(T, plan.DryRun)
+	assert.Equal(T, testJob, plan.Job)
+	assert.Equal(T, "main", plan.Branch)
+	assert.True(T, plan.RebuildFailedDeps, "dry-run JSON must reflect --rebuild-failed-deps")
+	assert.NotContains(T, got, "Would trigger", "human preview text must not appear in --json output")
+}
+
 func TestRunStartReuseDepsDryRun(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	ts.Handle("GET /app/rest/builds/id:6946", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -238,6 +238,56 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 				"Check the job ID with: teamcity job list",
 			)
 		}
+		f.Analytics.Track(analytics.GroupBuild, analytics.EventStarted, map[string]any{
+			"is_personal":       opts.personal,
+			"has_local_changes": opts.localChanges != "",
+			"has_branch":        opts.branch != "",
+			"has_revision":      opts.revision != "",
+			"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
+			"is_watched":        false,
+			"is_dry_run":        true,
+		})
+
+		if opts.json {
+			return p.PrintJSON(struct {
+				DryRun            bool              `json:"dry_run"`
+				Job               string            `json:"job"`
+				Branch            string            `json:"branch,omitempty"`
+				Revision          string            `json:"revision,omitempty"`
+				Personal          bool              `json:"personal"`
+				LocalChanges      string            `json:"local_changes,omitempty"`
+				Params            map[string]string `json:"params,omitempty"`
+				SystemProps       map[string]string `json:"system_properties,omitempty"`
+				EnvVars           map[string]string `json:"environment_variables,omitempty"`
+				Comment           string            `json:"comment,omitempty"`
+				Tags              []string          `json:"tags,omitempty"`
+				CleanSources      bool              `json:"clean_sources,omitempty"`
+				RebuildDeps       bool              `json:"rebuild_deps,omitempty"`
+				RebuildFailedDeps bool              `json:"rebuild_failed_deps,omitempty"`
+				QueueAtTop        bool              `json:"queue_at_top,omitempty"`
+				Agent             int               `json:"agent_id,omitempty"`
+				ReuseDeps         []int             `json:"reuse_deps,omitempty"`
+			}{
+				DryRun:            true,
+				Job:               jobID,
+				Branch:            opts.branch,
+				Revision:          opts.revision,
+				Personal:          opts.personal || opts.localChanges != "",
+				LocalChanges:      opts.localChanges,
+				Params:            opts.params,
+				SystemProps:       opts.systemProps,
+				EnvVars:           opts.envVars,
+				Comment:           opts.comment,
+				Tags:              opts.tags,
+				CleanSources:      opts.cleanSources,
+				RebuildDeps:       opts.rebuildDeps,
+				RebuildFailedDeps: opts.rebuildFailedDeps,
+				QueueAtTop:        opts.queueAtTop,
+				Agent:             opts.agent,
+				ReuseDeps:         opts.reuseDeps,
+			})
+		}
+
 		_, _ = fmt.Fprintf(p.Out, "%s Would trigger run for %s\n", output.Faint("[dry-run]"), output.Cyan(jobID))
 		if opts.branch != "" {
 			_, _ = fmt.Fprintf(p.Out, "  Branch: %s\n", opts.branch)
@@ -281,6 +331,9 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		if opts.rebuildDeps {
 			_, _ = fmt.Fprintln(p.Out, "  Rebuild dependencies: yes")
 		}
+		if opts.rebuildFailedDeps {
+			_, _ = fmt.Fprintln(p.Out, "  Rebuild failed dependencies: yes")
+		}
 		if len(opts.reuseDeps) > 0 {
 			printReuseDeps(p, fetchReuseDeps(f.Context(), client, opts.reuseDeps))
 		}
@@ -290,16 +343,19 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		if opts.agent > 0 {
 			_, _ = fmt.Fprintf(p.Out, "  Agent ID: %d\n", opts.agent)
 		}
-		f.Analytics.Track(analytics.GroupBuild, analytics.EventStarted, map[string]any{
-			"is_personal":       opts.personal,
-			"has_local_changes": opts.localChanges != "",
-			"has_branch":        opts.branch != "",
-			"has_revision":      opts.revision != "",
-			"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
-			"is_watched":        false,
-			"is_dry_run":        true,
-		})
 		return nil
+	}
+
+	// Progress lines write to stdout; suppress them in --json mode so they don't corrupt the document.
+	info := func(format string, a ...any) {
+		if !opts.json {
+			p.Info(format, a...)
+		}
+	}
+	success := func(format string, a ...any) {
+		if !opts.json {
+			p.Success(format, a...)
+		}
 	}
 
 	if opts.localChanges != "" && opts.branch == "" {
@@ -314,16 +370,16 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 			return err
 		}
 		opts.branch = branch
-		p.Info("Using current branch: %s", branch)
+		info("Using current branch: %s", branch)
 	}
 
 	if opts.localChanges != "" && !opts.noPush {
 		if !git.BranchExistsOnRemote(opts.branch) {
-			p.Info("Pushing branch to remote...")
+			info("Pushing branch to remote...")
 			if err := pushBranch(opts.branch); err != nil {
 				return err
 			}
-			p.Success("Branch pushed to remote")
+			success("Branch pushed to remote")
 		}
 	}
 
@@ -339,7 +395,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 			return err
 		}
 
-		p.Info("Uploading local changes...")
+		info("Uploading local changes...")
 		description := cmp.Or(opts.comment, "Personal build with local changes")
 
 		changeID, err := client.UploadDiffChanges(patch, description)
@@ -347,7 +403,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 			return fmt.Errorf("failed to upload changes: %w", err)
 		}
 		personalChangeID = changeID
-		p.Success("Uploaded changes (ID: %s)", changeID)
+		success("Uploaded changes (ID: %s)", changeID)
 
 		opts.personal = true
 	}


### PR DESCRIPTION
## Summary

`run start` could emit non-JSON text to stdout even with `--json`, since `--json` isn't mutually exclusive with `--dry-run` or `--local-changes` and `p.Info`/`p.Success` write to stdout (suppressed only by `--quiet`). `run start <job> --dry-run --json` printed the human preview and never called `PrintJSON`; `--local-changes --json` prefixed the JSON document with progress lines. Either way a consumer piping `--json` got invalid JSON.

## Changes

- `--dry-run --json` now emits a structured plan document (job, branch, revision, params, personal, local changes, tags, trigger toggles) instead of the human preview; the analytics event fires once for both paths.
- The local-changes progress messages are suppressed in `--json` mode (routed through `info`/`success` helpers), so stdout stays pure JSON.
- Test: `run start --dry-run --json` produces parseable JSON with `dry_run: true` and no preview text.

## Design Decisions

The dry-run plan is a new, additive JSON object using snake_case keys (consistent with `run log --json`'s `run_id`). Progress lines are suppressed under `--json` rather than moved to stderr, matching how `--quiet` already suppresses `p.Info`/`p.Success`.

## Example

```bash
teamcity run start MyJob --branch main --dry-run --json
# {"dry_run":true,"job":"MyJob","branch":"main","personal":false}
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [x] If adding a data-producing command: includes `--json` support — `--dry-run` now honors the existing `--json` flag
- [x] If modifying `--json` output: no field removals/renames (additive only) — adds a dry-run plan where there was none; the build-trigger `--json` shape is unchanged
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — `--json`/`--dry-run` already documented; no shape was specified for their combination
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member