### PR TITLE
fix(run): surface watch errors from the TUI instead of reporting success

### DIFF
--- a/internal/cmd/run/tui/tui.go
+++ b/internal/cmd/run/tui/tui.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -266,6 +267,16 @@ func RunWatchTUI(ctx context.Context, client api.ClientInterface, runID string, 
 	}
 
 	fm := finalModel.(watchModel)
+
+	// A clean tea.Quit (p.Run err is nil) can still leave fm.err set; surface it instead of reporting success.
+	if fm.err != nil {
+		if errors.Is(fm.err, context.DeadlineExceeded) {
+			// Execute renders ExitError silently, so print the timeout notice first (like the non-TUI path).
+			_, _ = fmt.Fprintf(output.DefaultPrinter().Out, "\n%s Timeout exceeded\n", output.Red(output.Sym().Cross))
+		}
+		return watchErrToExit(fm.err)
+	}
+
 	printer := output.DefaultPrinter()
 	_, _ = fmt.Fprintln(printer.Out)
 
@@ -276,4 +287,18 @@ func RunWatchTUI(ctx context.Context, client api.ClientInterface, runID string, 
 	}
 
 	return cmdutil.BuildResultError(ctx, printer, client, fm.build, true)
+}
+
+// watchErrToExit maps a watch fetch error to a command result: deadline→timeout, cancel→clean exit, else surface.
+func watchErrToExit(err error) error {
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, context.DeadlineExceeded):
+		return &cmdutil.ExitError{Code: cmdutil.ExitTimeout}
+	case errors.Is(err, context.Canceled):
+		return nil
+	default:
+		return err
+	}
 }

--- a/internal/cmd/run/tui/tui_test.go
+++ b/internal/cmd/run/tui/tui_test.go
@@ -1,13 +1,42 @@
 package tui
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestWatchErrToExit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		assert.NoError(t, watchErrToExit(nil))
+	})
+
+	t.Run("deadline becomes a timeout exit", func(t *testing.T) {
+		err := watchErrToExit(fmt.Errorf("get build: %w", context.DeadlineExceeded))
+		var ee *cmdutil.ExitError
+		require.ErrorAs(t, err, &ee)
+		assert.Equal(t, cmdutil.ExitTimeout, ee.Code)
+	})
+
+	t.Run("cancel exits cleanly", func(t *testing.T) {
+		assert.NoError(t, watchErrToExit(fmt.Errorf("get build: %w", context.Canceled)))
+	})
+
+	t.Run("other errors surface", func(t *testing.T) {
+		sentinel := errors.New("server returned 503")
+		assert.ErrorIs(t, watchErrToExit(sentinel), sentinel)
+	})
+}
 
 func TestWatchModelRenderHeader(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

The interactive watch TUI stores any mid-watch fetch failure in the model's `err` and quits, but `RunWatchTUI` never inspected it after `p.Run()`. Because bubbletea returns a nil error for a clean `tea.Quit`, a network drop, 5xx, or auth expiry during `run watch --logs` (and `run start --watch`) caused the command to print "Build still running in background", exit 0, and record the watch as a success in analytics (`watchExitStatus(nil) → BuildStatusSuccess`). A `--timeout` deadline was swallowed the same way instead of yielding the timeout exit code.

## Changes

- `RunWatchTUI` checks the final model's `err` before the build-state branch and maps it via a new `watchErrToExit` helper (deadline → `ExitTimeout`, cancel → clean exit, else surface). The returned error flows through the existing `watchExitStatus`, so analytics records failure/error instead of success.
- Test: `watchErrToExit` covers nil, wrapped deadline, wrapped cancel, and a generic error.

## Design Decisions

The mapping is extracted into `watchErrToExit` so it is unit-testable without a TTY (the full TUI needs an alt-screen terminal). Ctrl+C is a clean exit; the deadline maps to `ExitTimeout` (124) to match the non-TUI watch path.

## Example

```bash
teamcity run watch 12345 --logs   # connection drops mid-watch -> now exits non-zero, no false "success"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — `run watch --logs` TUI is excluded from acceptance (needs a terminal)
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no output-shape change
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — fixes exit code/analytics, no documented behavior change
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member