### PR TITLE
refactor(job): condense cycle-detection comment to one line

### DIFF
--- a/internal/cmd/job/tree.go
+++ b/internal/cmd/job/tree.go
@@ -156,9 +156,7 @@ func buildJobTreeNodes(client api.ClientInterface, jobID string, depth int, reve
 			nodes = append(nodes, node)
 			continue
 		}
-		// Track only the current ancestor path so a node is "circular" solely when
-		// it is its own ancestor; deleting on backtrack lets a re-convergent
-		// (diamond) dependency expand under each parent instead of being dropped.
+		// Track only the current ancestor path (delete on backtrack) so a diamond dep isn't mislabeled circular.
 		visited[bt.ID] = true
 		kids := buildJobTreeNodes(client, bt.ID, next, reverse, visited)
 		delete(visited, bt.ID)


### PR DESCRIPTION
## Summary

Follow-up tidy: the cycle-detection comment in `buildJobTreeNodes` (added in #342) spanned three lines. Condense it to one, matching the repo's one-line-comment convention.

## Changes

- One-line the ancestor-path comment in `internal/cmd/job/tree.go`. No code change.

## Design Decisions

Straightforward.

## Example

N/A — comment-only.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`) — `gofmt`/`go vet` clean
- [ ] Acceptance tests pass (`just acceptance`) — N/A — comment-only
- [ ] If adding a new command/flag: added `.txtar` test — N/A — comment-only
- [ ] If adding a data-producing command: includes `--json` support — N/A — comment-only
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — comment-only
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member