### PR TITLE
fix(auth): report TEAMCITY_TOKEN in status when TEAMCITY_URL is unset

### DIFF
--- a/internal/cmd/auth/auth_test.go
+++ b/internal/cmd/auth/auth_test.go
@@ -137,6 +137,37 @@ teamcity.serverUrl=` + ts.URL + "\n"
 	assert.Equal(T, "bearer", authMethod, "explicit token should take precedence")
 }
 
+func TestAuthStatusEnvTokenWithoutURL(T *testing.T) {
+	ts := cmdtest.NewTestServer(T)
+	T.Setenv("TEAMCITY_GUEST", "")
+	T.Setenv("TEAMCITY_BUILD_PROPERTIES_FILE", "")
+	T.Setenv("TC_INSECURE_SKIP_WARN", "1")
+	config.ResetDSLCache()
+	config.ResetForTest()
+
+	var sawAuth string
+	ts.Handle("GET /app/rest/users/current", func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		cmdtest.JSON(w, api.User{ID: 1, Username: "admin", Name: "Administrator"})
+	})
+	ts.Handle("GET /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Server{VersionMajor: 2025, VersionMinor: 7, BuildNumber: "197398"})
+	})
+
+	cfg := config.Get()
+	cfg.DefaultServer = ts.URL
+	cfg.Servers[ts.URL] = config.ServerConfig{Token: "stored-token", User: "admin", TokenExpiry: "2099-01-01T00:00:00Z"}
+
+	// TEAMCITY_TOKEN set without TEAMCITY_URL: status must report the env token, not the stored one.
+	T.Setenv("TEAMCITY_URL", "")
+	T.Setenv("TEAMCITY_TOKEN", "env-token")
+
+	got := cmdtest.CaptureOutput(T, ts.Factory, "auth", "status", "--json")
+	assert.Contains(T, got, `"token_source": "env"`)
+	assert.Equal(T, "Bearer env-token", sawAuth, "status must probe with the env token, not the stored token")
+	assert.NotContains(T, got, "2099", "stored expiry must not be reported for an env token")
+}
+
 func TestIsBuildEnvironment(T *testing.T) {
 	T.Setenv("TEAMCITY_BUILD_PROPERTIES_FILE", "/some/path")
 	assert.True(T, config.IsBuildEnvironment())

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -89,6 +89,13 @@ func collectAuthStatuses(f *cmdutil.Factory) []authStatus {
 		}
 	}
 
+	// TEAMCITY_TOKEN takes precedence over stored credentials even without TEAMCITY_URL, so report it against the resolved server (matching defaultGetClient).
+	if envToken := os.Getenv(config.EnvToken); envToken != "" && !config.IsGuestAuth() {
+		if serverURL := config.GetServerURL(); serverURL != "" {
+			return []authStatus{collectTokenStatus(f, serverURL, envToken, "env", false)}
+		}
+	}
+
 	if buildAuth, ok := config.GetBuildAuth(); ok {
 		return []authStatus{collectBuildStatus(f, buildAuth)}
 	}
@@ -174,11 +181,14 @@ func collectTokenStatus(f *cmdutil.Factory, serverURL, token, tokenSource string
 	s.Status = "authenticated"
 	s.User = &authUser{ID: user.ID, Username: user.Username, Name: user.Name}
 
-	cfg := config.Get()
-	if sc, ok := cfg.Servers[serverURL]; ok && sc.TokenExpiry != "" {
-		s.TokenExpiry = sc.TokenExpiry
-	} else if expiry := config.GetTokenExpiry(); expiry != "" {
-		s.TokenExpiry = expiry
+	// Stored expiry belongs to the keyring/config token, not an env-provided one.
+	if tokenSource != "env" {
+		cfg := config.Get()
+		if sc, ok := cfg.Servers[serverURL]; ok && sc.TokenExpiry != "" {
+			s.TokenExpiry = sc.TokenExpiry
+		} else if expiry := config.GetTokenExpiry(); expiry != "" {
+			s.TokenExpiry = expiry
+		}
 	}
 
 	if server, err := client.ServerVersion(); err == nil {


### PR DESCRIPTION
## Summary

`auth status` disagreed with what commands actually use. `GetTokenWithSource` (and `defaultGetClient`) honor `TEAMCITY_TOKEN` against the resolved server — including the configured `default_server` — even when `TEAMCITY_URL` is unset, matching the documented resolution order. But `collectAuthStatuses` only treated env auth as active when `TEAMCITY_URL` was *also* set, so a bare `TEAMCITY_TOKEN` fell through to the stored-credential path and reported the keyring/config token's validity while commands sent the env token. A stale `TEAMCITY_TOKEN` (common CI residue) thus made `auth status` say "authenticated via config" while commands failed with the env token.

## Changes

- `collectAuthStatuses` now reports `TEAMCITY_TOKEN` as the active `env` auth against the resolved server (`GetServerURL()`, i.e. `TEAMCITY_URL` or `default_server`) even when `TEAMCITY_URL` is unset, mirroring `defaultGetClient`'s precedence (guest → env token → build → stored).
- Test: with `TEAMCITY_TOKEN` set and `TEAMCITY_URL` unset, `auth status --json` reports `token_source: env` and probes with the env token, not the stored one.

## Design Decisions

The original audit finding proposed the opposite — gating the *client* so `TEAMCITY_TOKEN` is ignored without `TEAMCITY_URL`. That would contradict the documented contract (`teamcity-cli-authentication.md`; `teamcity-cli-configuration.md` "Takes precedence over the keyring and config file token"). The client is correct; the divergence was in `auth status`, so the reporting is fixed to match. This changes only `auth status` output, not which token any command sends.

## Example

```bash
unset TEAMCITY_URL; export TEAMCITY_TOKEN=…   # default_server in config.yml
teamcity auth status --json                   # now shows "token_source": "env"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — `auth status` already supports `--json`
- [x] If modifying `--json` output: no field removals/renames (additive only) — same fields; `token_source` now correctly reports `env`
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — brings `auth status` in line with the already-documented precedence
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member