### PR TITLE
Added instructions on working with teamcity.toml and the link command to the agent skill

### DIFF
--- a/evals/checks.py
+++ b/evals/checks.py
@@ -6,6 +6,8 @@ Checks are referenced by ID in tasks.json.
 
 from __future__ import annotations
 
+import re
+
 from scaffold.runner import EvalRunner
 
 # ---------------------------------------------------------------------------
@@ -321,23 +323,28 @@ def checked_repository_link(runner: EvalRunner) -> None:
 
 
 def added_repository_link(runner: EvalRunner) -> None:
-    if runner.has_command("teamcity", "link"):
+    if any(_has_repository_link_command(cmd) for cmd in runner.commands):
         runner.passed("Linked the repository to a TeamCity job / project")
     else:
         runner.failed("Did not link the repository to a TeamCity job / project")
 
 
 def added_repository_link_with_project_only(runner: EvalRunner) -> None:
+    project_flag = re.compile(r"(^|\s)(--project|-p)(\s|=)")
+    job_flag = re.compile(r"(^|\s)(--job|-j)(\s|=)")
     for cmd in runner.commands:
-        c = cmd.lower()
-        if "teamcity link" in c and ("--project " in c or " -p " in c) and ("--job " not in c and " -j " not in c):
+        if (
+            _has_repository_link_command(cmd) and
+            project_flag.search(cmd) and
+            not job_flag.search(cmd)
+        ):
             runner.passed("Linked the repository using only the project argument")
             return
     runner.failed("Did not link the repository using only the project argument")
 
 
 def did_not_add_repository_link(runner: EvalRunner) -> None:
-    if runner.has_command("teamcity", "link"):
+    if any(_has_repository_link_command(cmd) for cmd in runner.commands):
         runner.failed("Linked the repository to a TeamCity job / project")
     else:
         runner.passed("Did not link the repository to a TeamCity job / project")
@@ -382,18 +389,28 @@ def did_not_modify_teamcity_toml(runner: EvalRunner) -> None:
 
 
 def used_project_from_repository_link(runner: EvalRunner) -> None:
-    missing_linked_project = "No project found by name or internal/external id 'Project_uipBGpvQua'"
+    linked_project = "No project found by name or internal/external id 'Project_uipBGpvQua'"
     for result in runner.events.tool_results.values():
         content = result.get("content", "")
-        if isinstance(content, str) and missing_linked_project in content:
+        if isinstance(content, str) and linked_project in content:
             runner.passed("Used project from teamcity.toml")
             return
         if isinstance(content, list):
             for block in content:
-                if isinstance(block, dict) and missing_linked_project in block.get("text", ""):
+                if isinstance(block, dict) and linked_project in block.get("text", ""):
                     runner.passed("Used project from teamcity.toml")
                     return
     runner.failed("Did not use project from teamcity.toml")
+
+
+_LINK_INVOCATION = re.compile(r"(?:^|[;&|]\s*)(teamcity\s+link(?:\s+[^;&|]+)*)", re.IGNORECASE)
+_HELP_FLAG = re.compile(r"(^|\s)(--help|-h)(\s|$)")
+
+def _has_repository_link_command(cmd: str) -> bool:
+    return any(
+        not _HELP_FLAG.search(match.group(1))
+        for match in _LINK_INVOCATION.finditer(cmd)
+    )
 
 # ---------------------------------------------------------------------------
 # cross-project

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -6,8 +6,6 @@ Checks are referenced by ID in tasks.json.
 
 from __future__ import annotations
 
-import re
-
 from scaffold.runner import EvalRunner
 
 # ---------------------------------------------------------------------------
@@ -19,7 +17,7 @@ VALID_SUBCOMMANDS = {
     "run": [
         "list", "view", "start", "cancel", "restart", "watch", "log",
         "tests", "changes", "artifacts", "download", "pin", "unpin",
-        "tag", "untag", "comment",
+        "tag", "untag", "comment", "tree",
     ],
     "job": ["list", "view", "tree", "pause", "resume", "param"],
     "project": ["list", "view", "tree", "param", "token", "settings"],
@@ -30,6 +28,7 @@ VALID_SUBCOMMANDS = {
     ],
     "pool": ["list", "view", "link", "unlink"],
     "api": [],
+    "link": [],
     "alias": ["set", "list", "delete"],
     "skill": ["install", "update", "remove"],
 }
@@ -310,6 +309,93 @@ def uses_run_not_build(runner: EvalRunner) -> None:
 
 
 # ---------------------------------------------------------------------------
