### PR TITLE
fix(api): serialize empty step and settings lists as [] not null

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -139,6 +139,9 @@ func (c *Client) GetBuildSteps(buildTypeID string) (*BuildStepList, error) {
 	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
+	if result.Step == nil {
+		result.Step = []BuildStep{} // non-nil so --json emits [] not null
+	}
 
 	return &result, nil
 }

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -245,3 +245,19 @@ func TestSetBuildTypeSetting(t *testing.T) {
 	err := client.SetBuildTypeSetting("bt1", "maxRunningBuilds", "3")
 	require.NoError(t, err)
 }
+
+func TestGetBuildStepsEmptyIsNonNil(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Server omits the "step" key for a job with no steps.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":0}`))
+	})
+
+	steps, err := client.GetBuildSteps("bt1")
+	require.NoError(t, err)
+	assert.NotNil(t, steps.Step)
+	b, err := json.Marshal(steps)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"step":[]`)
+}

--- a/api/settings.go
+++ b/api/settings.go
@@ -26,6 +26,9 @@ func (c *Client) GetBuildTypeSettings(buildTypeID string) (*SettingsList, error)
 	if err := c.get(c.ctx(), path, &result); err != nil {
 		return nil, err
 	}
+	if result.Property == nil {
+		result.Property = []Setting{} // non-nil so --json emits [] not null
+	}
 
 	return &result, nil
 }

--- a/api/settings_test.go
+++ b/api/settings_test.go
@@ -41,3 +41,19 @@ func TestGetBuildTypeSetting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "+:build/** => out\n-:**/*.tmp\n", val)
 }
+
+func TestGetBuildTypeSettingsEmptyIsNonNil(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		// Server omits the "property" key for a job with no settings.
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":0}`))
+	})
+
+	settings, err := client.GetBuildTypeSettings("bt1")
+	require.NoError(t, err)
+	assert.NotNil(t, settings.Property)
+	b, err := json.Marshal(settings)
+	require.NoError(t, err)
+	assert.Contains(t, string(b), `"property":[]`)
+}


### PR DESCRIPTION
## Summary

b3eda8e made list endpoints return non-nil slices so `--json` emits `[]` instead of `null`, but `GetBuildSteps` and `GetBuildTypeSettings` landed later in the same release and missed the guard. `job step list --json` and `job settings list --json` on an empty job emitted `"step": null` / `"property": null`, inconsistent with every other list command.

## Changes

- Nil guards in `GetBuildSteps` and `GetBuildTypeSettings`, same pattern as `GetArtifacts`/`GetBuildMessages` from b3eda8e.
- Regression tests mirroring `TestGetArtifactsEmptyIsNonNil`.

## Design Decisions

Straightforward.

## Example

```bash
teamcity job step list EmptyJob --json
# {"count": 0, "step": []}   (was "step": null)
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A — covered by unit tests against a mock server; no acceptance script touched
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [x] If modifying `--json` output: no field removals/renames (additive only) — `null` → `[]` for empty lists, matching all other list commands
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — documented shape already shows arrays
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member
