### PR TITLE
fix(auth): validate callback state before acting on the result

### DIFF
--- a/internal/browserflow/flow.go
+++ b/internal/browserflow/flow.go
@@ -50,7 +50,7 @@ type Options struct {
 	ErrorTitle   string        // shown on the callback page when GitHub/upstream returns an error
 }
 
-// Result holds the validated callback code; state is checked inside Run and not exposed.
+// Result holds the validated callback code; state is checked in the callback handler and not exposed.
 type Result struct {
 	Code string
 }
@@ -125,6 +125,15 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Content-Security-Policy", "default-src 'self'; script-src 'unsafe-inline'; style-src 'unsafe-inline'")
 
+		// Validate state in the handler so a forged or stray request can't claim the result slot; real errors echo state (RFC 6749).
+		if subtle.ConstantTimeCompare([]byte(raw.state), []byte(opts.State)) != 1 {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = callbackTmpl.Execute(w, struct {
+				Error, ErrorTitle, SuccessTitle, SuccessBody string
+			}{Error: "invalid or expired request", ErrorTitle: errorTitle})
+			return
+		}
+
 		data := struct {
 			Error, ErrorTitle, SuccessTitle, SuccessBody string
 		}{ErrorTitle: errorTitle, SuccessTitle: successTitle, SuccessBody: successBody}
@@ -162,11 +171,9 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 
 	select {
 	case raw := <-resultCh:
+		// state was validated by the handler before raw reached this channel.
 		if raw.errMsg != "" {
 			return nil, fmt.Errorf("authorization denied: %s", raw.errMsg)
-		}
-		if subtle.ConstantTimeCompare([]byte(raw.state), []byte(opts.State)) != 1 {
-			return nil, errors.New("state mismatch: possible CSRF attack")
 		}
 		if raw.code == "" {
 			return nil, errors.New("callback received without code")

--- a/internal/browserflow/flow_test.go
+++ b/internal/browserflow/flow_test.go
@@ -50,8 +50,14 @@ func TestGenerateState(t *testing.T) {
 // hitCallback simulates the browser bouncing back to the callback path.
 func hitCallback(t *testing.T, port int, path, query string) {
 	t.Helper()
+	hitCallbackAfter(t, port, path, query, 50*time.Millisecond)
+}
+
+// hitCallbackAfter hits the callback path after a fixed delay, used to order requests deterministically.
+func hitCallbackAfter(t *testing.T, port int, path, query string, delay time.Duration) {
+	t.Helper()
 	go func() {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(delay)
 		resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d%s?%s", port, path, query))
 		if err != nil {
 			t.Logf("hit callback: %v", err)
@@ -81,23 +87,45 @@ func TestRunCapturesCode(t *testing.T) {
 	assert.Equal(t, "abc123", result.Code)
 }
 
-func TestRunRejectsStateMismatch(t *testing.T) {
+func TestRunIgnoresStateMismatch(t *testing.T) {
 	t.Parallel()
 
 	listener, err := FindAvailableListener()
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
 
+	// A non-matching callback is ignored, so with no valid follow-up Run times out instead of failing fast.
 	hitCallback(t, port, DefaultCallbackPath, "code=abc&state=wrong-state")
 
 	_, err = Run(t.Context(), Options{
 		Listener: listener,
 		State:    "expected-state",
 		OpenURL:  "http://127.0.0.1:" + fmt.Sprint(port) + "/__noop",
-		Timeout:  2 * time.Second,
+		Timeout:  300 * time.Millisecond,
 	})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "state mismatch")
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestRunForgedErrorDoesNotPreemptRealCallback(t *testing.T) {
+	t.Parallel()
+
+	listener, err := FindAvailableListener()
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	// The forged error callback (no state) provably arrives first but must not claim the slot; the real callback wins.
+	hitCallbackAfter(t, port, DefaultCallbackPath, "error=denied", 30*time.Millisecond)
+	hitCallbackAfter(t, port, DefaultCallbackPath, "code=real-code&state=expected-state", 120*time.Millisecond)
+
+	result, err := Run(t.Context(), Options{
+		Listener: listener,
+		State:    "expected-state",
+		OpenURL:  "http://127.0.0.1:" + fmt.Sprint(port) + "/__noop",
+		Timeout:  2 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "real-code", result.Code)
 }
 
 func TestRunSurfacesUpstreamError(t *testing.T) {
@@ -107,7 +135,8 @@ func TestRunSurfacesUpstreamError(t *testing.T) {
 	require.NoError(t, err)
 	port := listener.Addr().(*net.TCPAddr).Port
 
-	hitCallback(t, port, DefaultCallbackPath, "error=access_denied")
+	// A genuine upstream error echoes the state (RFC 6749), so it is honored.
+	hitCallback(t, port, DefaultCallbackPath, "error=access_denied&state=expected-state")
 
 	_, err = Run(t.Context(), Options{
 		Listener: listener,


### PR DESCRIPTION
## Summary

The local OAuth-style callback server (`auth login` PKCE, GitHub App manifest) accepted any GET on the callback path, wrote it into a buffered-1 channel, and `Run` consumed exactly once — so the first request to reach `/callback` decided the outcome, and `Run` returned on the `?error=` branch before validating `state`. During the multi-minute login window, any page the user browses could fire `GET 127.0.0.1:<port>/callback?error=denied` and abort the login the user just approved; a benign prefetch with empty state could do the same accidentally.

## Changes

- State is now validated in the callback handler: a request whose `state` doesn't match gets a generic error page and is not pushed to the result channel, so it cannot claim the single slot. Only a state-matching request (code or error) decides the flow.
- `Run` no longer re-checks state (the handler guarantees it) and keeps the `error`/`code` handling.
- Tests: a forged `?error=` arriving before the real callback no longer preempts it; a state mismatch is ignored (flow waits/times out); a genuine upstream error that echoes `state` (RFC 6749) is still surfaced.

## Design Decisions

A lone non-matching callback is ignored rather than failing fast with "state mismatch", since a real OAuth provider always echoes the original `state`, including on error responses.

## Example

N/A — not user-visible in normal use; hardens `auth login` / connection setup against a forged loopback callback.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched (login flow needs a browser)
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no command change
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — internal auth-flow hardening
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member