### PR TITLE
feat(evals): support ANTHROPIC_BASE_URL env var in Claude Code runs

### DIFF
--- a/evals/.env
+++ b/evals/.env
@@ -20,6 +20,7 @@ ANTHROPIC_API_KEY=op://Private/teamcity-cli-evals/ANTHROPIC_API_KEY
 # CLAUDE_CODE_OAUTH_TOKEN — 403s for org-managed accounts without Claude Code
 # API access; prefer the API key.
 # CLAUDE_CODE_OAUTH_TOKEN=op://Private/teamcity-cli-evals/CLAUDE_CODE_OAUTH_TOKEN
+# ANTHROPIC_BASE_URL="http://claude-code-proxy"
 
 # TeamCity server for eval tasks
 TEAMCITY_URL=https://buildserver.labs.intellij.net

--- a/evals/README.md
+++ b/evals/README.md
@@ -102,6 +102,7 @@ tooling.
 | Variable             | Required | Description                                              |
 |----------------------|----------|----------------------------------------------------------|
 | `ANTHROPIC_API_KEY`  | Yes      | Claude API key (agent + judge)                           |
+| `ANTHROPIC_BASE_URL` | No       | Custom Anthropic API base URL to be used by Claude Code  |
 | `TEAMCITY_URL`       | Yes      | TeamCity server URL                                      |
 | `TEAMCITY_TOKEN`     | Yes      | TeamCity API token                                       |
 | `SENTRY_DSN`         | No       | Ingest-only — sends observability traces to Sentry       |

--- a/evals/scaffold/claude.py
+++ b/evals/scaffold/claude.py
@@ -35,6 +35,7 @@ class ClaudeResult:
 # Env vars to propagate into Claude's subprocess
 _PROPAGATE_KEYS = (
     "ANTHROPIC_API_KEY",
+    "ANTHROPIC_BASE_URL",
     "CLAUDE_CODE_OAUTH_TOKEN",
     "TEAMCITY_URL",
     "TEAMCITY_TOKEN",


### PR DESCRIPTION
<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->

## Summary

<!-- One paragraph. What does this PR do, and why? Link related issues with "Fixes #123". -->
Added ANTHROPIC_BASE_URL to the list of env vars that are passed to Claude Code instance used for evals. Useful when a proxy is used for Claude Code access.


## Changes

<!-- Short bullet list of key changes; group by area if useful. Keep terse. -->

- Added ANTHROPIC_BASE_URL to `_PROPAGATE_KEYS` in `claude.py`.
- Updated docs and examples.

## Design Decisions

<!-- Non-obvious choices and trade-offs. Write "Straightforward." if there are none. -->
Straightforward

## Example

<!-- For CLI changes: show command + output. Write "N/A — not user-visible." if not applicable. -->

"N/A — not user-visible."

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`. N/A — not applicable.
- [ ] If adding a data-producing command: includes `--json` support. N/A — not applicable.
- [ ] If modifying `--json` output: no field removals/renames (additive only). N/A — not applicable.
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`. N/A — not applicable.
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change). N/A — not applicable.
