### PR TITLE
fix(output): suppress the activity spinner on dumb terminals

### DIFF
--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -20,9 +20,9 @@ type spinner struct {
 	done   chan struct{}
 }
 
-// StartSpinner shows a "Loading..." indicator on stdout until StopSpinner or the first byte of output; no-op when quiet, non-terminal, or already running, and the first frame waits one 80ms tick so fast work shows nothing.
+// StartSpinner shows a "Loading..." indicator on stdout until StopSpinner or the first byte of output; no-op when quiet, non-terminal, dumb-terminal, or already running, and the first frame waits one 80ms tick so fast work shows nothing.
 func StartSpinner(quiet bool) {
-	if quiet || !IsTerminal() {
+	if quiet || os.Getenv("TERM") == "dumb" || !IsTerminal() {
 		return
 	}
 	spin.mu.Lock()

--- a/internal/output/spinner_test.go
+++ b/internal/output/spinner_test.go
@@ -1,0 +1,41 @@
+package output
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func setTerminal(t *testing.T, v bool) {
+	prev := isTerminalFn
+	isTerminalFn = func() bool { return v }
+	t.Cleanup(func() { isTerminalFn = prev })
+}
+
+func spinnerActive() bool {
+	spin.mu.Lock()
+	defer spin.mu.Unlock()
+	return spin.active
+}
+
+func TestStartSpinnerNoOpOnDumbTerminal(t *testing.T) {
+	setTerminal(t, true)
+	t.Setenv("TERM", "dumb")
+
+	StartSpinner(false)
+	t.Cleanup(StopSpinner)
+	assert.False(t, spinnerActive(), "dumb terminals cannot render \\r animation or the ANSI clear-line escape")
+}
+
+func TestStartSpinnerNoOpWhenQuietOrNonTerminal(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+
+	setTerminal(t, false)
+	StartSpinner(false)
+	assert.False(t, spinnerActive())
+
+	setTerminal(t, true)
+	StartSpinner(true)
+	t.Cleanup(StopSpinner)
+	assert.False(t, spinnerActive())
+}


### PR DESCRIPTION
## Summary

`StartSpinner` gated only on `--quiet` and `IsTerminal()`, so on a `TERM=dumb` TTY (Emacs shell-mode, pty-wrapped CI) every command animated `| Loading...` with `\r` and left a raw `^[[K` clear-line escape on screen. The rest of the CLI already degrades for dumb terminals (banner in root.go, color in factory.go, ASCII glyphs) — the spinner was the one holdout.

## Changes

- `StartSpinner` no-ops when `TERM=dumb`, matching the existing banner/color gates.
- Tests for the dumb-terminal, non-terminal, and quiet no-op paths.

## Design Decisions

Gated on `TERM=dumb` directly rather than `output.NoColor`: `NO_COLOR` users still have terminals that interpret `\r`/`\x1b[K`, and animation is a separate capability from color.

## Example

```bash
TERM=dumb script -q /dev/null teamcity alias list | cat -v
# before: | Loading...^[[K prefixing the table; after: clean output
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A — TTY-only behavior; verified A/B with built binaries under `script(1)`
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [ ] If modifying `--json` output: no field removals/renames — N/A — no `--json` change
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — transient indicator, not documented
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member
