### PR TITLE
fix(pipeline): validate against the embedded schema when unauthenticated

### DIFF
--- a/internal/cmd/pipeline/pipeline_test.go
+++ b/internal/cmd/pipeline/pipeline_test.go
@@ -121,3 +121,15 @@ func TestPipelineValidateUnauthenticatedFallsBackToEmbeddedSchema(t *testing.T) 
 	assert.Contains(t, out, "embedded schema")
 	assert.Contains(t, out, "is valid")
 }
+
+func TestPipelineValidateUnauthenticatedRefreshSchemaErrors(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("TEAMCITY_URL", "")
+	t.Setenv("TEAMCITY_TOKEN", "")
+
+	file := filepath.Join(t.TempDir(), "p.tc.yml")
+	require.NoError(t, os.WriteFile(file, []byte("jobs: {}\n"), 0o644))
+
+	err := cmdtest.CaptureErr(t, cmdutil.NewFactory(), "pipeline", "validate", file, "--refresh-schema")
+	assert.Contains(t, err.Error(), "authenticated")
+}

--- a/internal/cmd/pipeline/pipeline_test.go
+++ b/internal/cmd/pipeline/pipeline_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 )
 
@@ -113,6 +114,7 @@ func TestPipelineValidateUnauthenticatedFallsBackToEmbeddedSchema(t *testing.T) 
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("TEAMCITY_URL", "")
 	t.Setenv("TEAMCITY_TOKEN", "")
+	require.NoError(t, config.Init())
 
 	file := filepath.Join(t.TempDir(), "p.tc.yml")
 	require.NoError(t, os.WriteFile(file, []byte("jobs:\n  build:\n    name: \"Build\"\n    runs-on: Linux-Large\n    steps:\n      - type: script\n        script-content: echo hi\n"), 0o644))
@@ -126,6 +128,7 @@ func TestPipelineValidateUnauthenticatedRefreshSchemaErrors(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv("TEAMCITY_URL", "")
 	t.Setenv("TEAMCITY_TOKEN", "")
+	require.NoError(t, config.Init())
 
 	file := filepath.Join(t.TempDir(), "p.tc.yml")
 	require.NoError(t, os.WriteFile(file, []byte("jobs: {}\n"), 0o644))

--- a/internal/cmd/pipeline/pipeline_test.go
+++ b/internal/cmd/pipeline/pipeline_test.go
@@ -2,12 +2,16 @@ package pipeline_test
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 )
 
@@ -103,4 +107,17 @@ func TestPipelineSchemaServerErrorPropagates(t *testing.T) {
 	err := cmdtest.CaptureErr(t, ts.Factory, "pipeline", "schema")
 	assert.Contains(t, err.Error(), "failed to fetch pipeline schema")
 	assert.NotContains(t, err.Error(), "predate TeamCity 2026.1")
+}
+
+func TestPipelineValidateUnauthenticatedFallsBackToEmbeddedSchema(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("TEAMCITY_URL", "")
+	t.Setenv("TEAMCITY_TOKEN", "")
+
+	file := filepath.Join(t.TempDir(), "p.tc.yml")
+	require.NoError(t, os.WriteFile(file, []byte("jobs:\n  build:\n    name: \"Build\"\n    runs-on: Linux-Large\n    steps:\n      - type: script\n        script-content: echo hi\n"), 0o644))
+
+	out := cmdtest.CaptureOutput(t, cmdutil.NewFactory(), "pipeline", "validate", file)
+	assert.Contains(t, out, "embedded schema")
+	assert.Contains(t, out, "is valid")
 }

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -117,6 +117,10 @@ func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, bool, error)
 
 	client, err := f.Client()
 	if err != nil {
+		// --refresh-schema explicitly asks for a server fetch, so don't mask the auth failure.
+		if opts.refreshSchema {
+			return nil, false, err
+		}
 		f.Printer.Warn("Not authenticated - validating against the embedded schema; run 'teamcity auth login' to use your server's schema")
 		return pipelineschema.Bytes, false, nil
 	}

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -117,7 +117,8 @@ func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, bool, error)
 
 	client, err := f.Client()
 	if err != nil {
-		return nil, false, err
+		f.Printer.Warn("Not authenticated - validating against the embedded schema; run 'teamcity auth login' to use your server's schema")
+		return pipelineschema.Bytes, false, nil
 	}
 
 	c, ok := client.(*api.Client)


### PR DESCRIPTION
## Summary

`teamcity migrate` works offline (it falls back to the embedded pipeline schema), then prints `Next: teamcity pipeline validate <file>` — but `pipeline validate` hard-required an authenticated client, so the very next command failed with "Not authenticated" for exactly the audience migrate targets: users coming from GitHub Actions/Bamboo who haven't run `auth login` yet. This makes validate fall back to the embedded schema with a warning when no client is available, same as migrate already does.

## Changes

- `loadSchema`: on `f.Client()` error, warn and return `pipelineschema.Bytes` instead of failing
- Test: unauthenticated `pipeline validate` on a valid file succeeds and mentions the embedded schema

## Design Decisions

Only the unauthenticated case falls back; an authenticated client whose schema fetch fails still errors as before (that's a real connectivity problem worth surfacing, and the cache already covers transient cases). `--schema <file>` behavior unchanged.

## Example

```bash
# fresh machine, no auth: previously "Error: Not authenticated"
teamcity pipeline validate ci.tc.yml
! Not authenticated - validating against the embedded schema; run 'teamcity auth login' to use your server's schema
✓ ci.tc.yml is valid
  Jobs: build, deploy, test_e2e, test_unit
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`) — N/A locally: golangci-lint binary here targets Go 1.25 < 1.26; gofmt + `go vet` clean, CI Lint covers it
- [ ] Acceptance tests pass (`just acceptance`) — N/A — existing validate acceptance coverage runs authenticated and is unaffected
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — strictly more permissive; docs describe validate's checks, not its auth requirements
- [ ] External contributors: links a `status:finalized` issue — N/A — maintainer session

https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246)_