+# repository binding
+# ---------------------------------------------------------------------------
+
+def checked_repository_link(runner: EvalRunner) -> None:
+    read_files = [p for p in runner.events.files_read if p.endswith("teamcity.toml")]
+    if read_files or runner.has_command("teamcity.toml"):
+        runner.passed("Checked teamcity.toml")
+    else:
+        runner.failed("Did not check for an existing teamcity.toml binding")
+
+
+def added_repository_link(runner: EvalRunner) -> None:
+    if runner.has_command("teamcity", "link"):
+        runner.passed("Linked the repository to a TeamCity job / project")
+    else:
+        runner.failed("Did not link the repository to a TeamCity job / project")
+
+
+def added_repository_link_with_project_only(runner: EvalRunner) -> None:
+    for cmd in runner.commands:
+        c = cmd.lower()
+        if "teamcity link" in c and ("--project " in c or " -p " in c) and ("--job " not in c and " -j " not in c):
+            runner.passed("Linked the repository using only the project argument")
+            return
+    runner.failed("Did not link the repository using only the project argument")
+
+
+def did_not_add_repository_link(runner: EvalRunner) -> None:
+    if runner.has_command("teamcity", "link"):
+        runner.failed("Linked the repository to a TeamCity job / project")
+    else:
+        runner.passed("Did not link the repository to a TeamCity job / project")
+
+
+def mentioned_teamcity_toml(runner: EvalRunner) -> None:
+    if runner.has_text("teamcity.toml"):
+        runner.passed("Mentioned teamcity.toml")
+    else:
+        runner.failed("Did not mention the teamcity.toml binding file")
+
+
+def did_not_modify_teamcity_toml(runner: EvalRunner) -> None:
+    modified = [
+        p for p in runner.events.files_created + runner.events.files_modified
+        if p.endswith("teamcity.toml")
+    ]
+    obvious_writes = (
+        "> teamcity.toml",
+        "> ./teamcity.toml",
+        ">teamcity.toml",
+        ">./teamcity.toml",
+        ">> teamcity.toml",
+        ">> ./teamcity.toml",
+        ">>teamcity.toml",
+        ">>./teamcity.toml",
+        "tee teamcity.toml",
+        "tee ./teamcity.toml",
+        "tee -a teamcity.toml",
+        "tee -a ./teamcity.toml",
+        "sed -i",
+        "perl -pi",
+    )
+    suspicious_shell = [
+        c for c in runner.commands
+        if "teamcity.toml" in c.lower() and any(pattern in c.lower() for pattern in obvious_writes)
+    ]
+    if modified or suspicious_shell:
+        runner.failed("Modified the teamcity.toml file manually")
+    else:
+        runner.passed("Did not modify teamcity.toml")
+
+
+def used_project_from_repository_link(runner: EvalRunner) -> None:
+    missing_linked_project = "No project found by name or internal/external id 'Project_uipBGpvQua'"
+    for result in runner.events.tool_results.values():
+        content = result.get("content", "")
+        if isinstance(content, str) and missing_linked_project in content:
+            runner.passed("Used project from teamcity.toml")
+            return
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and missing_linked_project in block.get("text", ""):
+                    runner.passed("Used project from teamcity.toml")
+                    return
+    runner.failed("Did not use project from teamcity.toml")
+
+# ---------------------------------------------------------------------------
 # cross-project
 # ---------------------------------------------------------------------------
 
