### PR TITLE
fix(api): close response bodies of retried attempts

### DIFF
--- a/api/retry.go
+++ b/api/retry.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"strconv"
@@ -34,6 +35,9 @@ var (
 	LongRetry = RetryConfig{MaxRetries: 3, Interval: 1 * time.Second}
 )
 
+// maxRetryDrain caps how much of a discarded response body is read to enable connection reuse.
+const maxRetryDrain = 4 << 10
+
 // withRetry retries op on network errors, 429, and 5xx (except 501/505), honoring Retry-After and ctx cancellation.
 func withRetry(ctx context.Context, cfg RetryConfig, op func() (*http.Response, error)) (*http.Response, error) {
 	if cfg.MaxRetries == 0 {
@@ -44,8 +48,17 @@ func withRetry(ctx context.Context, cfg RetryConfig, op func() (*http.Response, 
 	expo.InitialInterval = cfg.Interval
 	expo.MaxInterval = 30 * time.Second
 
+	// Close each retried response before the next attempt so it doesn't leak its body.
+	var prev *http.Response
 	return backoff.Retry(ctx, func() (*http.Response, error) {
+		if prev != nil {
+			// Drain a bounded amount to allow connection reuse without stalling on a huge body.
+			_, _ = io.Copy(io.Discard, io.LimitReader(prev.Body, maxRetryDrain))
+			_ = prev.Body.Close()
+			prev = nil
+		}
 		resp, err := op()
+		prev = resp
 		if err != nil {
 			if isRetryableNetworkError(err) {
 				return resp, err

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,52 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// closeTracker is an http.Response body that records when it is closed.
+type closeTracker struct {
+	id      int
+	onClose func(int)
+	closed  bool
+}
+
+func (c *closeTracker) Read([]byte) (int, error) { return 0, io.EOF }
+func (c *closeTracker) Close() error {
+	if !c.closed {
+		c.closed = true
+		c.onClose(c.id)
+	}
+	return nil
+}
+
+func TestWithRetry_ClosesRetriedBodies(t *testing.T) {
+	var closed []int
+	id := 0
+	mkResp := func(code int) *http.Response {
+		r := &http.Response{
+			StatusCode: code,
+			Header:     http.Header{},
+			Body:       &closeTracker{id: id, onClose: func(i int) { closed = append(closed, i) }},
+		}
+		id++
+		return r
+	}
+
+	call := 0
+	resp, err := withRetry(t.Context(), fastRetry, func() (*http.Response, error) {
+		call++
+		if call < 3 {
+			return mkResp(http.StatusServiceUnavailable), nil
+		}
+		return mkResp(http.StatusOK), nil
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	assert.Equal(t, 3, call)
+	assert.Equal(t, []int{0, 1}, closed, "the two retried responses must have their bodies closed")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+}
 
 var fastRetry = RetryConfig{MaxRetries: 3, Interval: 10 * time.Millisecond}
 


### PR DESCRIPTION
## Summary

`withRetry` hands each retryable response (429 / 5xx, or a transport error with a non-nil response) back to `backoff.Retry`, which sleeps and retries — discarding the previous `*http.Response` without closing its body. Only the final response returned to the caller gets a deferred `Close`, so every retried attempt leaked an open body, pinning a pooled TCP connection and leaving a reader goroutine alive until GC. With `ReadRetry`'s three retries, a flaky server could leak up to three connections per request.

## Changes

- `withRetry` remembers the previous attempt's response and drains + closes it at the start of the next attempt, so only the final (returned) response stays open. Draining lets the keep-alive connection be reused.
- Test: a 503 → 503 → 200 sequence asserts the two retried bodies are closed and the final body is the one returned.

## Design Decisions

Cleanup happens at the top of the next attempt (not inside the classify branches) so the final attempt's response is never closed prematurely — on retry exhaustion the caller still receives an open body to pass to `handleErrorResponse`.

## Example

N/A — not user-visible (internal HTTP retry behavior).

## Test Plan

- [x] Unit tests pass (`just unit`) — plus `go test ./api/...`
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no command change
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — internal behavior
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member