### PR TITLE
fix(api): stop nested TeamCity from cancelling integration test builds

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -57,11 +57,8 @@ func requireIdleAgent(t *testing.T) api.Agent {
 		}
 		running, _, _ := client.GetBuilds(t.Context(), api.BuildsOptions{State: "running", Limit: 10})
 		queued, _, _ := client.GetBuildQueue(api.QueueOptions{Limit: 10})
-		if running != nil {
-			for _, b := range running.Builds {
-				_ = client.CancelBuild(fmt.Sprintf("%d", b.ID), "test cleanup")
-			}
-		}
+		// Cancel queued strays only; cancelling a running build can get the whole
+		// agent unregistered ("Agent runs unknown build"), dropping other builds.
 		if queued != nil {
 			for _, b := range queued.Builds {
 				_ = client.CancelBuild(fmt.Sprintf("%d", b.ID), "test cleanup")
@@ -80,6 +77,12 @@ func requireIdleAgent(t *testing.T) api.Agent {
 		}
 		if detail.Build != nil {
 			t.Logf("requireIdleAgent: agent %d still has build %d, waiting...", detail.ID, detail.Build.ID)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		// A pending auto-upgrade restarts the agent at its next idle moment — wait it out.
+		if ok, err := agentsUpToDate(client, 1); err == nil && !ok {
+			t.Logf("requireIdleAgent: agent %d has a pending auto-upgrade, waiting...", detail.ID)
 			time.Sleep(2 * time.Second)
 			continue
 		}
@@ -1191,16 +1194,11 @@ func TestRebootAgentCancelledContext(T *testing.T) {
 	skipIfGuest(T)
 	T.Parallel()
 
-	agents, _, err := client.GetAgents(api.AgentsOptions{})
-	require.NoError(T, err)
-	if len(agents.Agents) == 0 {
-		T.Skip("no agents available")
-	}
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	err = client.RebootAgent(ctx, agents.Agents[0].ID, false)
+	// Bogus ID: the request must never be sent, and must never reboot the real agent.
+	err := client.RebootAgent(ctx, 99999, false)
 	assert.Error(T, err, "should error with cancelled context")
 }
 
@@ -1292,28 +1290,40 @@ func TestAgentOperations(T *testing.T) {
 
 func TestWaitForBuild_Integration(T *testing.T) {
 	skipIfGuest(T)
-	requireIdleAgent(T)
 
-	build, err := client.RunBuild(testConfig, api.RunBuildOptions{
-		Comment: "WaitForBuild integration test",
-	})
-	require.NoError(T, err)
-	buildID := fmt.Sprintf("%d", build.ID)
-	T.Logf("Queued build #%d, waiting for completion...", build.ID)
-
-	ctx, cancel := context.WithTimeout(T.Context(), 5*time.Minute)
-	defer cancel()
-
+	// Retry once: cancellation tests can briefly unregister the only agent
+	// ("Agent runs unknown build"), which cancels in-flight builds (UNKNOWN).
+	var result *api.Build
 	var progressCalls int
-	result, err := client.WaitForBuild(ctx, buildID, api.WaitForBuildOptions{
-		Interval: 3 * time.Second,
-		OnProgress: func(state, status string, percent int) error {
-			progressCalls++
-			T.Logf("  poll #%d: state=%s status=%s percent=%d", progressCalls, state, status, percent)
-			return nil
-		},
-	})
-	require.NoError(T, err)
+	for attempt := range 2 {
+		if attempt > 0 {
+			T.Logf("Build was canceled by the environment, retrying...")
+		}
+		requireIdleAgent(T)
+
+		build, err := client.RunBuild(testConfig, api.RunBuildOptions{
+			Comment: "WaitForBuild integration test",
+		})
+		require.NoError(T, err)
+		buildID := fmt.Sprintf("%d", build.ID)
+		T.Logf("Queued build #%d, waiting for completion...", build.ID)
+
+		ctx, cancel := context.WithTimeout(T.Context(), 5*time.Minute)
+		progressCalls = 0
+		result, err = client.WaitForBuild(ctx, buildID, api.WaitForBuildOptions{
+			Interval: 3 * time.Second,
+			OnProgress: func(state, status string, percent int) error {
+				progressCalls++
+				T.Logf("  poll #%d: state=%s status=%s percent=%d", progressCalls, state, status, percent)
+				return nil
+			},
+		})
+		cancel()
+		require.NoError(T, err)
+		if result.Status != "UNKNOWN" {
+			break
+		}
+	}
 
 	assert.Equal(T, "finished", result.State)
 	assert.Equal(T, "SUCCESS", result.Status)

--- a/api/sandbox_test.go
+++ b/api/sandbox_test.go
@@ -59,10 +59,12 @@ exec "$@"
 `), 0o755))
 
 	sandboxCmd := func(env []string, args ...string) *exec.Cmd {
-		full := []string{"@anthropic-ai/sandbox-runtime", "-s", settings, wrapper}
+		// Pin the version so CI doesn't float with srt releases; SRT_DEBUG streams
+		// seatbelt violations to stderr so proxy EPERM failures are diagnosable.
+		full := []string{"-y", "@anthropic-ai/sandbox-runtime@0.0.54", "-s", settings, wrapper}
 		full = append(full, args...)
 		cmd := exec.Command(npx, full...)
-		cmd.Env = append(os.Environ(), env...)
+		cmd.Env = append(os.Environ(), append([]string{"SRT_DEBUG=1"}, env...)...)
 		return cmd
 	}
 

--- a/api/testenv_test.go
+++ b/api/testenv_test.go
@@ -4,6 +4,7 @@ package api_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -30,6 +31,10 @@ const (
 	serverName  = "tc-test-server"
 	numAgents   = 1
 )
+
+// alwaysPull re-pulls both :latest images on CI agents (TEAMCITY_VERSION is set
+// there) so a stale Docker cache can't produce a server/agent version skew.
+var alwaysPull = os.Getenv("TEAMCITY_VERSION") != ""
 
 type testEnv struct {
 	Client    *api.Client
@@ -191,15 +196,20 @@ func startContainers() (*testEnv, error) {
 	log.Println("Starting TeamCity server...")
 	env.server, err = testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Name:         serverName,
-			Image:        serverImage,
-			ExposedPorts: []string{"8111/tcp"},
-			Networks:     []string{env.network.Name},
+			Name:            serverName,
+			Image:           serverImage,
+			AlwaysPullImage: alwaysPull,
+			ExposedPorts:    []string{"8111/tcp"},
+			Networks:        []string{env.network.Name},
 			NetworkAliases: map[string][]string{
 				env.network.Name: {"teamcity-server"},
 			},
 			Env: map[string]string{
-				"TEAMCITY_SERVER_OPTS": "-Dteamcity.installation.completed=true -Dteamcity.startup.maintenance=false -Dteamcity.licenseAgreement.accepted=true -Dteamcity.internal.server.oauth.pkce.enable=true",
+				// Skip post-boot bundled-tool installs (each changes the agent
+				// distribution signature, triggering an auto-upgrade that restarts the
+				// agent mid-suite and cancels its builds) and widen the 120s inactivity
+				// window that unregisters agents missing polls under -race load.
+				"TEAMCITY_SERVER_OPTS": "-Dteamcity.installation.completed=true -Dteamcity.startup.maintenance=false -Dteamcity.licenseAgreement.accepted=true -Dteamcity.internal.server.oauth.pkce.enable=true -Dteamcity.tools.bundled.installOnStartup=false -Dteamcity.agent.inactive.threshold.secs=600",
 			},
 			WaitingFor: wait.ForHTTP("/app/rest/server/version").
 				WithPort("8111/tcp").
@@ -256,11 +266,12 @@ func startContainers() (*testEnv, error) {
 			name := fmt.Sprintf("tc-test-agent-%d", idx+1)
 			c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 				ContainerRequest: testcontainers.ContainerRequest{
-					Name:       name,
-					Image:      agentImage,
-					Networks:   []string{env.network.Name},
-					Env:        map[string]string{"SERVER_URL": "http://teamcity-server:8111"},
-					Privileged: true,
+					Name:            name,
+					Image:           agentImage,
+					AlwaysPullImage: alwaysPull,
+					Networks:        []string{env.network.Name},
+					Env:             map[string]string{"SERVER_URL": "http://teamcity-server:8111"},
+					Privileged:      true,
 					ConfigModifier: func(cfg *container.Config) {
 						cfg.Tty = true
 						cfg.OpenStdin = true
@@ -451,12 +462,45 @@ func waitForAgents(client *api.Client, count int) error {
 			}
 		}
 		if len(authorized) >= count {
-			log.Printf("All %d agents authorized", count)
-			return nil
+			// A freshly registered agent gets an "upgrade" order when its plugins
+			// differ from the server's distribution; the upgrade restarts the agent
+			// at its next idle moment, so absorb it before tests queue builds.
+			if ok, err := agentsUpToDate(client, count); ok {
+				log.Printf("All %d agents authorized and up-to-date", count)
+				return nil
+			} else if err == nil {
+				log.Printf("Agents authorized, waiting for pending auto-upgrade...")
+			}
 		}
 		time.Sleep(5 * time.Second)
 	}
-	return fmt.Errorf("agent timeout: got %d of %d", len(authorized), count)
+	return fmt.Errorf("agent timeout: got %d of %d authorized and up-to-date", len(authorized), count)
+}
+
+// agentsUpToDate reports whether count authorized agents are connected with no pending auto-upgrade.
+func agentsUpToDate(client *api.Client, count int) (bool, error) {
+	resp, err := client.RawRequest(context.Background(), "GET",
+		"/app/rest/agents?locator=authorized:true&fields=count,agent(id,connected,uptodate)", nil, nil)
+	if err != nil {
+		return false, err
+	}
+	var list struct {
+		Agents []struct {
+			ID        int  `json:"id"`
+			Connected bool `json:"connected"`
+			Uptodate  bool `json:"uptodate"`
+		} `json:"agent"`
+	}
+	if err := json.Unmarshal(resp.Body, &list); err != nil {
+		return false, err
+	}
+	ready := 0
+	for _, a := range list.Agents {
+		if a.Connected && a.Uptodate {
+			ready++
+		}
+	}
+	return ready >= count, nil
 }
 
 func setServerURL(serverURL, superToken, internalURL string) {


### PR DESCRIPTION
## Summary

Integration tests on cli.teamcity.com (macOS and Linux) intermittently fail with builds finishing `UNKNOWN` (`TestWaitForBuild_Integration`, `TestBuildLevelAuth`, e.g. run 12328). Reproduced locally by looping the unmodified suite; three causes, all observable in the nested server/agent logs, each one masked by the previous: 
1. the fresh server installs bundled tools (ReSharper CLT, a >1GB IntelliJ IDEA download) for minutes after boot, and every install changes the agent distribution signature, triggering an agent auto-upgrade that restarts the agent mid-suite and cancels its builds; 
2. under `-race` load the agent misses polls past the 120s inactivity default and gets unregistered ("Could not connect to build agent"); 
3. cancelling a *running* build makes the server forget it before the agent does, and the agent's next poll mentioning it gets the agent unregistered ("Agent runs unknown build we're not aware of") — `requireIdleAgent`'s own cleanup cancels were feeding this.

## Changes

- testenv: `-Dteamcity.tools.bundled.installOnStartup=false` and `-Dteamcity.agent.inactive.threshold.secs=600` on the nested server; `AlwaysPullImage` on CI agents so `:latest` server/agent images can't skew
- testenv: `waitForAgents` also waits for REST `uptodate`, absorbing the registration-time upgrade before tests queue builds
- `requireIdleAgent`: cancel queued strays only, wait for running builds instead of cancelling them; also wait out a pending auto-upgrade
- `TestWaitForBuild_Integration`: one logged retry when the build comes back `UNKNOWN` (same absorption `TestBuildLevelAuth` already has)
- `TestRebootAgentCancelledContext`: bogus agent ID, so the cancelled-context request can never reboot the suite's only agent
- sandbox (macOS): pin `sandbox-runtime@0.0.54` and set `SRT_DEBUG=1` so the recurring proxy-dial EPERM carries seatbelt-violation evidence in the failure output

## Design Decisions

Disabling agent upgrades outright was tested and rejected: `teamcity.agentsUpgrade.enabled=false` makes the server unregister-loop not-up-to-date agents, and `teamcity.agent.disable.autoupgrade=true` silently never schedules builds on version-skewed agents. Keeping upgrades enabled and removing the things that re-trigger them (tool installs, image skew) is the stable combination. Verified locally: 5/5 full-suite runs green (2 with a deliberately stale agent image, 3 matched), where unmodified code failed within 4 iterations.

## Example

N/A — not user-visible (test environment only).

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A: no CLI changes; integration suite run 5x locally instead
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A
