### PR TITLE
fix(migrate): guard blank docker tags before indexing

### DIFF
--- a/internal/migrate/convert_test.go
+++ b/internal/migrate/convert_test.go
@@ -116,6 +116,14 @@ func TestActionTransformers(t *testing.T) {
 		assert.Contains(t, r.Steps[0].ScriptContent, "docker build")
 		assert.Contains(t, r.Steps[0].ScriptContent, "docker push")
 	})
+
+	t.Run("docker build-push whitespace-only tags fall back to IMAGE guard", func(t *testing.T) {
+		t.Parallel()
+		transformer, _ := LookupActionTransformer("docker/build-push-action@v5")
+		r := transformer("Build", map[string]string{"tags": " \n", "push": "true"})
+		require.Len(t, r.Steps, 1)
+		assert.Contains(t, r.Steps[0].ScriptContent, "${IMAGE:?")
+	})
 }
 
 func TestUnknownActionMultilineInputCommented(t *testing.T) {

--- a/internal/migrate/github_actions.go
+++ b/internal/migrate/github_actions.go
@@ -317,8 +317,7 @@ func transformDockerBuild(name string, inputs map[string]string) StepResult {
 		lines = append(lines, "DOCKERFILE="+shellQuote(file))
 	}
 	var extraTags []string
-	if tags != "" {
-		tagList := strings.Fields(tags)
+	if tagList := strings.Fields(tags); len(tagList) > 0 {
 		lines = append(lines, "IMAGE="+shellQuote(tagList[0]))
 		extraTags = tagList[1:]
 	} else {


### PR DESCRIPTION
## Summary

`docker/build-push-action` with a whitespace-only `tags:` input passed the `tags != ""` guard, then `strings.Fields` returned an empty slice and `tagList[0]` panicked, crashing the whole migration with a stack trace instead of a report. Reproduced end-to-end on a minimal workflow; this guards on the parsed field list so blank tags fall back to the existing `IMAGE:?` shell guard. Addresses the unresolved Codex P2 thread on #226.

## Changes

- `transformDockerBuild`: branch on `len(strings.Fields(tags)) > 0` instead of `tags != ""`
- Regression subtest: whitespace-only `tags` emit the `${IMAGE:?` guard

## Design Decisions

Straightforward.

## Example

```bash
# .github/workflows/docker.yml with `tags: " "` — previously: panic + stack trace
teamcity migrate --dry-run
...
          IMAGE="${IMAGE:?Set IMAGE variable}"
          docker build -t "$IMAGE" '.'
          docker push "$IMAGE"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`) — N/A locally: golangci-lint binary here targets Go 1.25 < 1.26; gofmt + `go vet` clean, CI Lint covers it
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no server-facing behavior changed
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — bug fix only
- [ ] External contributors: links a `status:finalized` issue — N/A — maintainer session

https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246)_