### PR TITLE
refactor: finish in-flight modern-Go idiom migrations

### DIFF
--- a/acceptance/acceptance_test.go
+++ b/acceptance/acceptance_test.go
@@ -104,7 +104,6 @@ func TestAcceptance(t *testing.T) {
 	}
 
 	for _, dir := range dirs {
-		dir := dir
 		t.Run(dir, func(t *testing.T) {
 			t.Parallel()
 			runScripts(t, dir, host, token, scriptFilter)

--- a/api/agents_test.go
+++ b/api/agents_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -221,6 +220,6 @@ func TestRebootAgent(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	err := client.RebootAgent(context.Background(), 1, false)
+	err := client.RebootAgent(t.Context(), 1, false)
 	require.NoError(t, err)
 }

--- a/api/builds.go
+++ b/api/builds.go
@@ -110,11 +110,10 @@ func cleanupBuildTriggered(b *Build) {
 // If ref starts with #, it's treated as a build number and looked up.
 // Otherwise it's used as-is (assumed to be an ID).
 func (c *Client) ResolveBuildID(ctx context.Context, ref string) (string, error) {
-	if !strings.HasPrefix(ref, "#") {
+	number, ok := strings.CutPrefix(ref, "#")
+	if !ok {
 		return ref, nil
 	}
-
-	number := strings.TrimPrefix(ref, "#")
 	builds, _, err := c.GetBuilds(ctx, BuildsOptions{Limit: 1, Number: number})
 	if err != nil {
 		return "", err

--- a/api/client.go
+++ b/api/client.go
@@ -7,10 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"net/http"
 	"runtime"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -102,11 +103,7 @@ func (c *Client) debugLogResponse(resp *http.Response) {
 }
 
 func (c *Client) debugLogHeaders(prefix string, headers http.Header) {
-	names := make([]string, 0, len(headers))
-	for name := range headers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
+	names := slices.Sorted(maps.Keys(headers))
 
 	for _, name := range names {
 		values := headers[name]

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1060,16 +1060,17 @@ func TestReadOnlyMode(T *testing.T) {
 		// POST via typed method
 		_, err := client.RunBuild("SomeJob", RunBuildOptions{})
 		require.ErrorIs(t, err, ErrReadOnly)
-		var netErr *NetworkError
-		require.False(t, errors.As(err, &netErr), "ErrReadOnly must not be wrapped in NetworkError; got: %v", err)
-		var ue UserError
-		require.True(t, errors.As(err, &ue))
+		_, ok := errors.AsType[*NetworkError](err)
+		require.False(t, ok, "ErrReadOnly must not be wrapped in NetworkError; got: %v", err)
+		ue, ok := errors.AsType[UserError](err)
+		require.True(t, ok)
 		require.Equal(t, CatReadOnly, ue.Category())
 
 		// PUT via RawRequest
 		_, err = client.RawRequest(T.Context(), "PUT", "/app/rest/something", nil, nil)
 		require.ErrorIs(t, err, ErrReadOnly)
-		require.False(t, errors.As(err, &netErr), "ErrReadOnly must not be wrapped in NetworkError; got: %v", err)
+		_, ok = errors.AsType[*NetworkError](err)
+		require.False(t, ok, "ErrReadOnly must not be wrapped in NetworkError; got: %v", err)
 	})
 
 	T.Run("allows GET requests", func(t *testing.T) {

--- a/api/errors_test.go
+++ b/api/errors_test.go
@@ -51,8 +51,7 @@ func TestPermissionError_ErrorMessage(t *testing.T) {
 
 	t.Run("perm + project", func(t *testing.T) {
 		err := mustClassify(t, 403, `{"errors":[{"message":"You do not have \"Run build\" permission in project: 'My_Project'"}]}`)
-		var pe *PermissionError
-		ok := errors.As(err, &pe)
+		pe, ok := errors.AsType[*PermissionError](err)
 		require.True(t, ok)
 		assert.Equal(t, `missing "Run build" permission in project My_Project`, pe.Error())
 	})

--- a/api/fields.go
+++ b/api/fields.go
@@ -2,9 +2,9 @@ package api
 
 import (
 	"fmt"
+	"maps"
 	"net/url"
 	"slices"
-	"sort"
 	"strings"
 )
 
@@ -57,11 +57,7 @@ func ToAPIFields(fields []string) string {
 	var result []string
 	result = append(result, topLevel...)
 
-	var parents []string
-	for p := range groups {
-		parents = append(parents, p)
-	}
-	sort.Strings(parents)
+	parents := slices.Sorted(maps.Keys(groups))
 
 	for _, p := range parents {
 		result = append(result, fmt.Sprintf("%s(%s)", p, ToAPIFields(groups[p])))

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -105,9 +105,9 @@ func TestIsRetryableNetworkError_ContextCancellation(T *testing.T) {
 func TestWithRetry_RetriesOnServerError(T *testing.T) {
 	T.Parallel()
 
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if atomic.AddInt32(&attempts, 1) < 3 {
+		if attempts.Add(1) < 3 {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
@@ -122,7 +122,7 @@ func TestWithRetry_RetriesOnServerError(T *testing.T) {
 
 	require.NoError(T, err)
 	assert.Equal(T, http.StatusOK, resp.StatusCode)
-	assert.Equal(T, int32(3), atomic.LoadInt32(&attempts))
+	assert.Equal(T, int32(3), attempts.Load())
 	resp.Body.Close()
 }
 
@@ -143,9 +143,9 @@ func TestRetryAfterMissing(T *testing.T) {
 func TestWithRetry_RetriesOn429(T *testing.T) {
 	T.Parallel()
 
-	var attempts int32
+	var attempts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if atomic.AddInt32(&attempts, 1) < 2 {
+		if attempts.Add(1) < 2 {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
@@ -160,7 +160,7 @@ func TestWithRetry_RetriesOn429(T *testing.T) {
 
 	require.NoError(T, err)
 	assert.Equal(T, http.StatusOK, resp.StatusCode)
-	assert.Equal(T, int32(2), atomic.LoadInt32(&attempts))
+	assert.Equal(T, int32(2), attempts.Load())
 	resp.Body.Close()
 }
 
@@ -168,10 +168,10 @@ func TestWithRetry_RetriesOn429(T *testing.T) {
 func TestWithRetry_HonorsRetryAfter(T *testing.T) {
 	T.Parallel()
 
-	var attempts int32
+	var attempts atomic.Int32
 	var firstAt, secondAt time.Time
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := atomic.AddInt32(&attempts, 1)
+		n := attempts.Add(1)
 		if n == 1 {
 			firstAt = time.Now()
 			w.Header().Set("Retry-After", "1")
@@ -245,16 +245,16 @@ func TestGetWithRetry_ExhaustionPreservesHTTPError(T *testing.T) {
 func TestWithRetry_RetriesOnNetworkError(T *testing.T) {
 	T.Parallel()
 
-	var attempts int32
+	var attempts atomic.Int32
 	cfg := RetryConfig{MaxRetries: 2, Interval: 10 * time.Millisecond}
 
 	//nolint:errcheck // exercising retry behavior, not the return
 	withRetry(T.Context(), cfg, func() (*http.Response, error) {
-		atomic.AddInt32(&attempts, 1)
+		attempts.Add(1)
 		return http.Get("http://127.0.0.1:1") // connection refused
 	})
 
-	assert.Equal(T, int32(3), atomic.LoadInt32(&attempts))
+	assert.Equal(T, int32(3), attempts.Load())
 }
 
 // Client integration: verify get- / post-behavior
@@ -266,9 +266,9 @@ func TestClientRetryBehavior(T *testing.T) {
 	T.Run("get retries on 503", func(t *testing.T) {
 		t.Parallel()
 
-		var attempts int32
+		var attempts atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if atomic.AddInt32(&attempts, 1) < 3 {
+			if attempts.Add(1) < 3 {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
@@ -283,15 +283,15 @@ func TestClientRetryBehavior(T *testing.T) {
 
 		require.NoError(t, err)
 		assert.Equal(t, "2024.1", result.Version)
-		assert.Equal(t, int32(3), atomic.LoadInt32(&attempts))
+		assert.Equal(t, int32(3), attempts.Load())
 	})
 
 	T.Run("post never retries", func(t *testing.T) {
 		t.Parallel()
 
-		var attempts int32
+		var attempts atomic.Int32
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			atomic.AddInt32(&attempts, 1)
+			attempts.Add(1)
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}))
 		t.Cleanup(server.Close)
@@ -299,6 +299,6 @@ func TestClientRetryBehavior(T *testing.T) {
 		client := NewClient(server.URL, "test-token")
 		client.post(t.Context(), "/app/rest/buildQueue", nil, nil)
 
-		assert.Equal(t, int32(1), atomic.LoadInt32(&attempts))
+		assert.Equal(t, int32(1), attempts.Load())
 	})
 }

--- a/api/testenv_test.go
+++ b/api/testenv_test.go
@@ -260,10 +260,8 @@ func startContainers() (*testEnv, error) {
 	results := make([]agentResult, numAgents)
 	var wg sync.WaitGroup
 	for i := range numAgents {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			name := fmt.Sprintf("tc-test-agent-%d", idx+1)
+		wg.Go(func() {
+			name := fmt.Sprintf("tc-test-agent-%d", i+1)
 			c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 				ContainerRequest: testcontainers.ContainerRequest{
 					Name:            name,
@@ -281,8 +279,8 @@ func startContainers() (*testEnv, error) {
 				},
 				Started: true,
 			})
-			results[idx] = agentResult{c, err}
-		}(i)
+			results[i] = agentResult{c, err}
+		})
 	}
 	wg.Wait()
 	for i, r := range results {

--- a/internal/analytics/session.go
+++ b/internal/analytics/session.go
@@ -3,6 +3,7 @@ package analytics
 import (
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"time"
@@ -46,7 +47,7 @@ func loadOrCreateSessionAt(path string, now time.Time) (*Session, error) {
 func readSession(path string) (*Session, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/browserflow/flow.go
+++ b/internal/browserflow/flow.go
@@ -2,6 +2,7 @@
 package browserflow
 
 import (
+	"cmp"
 	"context"
 	"crypto/rand"
 	"crypto/subtle"
@@ -86,26 +87,11 @@ func Run(ctx context.Context, opts Options) (*Result, error) {
 		return nil, errors.New("browserflow: OpenURL is required")
 	}
 
-	cbPath := opts.CallbackPath
-	if cbPath == "" {
-		cbPath = DefaultCallbackPath
-	}
-	timeout := opts.Timeout
-	if timeout == 0 {
-		timeout = DefaultTimeout
-	}
-	successTitle := opts.SuccessTitle
-	if successTitle == "" {
-		successTitle = "Authentication successful"
-	}
-	successBody := opts.SuccessBody
-	if successBody == "" {
-		successBody = "You can close this window and return to the terminal."
-	}
-	errorTitle := opts.ErrorTitle
-	if errorTitle == "" {
-		errorTitle = "Authentication failed"
-	}
+	cbPath := cmp.Or(opts.CallbackPath, DefaultCallbackPath)
+	timeout := cmp.Or(opts.Timeout, DefaultTimeout)
+	successTitle := cmp.Or(opts.SuccessTitle, "Authentication successful")
+	successBody := cmp.Or(opts.SuccessBody, "You can close this window and return to the terminal.")
+	errorTitle := cmp.Or(opts.ErrorTitle, "Authentication failed")
 
 	type rawResult struct {
 		code, state, errMsg string

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -113,11 +113,11 @@ func runAPI(f *cmdutil.Factory, endpoint string, opts *apiOptions) error {
 
 	headers := make(map[string]string)
 	for _, h := range opts.headers {
-		parts := strings.SplitN(h, ":", 2)
-		if len(parts) != 2 {
+		k, v, ok := strings.Cut(h, ":")
+		if !ok {
 			return fmt.Errorf("invalid header format %q (expected 'Key: Value')", h)
 		}
-		headers[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+		headers[strings.TrimSpace(k)] = strings.TrimSpace(v)
 	}
 
 	var body io.Reader
@@ -138,12 +138,10 @@ func runAPI(f *cmdutil.Factory, endpoint string, opts *apiOptions) error {
 	} else if len(opts.fields) > 0 {
 		jsonBody := make(map[string]any)
 		for _, f := range opts.fields {
-			parts := strings.SplitN(f, "=", 2)
-			if len(parts) != 2 {
+			key, value, ok := strings.Cut(f, "=")
+			if !ok {
 				return fmt.Errorf("invalid field format %q (expected 'key=value')", f)
 			}
-			key := parts[0]
-			value := parts[1]
 
 			var jsonValue any
 			if err := json.Unmarshal([]byte(value), &jsonValue); err != nil {

--- a/internal/cmd/link/link.go
+++ b/internal/cmd/link/link.go
@@ -168,7 +168,7 @@ func loadOrEmpty(path string) (*link.Config, error) {
 	if err == nil {
 		return c, nil
 	}
-	if os.IsNotExist(err) {
+	if errors.Is(err, os.ErrNotExist) {
 		return &link.Config{}, nil
 	}
 	return nil, err

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -378,7 +378,7 @@ func runProjectSettingsValidate(f *cmdutil.Factory, opts *projectSettingsValidat
 	}
 
 	pomPath := filepath.Join(dslDir, "pom.xml")
-	if _, err := os.Stat(pomPath); os.IsNotExist(err) {
+	if _, err := os.Stat(pomPath); errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("pom.xml not found in %s", dslDir)
 	}
 

--- a/internal/cmd/run/analysis.go
+++ b/internal/cmd/run/analysis.go
@@ -84,9 +84,7 @@ func runRunChanges(f *cmdutil.Factory, runID string, opts *runChangesOptions) er
 		_, _ = fmt.Fprintf(p.Out, "%s  %s  %s\n", output.Yellow(sha), output.Faint(c.Username), output.Faint(date))
 
 		comment := strings.TrimSpace(c.Comment)
-		if idx := strings.Index(comment, "\n"); idx > 0 {
-			comment = comment[:idx]
-		}
+		comment, _, _ = strings.Cut(comment, "\n")
 		_, _ = fmt.Fprintf(p.Out, "  %s\n", comment)
 
 		if !opts.noFiles && c.Files != nil && len(c.Files.File) > 0 {

--- a/internal/cmd/run/local_changes.go
+++ b/internal/cmd/run/local_changes.go
@@ -1,6 +1,7 @@
 package run
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -76,7 +77,7 @@ func loadLocalChanges(source string, stdin io.Reader) ([]byte, error) {
 	default:
 		patch, err := os.ReadFile(source)
 		if err != nil {
-			if os.IsNotExist(err) {
+			if errors.Is(err, os.ErrNotExist) {
 				return nil, api.Validation(
 					"diff file not found: "+source,
 					"Check the file path and try again",

--- a/internal/cmd/run/log.go
+++ b/internal/cmd/run/log.go
@@ -381,9 +381,7 @@ func runLogFollow(f *cmdutil.Factory, client api.ClientInterface, runID string, 
 
 	lastSeenID := 0
 	for _, msg := range resp.Messages {
-		if msg.ID > lastSeenID {
-			lastSeenID = msg.ID
-		}
+		lastSeenID = max(lastSeenID, msg.ID)
 		printFollowMessage(p.Out, msg, showVerbose, opts.raw, opts.json)
 	}
 

--- a/internal/cmd/skill/skill_test.go
+++ b/internal/cmd/skill/skill_test.go
@@ -50,7 +50,7 @@ func TestSkillInstallRemoveDefault(t *testing.T) {
 
 	cmdtest.RunCmd(t, "skill", "remove", "--agent", "claude-code")
 	_, err = os.Stat(skillDir)
-	assert.True(t, os.IsNotExist(err), "skill dir should be gone after remove")
+	assert.ErrorIs(t, err, os.ErrNotExist, "skill dir should be gone after remove")
 }
 
 func TestSkillInstallUnknownSkill(t *testing.T) {

--- a/internal/cmdtest/testutil.go
+++ b/internal/cmdtest/testutil.go
@@ -49,11 +49,10 @@ func NewTestServer(t *testing.T) *TestServer {
 		var bestMatch string
 		var bestHandler http.HandlerFunc
 		for pattern, h := range ts.handlers {
-			parts := strings.SplitN(pattern, " ", 2)
-			if len(parts) != 2 {
+			method, path, ok := strings.Cut(pattern, " ")
+			if !ok {
 				continue
 			}
-			method, path := parts[0], parts[1]
 			if r.Method == method && strings.HasPrefix(r.URL.Path, path) {
 				if len(path) > len(bestMatch) {
 					bestMatch = path

--- a/internal/cmdutil/helpers_test.go
+++ b/internal/cmdutil/helpers_test.go
@@ -2,7 +2,6 @@ package cmdutil
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -272,7 +271,7 @@ func TestProbeGuestAccess(t *testing.T) {
 
 	t.Run("empty url → false (no network call)", func(t *testing.T) {
 		t.Parallel()
-		assert.False(t, ProbeGuestAccess(context.Background(), ""))
+		assert.False(t, ProbeGuestAccess(t.Context(), ""))
 	})
 
 	t.Run("200 → true", func(t *testing.T) {
@@ -282,7 +281,7 @@ func TestProbeGuestAccess(t *testing.T) {
 			_, _ = w.Write([]byte(`{"version":"2025.7","versionMajor":2025,"versionMinor":7,"buildNumber":"1"}`))
 		}))
 		defer srv.Close()
-		assert.True(t, ProbeGuestAccess(context.Background(), srv.URL))
+		assert.True(t, ProbeGuestAccess(t.Context(), srv.URL))
 	})
 
 	t.Run("401 → false", func(t *testing.T) {
@@ -290,13 +289,13 @@ func TestProbeGuestAccess(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
 		defer srv.Close()
-		assert.False(t, ProbeGuestAccess(context.Background(), srv.URL))
+		assert.False(t, ProbeGuestAccess(t.Context(), srv.URL))
 	})
 
 	t.Run("dead address → false", func(t *testing.T) {
 		t.Parallel()
 		// Closed port; ProbeGuestAccess must return false without panicking.
-		assert.False(t, ProbeGuestAccess(context.Background(), "http://127.0.0.1:1"))
+		assert.False(t, ProbeGuestAccess(t.Context(), "http://127.0.0.1:1"))
 	})
 }
 
@@ -305,7 +304,7 @@ func TestNotAuthenticatedError(t *testing.T) {
 
 	t.Run("no keyring err", func(t *testing.T) {
 		t.Parallel()
-		err := NotAuthenticatedError(context.Background(), "", nil)
+		err := NotAuthenticatedError(t.Context(), "", nil)
 		require.NotNil(t, err)
 		assert.Equal(t, "Not authenticated", err.Error())
 		assert.Contains(t, err.Suggestion(), "TEAMCITY_URL")
@@ -314,7 +313,7 @@ func TestNotAuthenticatedError(t *testing.T) {
 	t.Run("with keyring err mentions it", func(t *testing.T) {
 		t.Parallel()
 		ke := errors.New("keychain locked")
-		err := NotAuthenticatedError(context.Background(), "", ke)
+		err := NotAuthenticatedError(t.Context(), "", ke)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Error(), "keyring")
 		assert.Contains(t, err.Error(), "keychain locked")
@@ -327,7 +326,7 @@ func TestNotAuthenticatedError(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		err := NotAuthenticatedError(context.Background(), srv.URL, nil)
+		err := NotAuthenticatedError(t.Context(), srv.URL, nil)
 		require.NotNil(t, err)
 		assert.Contains(t, err.Suggestion(), "TEAMCITY_GUEST=1")
 	})

--- a/internal/cmdutil/prompt.go
+++ b/internal/cmdutil/prompt.go
@@ -119,61 +119,53 @@ func echo(p *output.Printer, label, value string) {
 	_, _ = fmt.Fprintf(p.Out, "%s: %s\n", label, output.Cyan(value))
 }
 
-var (
-	promptThemeOnce sync.Once
-	promptThemeVal  *huh.Theme
-)
-
 // promptTheme renders huh prompts in the CLI's 16-color palette with no borders or magenta accents.
-func promptTheme() *huh.Theme {
-	promptThemeOnce.Do(func() {
-		t := huh.ThemeBase()
+var promptTheme = sync.OnceValue(func() *huh.Theme {
+	t := huh.ThemeBase()
 
-		var (
-			cyan   = lipgloss.Color("6")
-			green  = lipgloss.Color("2")
-			yellow = lipgloss.Color("3")
-			red    = lipgloss.Color("1")
-			faint  = lipgloss.Color("8")
-			plain  = lipgloss.NewStyle()
-		)
+	var (
+		cyan   = lipgloss.Color("6")
+		green  = lipgloss.Color("2")
+		yellow = lipgloss.Color("3")
+		red    = lipgloss.Color("1")
+		faint  = lipgloss.Color("8")
+		plain  = lipgloss.NewStyle()
+	)
 
-		t.Focused.Base = plain
-		t.Focused.Card = plain
-		t.Focused.Title = plain.Bold(true)
-		t.Focused.NoteTitle = plain.Bold(true)
-		t.Focused.Description = plain.Foreground(faint)
-		t.Focused.ErrorIndicator = plain.Foreground(red).SetString(" " + output.Sym().Cross)
-		t.Focused.ErrorMessage = plain.Foreground(red)
+	t.Focused.Base = plain
+	t.Focused.Card = plain
+	t.Focused.Title = plain.Bold(true)
+	t.Focused.NoteTitle = plain.Bold(true)
+	t.Focused.Description = plain.Foreground(faint)
+	t.Focused.ErrorIndicator = plain.Foreground(red).SetString(" " + output.Sym().Cross)
+	t.Focused.ErrorMessage = plain.Foreground(red)
 
-		t.Focused.SelectSelector = plain.Foreground(yellow).SetString(output.Sym().Arrow + " ")
-		t.Focused.NextIndicator = plain.Foreground(yellow).MarginLeft(1).SetString(output.Sym().Arrow)
-		t.Focused.PrevIndicator = plain.Foreground(yellow).MarginRight(1).SetString(output.Sym().ArrowLeft)
-		t.Focused.Option = plain
-		t.Focused.SelectedOption = plain
+	t.Focused.SelectSelector = plain.Foreground(yellow).SetString(output.Sym().Arrow + " ")
+	t.Focused.NextIndicator = plain.Foreground(yellow).MarginLeft(1).SetString(output.Sym().Arrow)
+	t.Focused.PrevIndicator = plain.Foreground(yellow).MarginRight(1).SetString(output.Sym().ArrowLeft)
+	t.Focused.Option = plain
+	t.Focused.SelectedOption = plain
 
-		t.Focused.MultiSelectSelector = plain.Foreground(yellow).SetString(output.Sym().Arrow + " ")
-		t.Focused.SelectedPrefix = plain.Foreground(green).SetString(output.Sym().Check + " ")
-		t.Focused.UnselectedPrefix = plain.Foreground(faint).SetString(output.Sym().Bullet + " ")
-		t.Focused.UnselectedOption = plain
+	t.Focused.MultiSelectSelector = plain.Foreground(yellow).SetString(output.Sym().Arrow + " ")
+	t.Focused.SelectedPrefix = plain.Foreground(green).SetString(output.Sym().Check + " ")
+	t.Focused.UnselectedPrefix = plain.Foreground(faint).SetString(output.Sym().Bullet + " ")
+	t.Focused.UnselectedOption = plain
 
-		t.Focused.FocusedButton = plain.Bold(true).Foreground(cyan).MarginLeft(3)
-		t.Focused.BlurredButton = plain.Foreground(faint).MarginLeft(3)
+	t.Focused.FocusedButton = plain.Bold(true).Foreground(cyan).MarginLeft(3)
+	t.Focused.BlurredButton = plain.Foreground(faint).MarginLeft(3)
 
-		t.Focused.TextInput.Cursor = plain.Foreground(cyan)
-		t.Focused.TextInput.Placeholder = plain.Foreground(faint)
-		t.Focused.TextInput.Prompt = plain.Foreground(yellow)
+	t.Focused.TextInput.Cursor = plain.Foreground(cyan)
+	t.Focused.TextInput.Placeholder = plain.Foreground(faint)
+	t.Focused.TextInput.Prompt = plain.Foreground(yellow)
 
-		t.Blurred = t.Focused
-		t.Blurred.Base = plain
-		t.Blurred.Card = plain
-		t.Blurred.NextIndicator = plain
-		t.Blurred.PrevIndicator = plain
+	t.Blurred = t.Focused
+	t.Blurred.Base = plain
+	t.Blurred.Card = plain
+	t.Blurred.NextIndicator = plain
+	t.Blurred.PrevIndicator = plain
 
-		t.Group.Title = t.Focused.Title
-		t.Group.Description = t.Focused.Description
+	t.Group.Title = t.Focused.Title
+	t.Group.Description = t.Focused.Description
 
-		promptThemeVal = t
-	})
-	return promptThemeVal
-}
+	return t
+})

--- a/internal/config/buildauth.go
+++ b/internal/config/buildauth.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"cmp"
 	"net/url"
 	"os"
 
@@ -41,13 +42,11 @@ func GetBuildAuth() (*BuildAuth, bool) {
 		return nil, false
 	}
 
-	serverURL := os.Getenv(EnvServerURL)
-	if serverURL == "" {
-		serverURL = extractServerURL(os.Getenv(EnvBuildURL))
-	}
-	if serverURL == "" {
-		serverURL = props.GetString("teamcity.serverUrl", "")
-	}
+	serverURL := cmp.Or(
+		os.Getenv(EnvServerURL),
+		extractServerURL(os.Getenv(EnvBuildURL)),
+		props.GetString("teamcity.serverUrl", ""),
+	)
 	if serverURL == "" {
 		return nil, false
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ func Init() error {
 
 	if err := vi.ReadInConfig(); err != nil {
 		if _, ok := errors.AsType[viper.ConfigFileNotFoundError](err); !ok {
-			if !os.IsNotExist(err) {
+			if !errors.Is(err, os.ErrNotExist) {
 				return fmt.Errorf("failed to read config: %w", err)
 			}
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -193,8 +193,8 @@ func CanonicalURL(rawURL string) string {
 		return ""
 	}
 	if rest, ok := strings.CutPrefix(raw, "ssh://"); ok {
-		if i := strings.Index(rest, "@"); i >= 0 {
-			rest = rest[i+1:]
+		if _, after, ok := strings.Cut(rest, "@"); ok {
+			rest = after
 		}
 		if slash := strings.Index(rest, "/"); slash > 0 {
 			host, path := rest[:slash], rest[slash:]
@@ -229,8 +229,8 @@ func RepoPath(rawURL string) string {
 	if canonical == "" {
 		return ""
 	}
-	if i := strings.Index(canonical, "/"); i >= 0 {
-		return strings.TrimPrefix(canonical[i:], "/")
+	if _, after, ok := strings.Cut(canonical, "/"); ok {
+		return after
 	}
 	return canonical
 }

--- a/internal/output/render_error_test.go
+++ b/internal/output/render_error_test.go
@@ -27,8 +27,7 @@ func httpErr(t *testing.T, status int, body string) error {
 // permErr returns a *api.PermissionError with AuthSource set, routed via ErrorFromResponse so cat is populated.
 func permErr(t *testing.T, body string, src api.AuthSource) *api.PermissionError {
 	t.Helper()
-	var pe *api.PermissionError
-	ok := errors.As(httpErr(t, http.StatusForbidden, body), &pe)
+	pe, ok := errors.AsType[*api.PermissionError](httpErr(t, http.StatusForbidden, body))
 	require.True(t, ok, "expected *api.PermissionError")
 	pe.AuthSource = src
 	return pe
@@ -37,8 +36,7 @@ func permErr(t *testing.T, body string, src api.AuthSource) *api.PermissionError
 func notFoundErr(t *testing.T, message string) *api.NotFoundError {
 	t.Helper()
 	body := `{"errors":[{"message":` + jsonString(message) + `}]}`
-	var nf *api.NotFoundError
-	ok := errors.As(httpErr(t, http.StatusNotFound, body), &nf)
+	nf, ok := errors.AsType[*api.NotFoundError](httpErr(t, http.StatusNotFound, body))
 	require.True(t, ok, "expected *api.NotFoundError")
 	return nf
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -320,15 +320,11 @@ func stripANSI(s string) string {
 func extractExecOutput(raw string) string {
 	raw = normalizeLineEndings(stripANSI(raw))
 	startPattern := execMarker + "\n"
-	startIdx := strings.Index(raw, startPattern)
-	if startIdx == -1 {
+	_, after, ok := strings.Cut(raw, startPattern)
+	if !ok {
 		return ""
 	}
-	raw = raw[startIdx+len(startPattern):]
-	endIdx := strings.Index(raw, execMarker)
-	if endIdx != -1 {
-		raw = raw[:endIdx]
-	}
+	raw, _, _ = strings.Cut(after, execMarker)
 
 	return strings.TrimSpace(raw)
 }

--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -137,8 +137,8 @@ func IsNewer(current, latest string) bool {
 
 func parseSemver(v string) (major, minor, patch int) {
 	v = strings.TrimPrefix(v, "v")
-	parts := strings.SplitN(v, "-", 2)
-	parts = strings.SplitN(parts[0], ".", 4)
+	base, _, _ := strings.Cut(v, "-")
+	parts := strings.SplitN(base, ".", 4)
 
 	if len(parts) >= 1 {
 		major, _ = strconv.Atoi(parts[0])

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -1,7 +1,6 @@
 package update
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -75,7 +74,7 @@ func TestLatestReleaseFromAPI(t *testing.T) {
 		t.Cleanup(func() { latestReleaseAPIURL = defaultURL })
 		latestReleaseAPIURL = srv.URL
 
-		got, err := latestReleaseFromAPI(context.Background())
+		got, err := latestReleaseFromAPI(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, "1.2.3", got.Version) // "v" prefix stripped
 		assert.Equal(t, "https://github.com/x/y/releases/tag/v1.2.3", got.URL)
@@ -89,7 +88,7 @@ func TestLatestReleaseFromAPI(t *testing.T) {
 		t.Cleanup(func() { latestReleaseAPIURL = defaultURL })
 		latestReleaseAPIURL = srv.URL
 
-		_, err := latestReleaseFromAPI(context.Background())
+		_, err := latestReleaseFromAPI(t.Context())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "403")
 	})
@@ -102,7 +101,7 @@ func TestLatestReleaseFromAPI(t *testing.T) {
 		t.Cleanup(func() { latestReleaseAPIURL = defaultURL })
 		latestReleaseAPIURL = srv.URL
 
-		_, err := latestReleaseFromAPI(context.Background())
+		_, err := latestReleaseFromAPI(t.Context())
 		assert.Error(t, err)
 	})
 }
@@ -120,7 +119,7 @@ func TestLatestReleaseFromRedirect(t *testing.T) {
 		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
 		latestReleaseRedirectURL = srv.URL
 
-		got, err := latestReleaseFromRedirect(context.Background())
+		got, err := latestReleaseFromRedirect(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, "1.5.0", got.Version)
 		assert.Equal(t, "https://github.com/JetBrains/teamcity-cli/releases/tag/v1.5.0", got.URL)
@@ -135,7 +134,7 @@ func TestLatestReleaseFromRedirect(t *testing.T) {
 		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
 		latestReleaseRedirectURL = srv.URL
 
-		got, err := latestReleaseFromRedirect(context.Background())
+		got, err := latestReleaseFromRedirect(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, "2.0.0", got.Version)
 	})
@@ -148,7 +147,7 @@ func TestLatestReleaseFromRedirect(t *testing.T) {
 		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
 		latestReleaseRedirectURL = srv.URL
 
-		_, err := latestReleaseFromRedirect(context.Background())
+		_, err := latestReleaseFromRedirect(t.Context())
 		assert.Error(t, err)
 	})
 
@@ -160,7 +159,7 @@ func TestLatestReleaseFromRedirect(t *testing.T) {
 		t.Cleanup(func() { latestReleaseRedirectURL = defaultURL })
 		latestReleaseRedirectURL = srv.URL
 
-		_, err := latestReleaseFromRedirect(context.Background())
+		_, err := latestReleaseFromRedirect(t.Context())
 		assert.Error(t, err)
 	})
 }
@@ -181,7 +180,7 @@ func TestLatestRelease_FallbackOnAPIFailure(t *testing.T) {
 	latestReleaseAPIURL = apiSrv.URL
 	latestReleaseRedirectURL = redirectSrv.URL
 
-	got, err := LatestRelease(context.Background())
+	got, err := LatestRelease(t.Context())
 	require.NoError(t, err, "fallback should rescue from API failure")
 	assert.Equal(t, "9.9.9", got.Version)
 }
@@ -201,7 +200,7 @@ func TestLatestRelease_BothPathsFail(t *testing.T) {
 	latestReleaseAPIURL = apiSrv.URL
 	latestReleaseRedirectURL = redirectSrv.URL
 
-	_, err := LatestRelease(context.Background())
+	_, err := LatestRelease(t.Context())
 	require.Error(t, err)
 	// Error must mention both failures, not just one.
 	assert.Contains(t, err.Error(), "fallback failed")

--- a/scripts/generate-docs.go
+++ b/scripts/generate-docs.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"regexp"
 	"slices"
-	"sort"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmd"
 	"github.com/spf13/cobra"
@@ -126,7 +125,7 @@ func orderedCommands(rootCmd *cobra.Command, includeCompletion bool) ([]string, 
 			rest = append(rest, name)
 		}
 	}
-	sort.Strings(rest)
+	slices.Sort(rest)
 	names = append(names, rest...)
 	return names, cmds
 }

--- a/scripts/sync-docs.go
+++ b/scripts/sync-docs.go
@@ -165,7 +165,8 @@ func push(branchOverride string) {
 	branch := resolveBranch(branchOverride)
 	syncBranch := "cli-docs-sync-" + time.Now().Format("20060102")
 	user := ghUser()
-	forkRepo := user + "/" + strings.SplitN(externalRepo, "/", 2)[1]
+	_, repo, _ := strings.Cut(externalRepo, "/")
+	forkRepo := user + "/" + repo
 
 	tmpDir, err := os.MkdirTemp("", "tc-docs-push-*")
 	if err != nil {


### PR DESCRIPTION
## Summary

Mechanical sweep finishing idiom migrations the codebase already adopted elsewhere, targeting the declared Go 1.26: every site was vetted as a behavior-preserving drop-in before conversion, and judgement-call/behavior-affecting candidates were deliberately left alone.

## Changes

- `errors.AsType[T]` for the 6 remaining pre-declared-var `errors.As` sites; `errors.Is(err, os.ErrNotExist)` for the 6 `os.IsNotExist` calls
- `strings.Cut`/`CutPrefix` for 12 SplitN/Index-slicing/HasPrefix+TrimPrefix sites
- `slices.Sorted(maps.Keys(m))` for the 2 remaining collect+sort loops; `slices.Sort` over `sort.Strings`; one `max()`; `cmp.Or` for the buildauth/browserflow default chains
- `sync.OnceValue` for the prompt-theme pair; `wg.Go` and typed `atomic.Int32` in tests; 17 `context.Background()` → `t.Context()`; one obsolete pre-1.22 `x := x` loop copy removed
- Drops 4 now-unneeded imports (`sort` ×3, `context` ×3 in tests)

## Design Decisions

`tipFor`'s `Suggestion()` hinter stays on `errors.As`: `errors.AsType`'s type parameter is constrained to `error`, which the marker interface doesn't satisfy. Skipped as churn: statement-level `if x == "" {}` fallbacks, `time.Tick`, the test-resettable `sync.Once` pairs in config, and `omitempty`→`omitzero` tag changes (those alter JSON output and are tracked separately).

## Example

N/A — not user-visible.

## Test Plan

- [x] Unit tests pass (`just unit`) — full `go test -race -shuffle=on ./...`, 1655 tests
- [x] Linter passes (`just lint`) — plus `go vet` under `-tags=integration` and `-tags=acceptance` for the touched tagged files
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no behavior change; tagged files compile-checked
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [ ] If modifying `--json` output: no field removals/renames — N/A — no `--json` change
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — internal refactor
- [ ] External contributors: links a `status:finalized` issue — N/A — JetBrains member
