### PR TITLE
fix(run): exit non-zero when artifact downloads fail

### DIFF
--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -210,6 +210,22 @@ func TestRunStartDryRunNonExistentJob(T *testing.T) {
 	assert.Contains(T, err.Error(), "not found")
 }
 
+func TestRunDownloadFailsWhenArtifactsFail(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	ts.Handle("GET /app/rest/builds/id:1/artifacts/children", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Artifacts{Count: 2, File: []api.Artifact{
+			{Name: "a.txt", Size: 10, Content: &api.Content{Href: "/a.txt"}},
+			{Name: "b.txt", Size: 20, Content: &api.Content{Href: "/b.txt"}},
+		}})
+	})
+	ts.Handle("GET /app/rest/builds/id:1/artifacts/content/", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.Error(w, http.StatusInternalServerError, "boom")
+	})
+
+	err := cmdtest.CaptureErr(T, ts.Factory, "run", "download", testBuildID, "-o", T.TempDir())
+	assert.Contains(T, err.Error(), "downloaded 0 of 2 artifacts")
+}
+
 func TestRunCancel(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -210,22 +210,6 @@ func TestRunStartDryRunNonExistentJob(T *testing.T) {
 	assert.Contains(T, err.Error(), "not found")
 }
 
-func TestRunDownloadFailsWhenArtifactsFail(T *testing.T) {
-	ts := cmdtest.SetupMockClient(T)
-	ts.Handle("GET /app/rest/builds/id:1/artifacts/children", func(w http.ResponseWriter, r *http.Request) {
-		cmdtest.JSON(w, api.Artifacts{Count: 2, File: []api.Artifact{
-			{Name: "a.txt", Size: 10, Content: &api.Content{Href: "/a.txt"}},
-			{Name: "b.txt", Size: 20, Content: &api.Content{Href: "/b.txt"}},
-		}})
-	})
-	ts.Handle("GET /app/rest/builds/id:1/artifacts/content/", func(w http.ResponseWriter, r *http.Request) {
-		cmdtest.Error(w, http.StatusInternalServerError, "boom")
-	})
-
-	err := cmdtest.CaptureErr(T, ts.Factory, "run", "download", testBuildID, "-o", T.TempDir())
-	assert.Contains(T, err.Error(), "downloaded 0 of 2 artifacts")
-}
-
 func TestRunCancel(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -132,8 +132,6 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 	}
 
 	if downloaded < len(flatList) {
-		// Per-file errors were already printed above; return non-zero so automation
-		// (e.g. `teamcity run download ... && deploy`) doesn't proceed on a partial set.
 		return fmt.Errorf("downloaded %d of %d artifacts", downloaded, len(flatList))
 	}
 

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -131,6 +131,12 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 		downloaded++
 	}
 
+	if downloaded < len(flatList) {
+		// Per-file errors were already printed above; return non-zero so automation
+		// (e.g. `teamcity run download ... && deploy`) doesn't proceed on a partial set.
+		return fmt.Errorf("downloaded %d of %d artifacts", downloaded, len(flatList))
+	}
+
 	_, _ = fmt.Fprintf(p.Out, "\n%s %s downloaded\n", output.Green(output.Sym().Check), english.Plural(downloaded, "artifact", ""))
 	return nil
 }


### PR DESCRIPTION
## Summary

`run download` printed per-file errors and skipped failed artifacts with `continue`, but `runRunDownload` always returned nil — so the process exited 0 even when zero artifacts downloaded because every file failed. A pipeline like `teamcity run download 123 -o ./out && deploy ./out` would proceed with an empty or partial directory, and automation couldn't distinguish complete success from total failure.

## Changes

- `runRunDownload` returns `downloaded %d of %d artifacts` when any artifact did not download, so the exit code reflects the outcome. The per-file `✓`/`✗` lines still print; the green summary line now appears only on full success.
- Test: a build whose artifact content endpoint returns 500 → the command errors with `downloaded 0 of 2 artifacts`.

## Design Decisions

Fail on any shortfall (`downloaded < total`), not only total failure — a partial download is unsafe to feed to a downstream deploy step, and path-escape rejections must surface.

## Example

```bash
teamcity run download 12345 -o ./out && deploy ./out
# now stops at the download step (non-zero exit) if any artifact failed
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — `run download` writes files, not data output
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — exit-code fix; output text unchanged on success
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member