### PR TITLE
fix(alias): give shell alias subprocesses the raw stdio streams

### DIFF
--- a/internal/cmd/alias/expand.go
+++ b/internal/cmd/alias/expand.go
@@ -92,11 +92,13 @@ func newShellAliasCmd(f *cmdutil.Factory, name, expansion string) *cobra.Command
 				return nil
 			}
 			expanded := expandShellArgs(expansion, args)
+			output.StopSpinner() // the subprocess writes to the raw fds, never through the spinner-clearing stopWriter
 			//nolint:gosec // shell aliases are user-defined, intentional shell execution
 			c := exec.Command("sh", "-c", expanded)
+			// IOStreams, not Printer: Printer wraps stdout/stderr in a non-*os.File writer, which makes os/exec substitute pipes and the subprocess lose the TTY (no color/width, risk of Wait hanging on inherited pipe fds).
 			c.Stdin = f.IOStreams.In
-			c.Stdout = f.Printer.Out
-			c.Stderr = f.Printer.ErrOut
+			c.Stdout = f.IOStreams.Out
+			c.Stderr = f.IOStreams.ErrOut
 			return c.Run()
 		},
 	}

--- a/internal/cmd/alias/expand_test.go
+++ b/internal/cmd/alias/expand_test.go
@@ -1,11 +1,32 @@
 package alias
 
 import (
+	"bytes"
+	"runtime"
+	"strings"
 	"testing"
 
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestShellAliasUsesRawStreams(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+	var rawOut, rawErr, wrapped bytes.Buffer
+	f := &cmdutil.Factory{
+		IOStreams: &cmdutil.IOStreams{In: strings.NewReader(""), Out: &rawOut, ErrOut: &rawErr},
+		Printer:   &output.Printer{Out: &wrapped, ErrOut: &wrapped},
+	}
+	cmd := newShellAliasCmd(f, "greet", "echo hi; echo err >&2")
+	require.NoError(t, cmd.RunE(cmd, nil))
+	assert.Equal(t, "hi\n", rawOut.String())
+	assert.Equal(t, "err\n", rawErr.String())
+	assert.Empty(t, wrapped.String(), "subprocess output must go to the raw streams, not the spinner-wrapping Printer")
+}
 
 func TestExpandPositionalArgs(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Since the activity spinner landed (5abee77), `Printer.Out`/`ErrOut` wrap `os.Stdout`/`os.Stderr` in the non-`*os.File` `stopWriter`. Shell aliases (`!...`) wired the subprocess to those wrappers, so `os/exec` silently substituted pipes: every subprocess lost the TTY (git/gh/ls disable color and width detection), and `Wait` can hang on pipe fds inherited by background children.

## Changes

- `newShellAliasCmd` wires the subprocess to `f.IOStreams` (raw `*os.File` in production) instead of `f.Printer`, and stops the spinner explicitly before `Run` since nothing flows through `stopWriter` anymore.
- Regression test pinning subprocess output to the raw streams even when `Printer` wraps different writers.

## Design Decisions

Same pattern as `output.WithPager`, which already writes to raw `os.Stdout` and calls `StopSpinner()` itself for the same reason.

## Example

```bash
teamcity alias set --shell istty 'test -t 1 && echo IS-A-TTY || echo NOT-A-TTY'
teamcity istty   # on a terminal: IS-A-TTY (was NOT-A-TTY)
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A — interactive TTY behavior, not assertable headless; verified manually under `script(1)`
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [ ] If modifying `--json` output: no field removals/renames — N/A — no `--json` change
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — bug fix, restores pre-spinner behavior
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member