@@ -516,6 +602,14 @@ CHECK_REGISTRY: dict[str, callable] = {
     "filters_by_project": filters_by_project,
     "uses_json": uses_json,
     "uses_run_not_build": uses_run_not_build,
+    # repository binding
+    "checked_repository_link": checked_repository_link,
+    "added_repository_link": added_repository_link,
+    "added_repository_link_with_project_only": added_repository_link_with_project_only,
+    "mentioned_teamcity_toml": mentioned_teamcity_toml,
+    "did_not_add_repository_link": did_not_add_repository_link,
+    "did_not_modify_teamcity_toml": did_not_modify_teamcity_toml,
+    "used_project_from_repository_link": used_project_from_repository_link,
     # cross-project
     "finds_subprojects": finds_subprojects,
     "lists_jobs": lists_jobs,

--- a/evals/scaffold/claude.py
+++ b/evals/scaffold/claude.py
@@ -9,6 +9,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from string import Template
 
 # Claude binary path. Set CLAUDE_BIN env var in CI if claude isn't on PATH.
 _CLAUDE_BIN = os.environ.get("CLAUDE_BIN") or shutil.which("claude") or "claude"
@@ -65,12 +66,20 @@ def _copy_auth_config(work_dir: Path) -> None:
 def _setup_workspace(
     work_dir: Path,
     treatment: Treatment,
+    setup_files: dict[str, str] | None = None,
 ) -> None:
     """Write skill files and auth config into the workspace."""
     _copy_auth_config(work_dir)
     if treatment.skill_dir and treatment.skill_dir.exists():
         dest = work_dir / ".claude" / "skills" / "teamcity-cli"
         shutil.copytree(treatment.skill_dir, dest)
+    for rel_path, content in (setup_files or {}).items():
+        if Path(rel_path).is_absolute():
+            raise ValueError(f"setup file path must be relative: {rel_path}")
+        path = work_dir / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        values = {k: os.environ.get(k, "") for k in _PROPAGATE_KEYS}
+        path.write_text(Template(content).safe_substitute(values))
 
 
 def _build_isolated_env(work_dir: Path) -> dict[str, str]:
@@ -112,13 +121,14 @@ def run_claude(
     *,
     model: str | None = None,
     timeout: int = 600,
+    setup_files: dict[str, str] | None = None,
 ) -> ClaudeResult:
     """Run Claude Code CLI locally in a temp directory with isolated config."""
     model = model or os.environ.get("BENCH_CC_MODEL", "claude-sonnet-4-5-20250929")
 
     with tempfile.TemporaryDirectory(prefix="tc-eval-") as tmp:
         work_dir = Path(tmp)
-        _setup_workspace(work_dir, treatment)
+        _setup_workspace(work_dir, treatment, setup_files)
         env = _build_isolated_env(work_dir)
 
         cmd = [
@@ -162,13 +172,14 @@ def run_claude_docker(
     model: str | None = None,
     timeout: int = 600,
     image: str = "tc-skill-eval",
+    setup_files: dict[str, str] | None = None,
 ) -> ClaudeResult:
     """Run Claude Code CLI inside a Docker container (fully isolated)."""
     model = model or os.environ.get("BENCH_CC_MODEL", "claude-sonnet-4-5-20250929")
 
     with tempfile.TemporaryDirectory(prefix="tc-eval-") as tmp:
         work_dir = Path(tmp)
-        _setup_workspace(work_dir, treatment)
+        _setup_workspace(work_dir, treatment, setup_files)
 
         env_flags: list[str] = []
         for key in _PROPAGATE_KEYS:

--- a/evals/scaffold/tasks.py
+++ b/evals/scaffold/tasks.py
@@ -16,6 +16,7 @@ class TaskConfig:
     checks: list[str] = field(default_factory=list)
     llm_grade: bool = False
     default_treatments: list[str] = field(default_factory=lambda: ["CONTROL", "CURRENT"])
+    setup_files: dict[str, str] = field(default_factory=dict)
 
 
 def _load_all() -> list[dict]:
@@ -32,6 +33,7 @@ def load_task(task_name: str) -> TaskConfig:
                 checks=t.get("checks", []),
                 llm_grade=t.get("llm_grade", False),
                 default_treatments=t.get("treatments", ["CONTROL", "CURRENT"]),
+                setup_files=t.get("setup_files", {}),
             )
     raise KeyError(f"Task '{task_name}' not found in {TASKS_FILE}")
 

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -2,41 +2,49 @@
   {
     "id": "investigate-failure",
     "prompt": "Find a recent failed build on this TeamCity server and investigate what went wrong.\n\nTell me:\n1. Which build failed and in which job\n2. What the build log says about the failure\n3. Which tests failed (if any)\n4. What changes triggered the build",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "found_failed_build", "viewed_log", "viewed_tests", "viewed_changes", "produced_diagnosis", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "found_failed_build", "viewed_log", "viewed_tests", "viewed_changes", "produced_diagnosis", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "daily-loop",
     "prompt": "Show me the last 5 builds on the `master` branch and check if any of them failed.\n\nFor any failure you find:\n1. Show me the failure details and what tests broke\n2. Tell me what changes went into that build",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "lists_builds", "investigates_failure", "views_changes", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "lists_builds", "investigates_failure", "views_changes", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "composite-failure",
     "prompt": "The job `ijplatform_master_Idea_Test_Ultimate_Aggregator` is a composite build with many snapshot dependencies. Find its most recent failed run, then:\n\n1. Show me the dependency tree for this job\n2. Find which child build(s) actually failed\n3. Get the test failures from those child builds",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "multi_step", "no_thrashing", "provides_diagnosis", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "provides_diagnosis", "added_repository_link", "mentioned_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "inspect-url",
     "prompt": "What's going on with this build configuration? Show me recent builds and their status.\n\nhttps://buildserver.labs.intellij.net/buildConfiguration/ijplatform_master_CIDR_CLion_CLionTrunkHeavyTests_TestsUbuntu2404x86_64",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "executes_commands", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "added_repository_link", "mentioned_teamcity_toml", "executes_commands", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "find-builds",
     "prompt": "Find the 10 most recent failed builds in the JetBrains Runtime project (project ID: JBR). Give me their IDs, statuses, and branch names in JSON format.",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "added_repository_link", "added_repository_link_with_project_only", "mentioned_teamcity_toml", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "cross-project",
     "prompt": "I'm trying to understand the CI setup for the CEF/JCEF part of JetBrains Runtime. Can you:\n\n1. Find the JCEF-related subprojects under JetBrains Runtime\n2. List the build jobs in those projects\n3. Show me the recent build history — are things generally green or are there frequent failures?\n4. Find if there are any builds currently in the queue for these projects\n\nGive me a summary of the CI health for this area.",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_subprojects", "lists_jobs", "views_build_history", "checks_queue", "provides_health_summary", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "finds_subprojects", "lists_jobs", "views_build_history", "checks_queue", "provides_health_summary", "added_repository_link", "added_repository_link_with_project_only", "mentioned_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "explore-infrastructure",
     "prompt": "I'm new to this TeamCity server. Can you give me an overview?\n\n1. What top-level projects are there?\n2. How many agent pools exist and what are the main ones?\n3. Show me the project hierarchy tree for the JetBrains Runtime project",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "lists_projects", "lists_pools", "shows_tree", "provides_overview", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "lists_projects", "lists_pools", "shows_tree", "provides_overview", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"]
+  },
+  {
+    "id": "use-repository-link",
+    "prompt": "When did the last build finish?",
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "used_project_from_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"],
+    "setup_files": {
+      "teamcity.toml": "[[server]]\nurl = \"${TEAMCITY_URL}\"\nproject = \"Project_uipBGpvQua\"\njob = \"FooJob\"\n"
+    }
   },
   {
     "id": "hallucination-resistance",

--- a/evals/tests/test_tasks.py
+++ b/evals/tests/test_tasks.py
@@ -48,6 +48,7 @@ def test_task(
         treatment=treatment_config,
         model=model,
         timeout=timeout,
+        setup_files=task_config.setup_files,
     )
 
     # --- Parse events ---

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -6,6 +6,14 @@ description: Use when working with TeamCity CI/CD or when a user provides a Team
 
 # TeamCity CLI (`teamcity`)
 
+## Mandatory rules
+
+- **Do not guess flags or syntax.** Use the [command reference](references/commands.md) or `teamcity <command> --help`. Builds are **runs** (`teamcity run`); build configurations are **jobs** (`teamcity job`). Never use `--count` — use `--limit` (or `-n`).
+- **Always check the repository binding before TeamCity work.** Before executing any `teamcity` command, inspect the binding in `teamcity.toml`. Use the linked project/job unless the user explicitly supplied a different project, job, or URL. The binding is scoped by server and optional path; `jobs` can contain multiple jobs relevant to the repository.
+- **Create or complete the repository binding only for scoped work, and do it before the final answer.** Scoped work means the user supplied a project id/name, job id/name, TeamCity URL, or asks about a specific project area. If `teamcity.toml` is missing or lacks that target, run the ["teamcity link" command](references/commands.md#link-teamcity-link); this is required even when the investigation itself is already done. For project-wide tasks, run `teamcity link --project <project-id> --no-input`. For job-specific tasks, run `teamcity link --project <project-id> --job <job-id> --no-input` when both are known, or `teamcity link --job <job-id> --no-input` if only the job is known. For a TeamCity URL, use the URL's server with `--server <url>` if the active server may differ.
+- **Do not create repository bindings for server-wide work.** For broad tasks such as finding recent builds, listing projects, listing pools, or giving a server overview, check `teamcity.toml` but do not run `teamcity link`. Do not bind a random failed job or sample project inspected as part of a broad overview.
+- **Do not manually edit `teamcity.toml`.** Use `teamcity link` only. If a repository binding exists, do not overwrite it unless specifically asked by the user; it is permissible to add the missing project or job id. Mention both `teamcity.toml` and any `teamcity link` command you ran in the final answer.
+
 ## Quick Start
 
 ```bash
@@ -13,8 +21,6 @@ teamcity auth status                    # Check authentication
 teamcity run list --status failure      # Find failed builds
 teamcity run log <id> --failed --raw    # Full failure diagnostics
 ```
-
-**Do not guess flags or syntax.** Use the [command reference](references/commands.md) or `teamcity <command> --help`. Builds are **runs** (`teamcity run`); build configurations are **jobs** (`teamcity job`). Never use `--count` — use `--limit` (or `-n`).
 
 ## Gotchas
 

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -12,6 +12,7 @@
 - Pipelines (`teamcity pipeline`)
 - Configuration (`teamcity config`)
 - Direct API (`teamcity api`)
+- Link (`teamcity link`)
 - Global Flags
 - List Output Flags
 
@@ -523,6 +524,33 @@ teamcity api '/app/rest/builds/id:BUILD_ID/artifacts/children/SUBPATH'
 - `--raw` - Output raw response without formatting
 - `--silent` - Suppress output on success
 - `-i, --include` - Include response headers in output
+
+## Link (`teamcity link`)
+
+Binds a Git repository to a TeamCity project or job by creating or updating the `teamcity.toml` file at the repo root. When invoked from a repository subdirectory, the command upserts a binding that is applied to commands run from that directory. This can be used in a monorepo for binding specific subdirectories to specific jobs.
+
+**Bind the current repository to a job and project:**
+```bash
+# Bind the current repository to a job and project
+teamcity link --project ProjectA --job JobA
+
+# Bind the current repository to a project, specifying multiple jobs of interest
+teamcity link --project ProjectA --jobs JobA,JobB
+
+# Bind the current repository to a project, specifying the scope
+teamcity link --project ProjectA --scope /services/api
+
+# Bind the current repository to a job, specifying the server:
+teamcity link --job JobA --server https://nightly.example
+```
+
+### Flags
+
+- `--project <id>` - Specifies the project for the binding
+- `--job <id>` - Specifies the job for the binding
+- `--jobs <id1,id2>` - Specifies jobs of interest stored separately from the main binding job
+- `--server <url>` - When multiple servers are authenticated, can be used to specify the server for which the binding is upserted
+- `--scope <path>` - Upserts a binding for a specific directory. If the value is an empty string, upserts the binding for the repository root.
 
 ## Global Flags
 

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -7,6 +7,7 @@
 - Starting and monitoring builds
 - Personal builds (local changes)
 - Finding jobs and projects
+- Binding a repository to a job or a project
 - Working with build artifacts
 - Build metadata (pin/unpin, tag, comment)
 - Managing the build queue
@@ -220,6 +221,23 @@ teamcity job view <job-id>
 **Search for a job by name:**
 ```bash
 teamcity job list --json | jq '.[] | select(.name | contains("deploy"))'
+```
+
+## Binding a repository to a job or a project
+
+**Bind the current repository to a job and project:**
+```bash
+teamcity link --project ProjectA --job JobA
+```
+
+**Bind the current repository to a project, specifying the scope:**
+```bash
+teamcity link --project ProjectA --scope /services/api
+```
+
+**Bind the current repository to a job, specifying the server:**
+```bash
+teamcity link --job JobA --server https://nightly.example
 ```
 
 ## Working with Build Artifacts


### PR DESCRIPTION
<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->

## Summary

Instructions on working with `teamcity.toml` and the `link` command are added to the agent skill. Evals are updated and expanded to check the new requirements.

## Changes

- `SKILL.md`, `commands.md`, `workflows.md` – instructions on working with `teamcity.toml` and the `link` command.
- `evals/task.json`, `evals/checks.py` – updated evals, added one new eval to check if the repository binding is being used.
- Other files undes `evals/` – changes that make it possible to setup evals with files.

## Design Decisions

Added a "Mandatory rules" section at the top of `SKILL.md` to force agents to adhere to the new rule.

## Example

N/A — not user-visible.

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`. N/A — no applicable changes.
- [ ] If adding a data-producing command: includes `--json` support. N/A — no applicable changes.
- [ ] If modifying `--json` output: no field removals/renames (additive only). N/A — no applicable changes.
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`. N/A — no applicable changes.
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change). N/A — no applicable changes.