### PR TITLE
fix(migrate): surface dropped Bamboo stage jobs and redact nested stub secrets

### DIFF
--- a/internal/migrate/bamboo.go
+++ b/internal/migrate/bamboo.go
@@ -1217,10 +1217,34 @@ func bambooLooksSecret(name string) bool {
 	})
 }
 
+// flattenStringMap stringifies task fields for stub rendering, redacting secret-looking leaves in nested values first.
 func flattenStringMap(m map[string]any) map[string]string {
 	out := map[string]string{}
 	for k, v := range m {
-		out[k] = stringFromAny(v)
+		out[k] = stringFromAny(redactSecretLeaves(v))
 	}
 	return out
+}
+
+// redactSecretLeaves walks nested maps and lists, replacing any value whose key looks secret so it can't leak into stub comments.
+func redactSecretLeaves(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			if bambooLooksSecret(k) {
+				out[k] = "REDACTED"
+				continue
+			}
+			out[k] = redactSecretLeaves(val)
+		}
+		return out
+	case []any:
+		out := make([]any, len(t))
+		for i, item := range t {
+			out[i] = redactSecretLeaves(item)
+		}
+		return out
+	}
+	return v
 }

--- a/internal/migrate/bamboo.go
+++ b/internal/migrate/bamboo.go
@@ -92,6 +92,10 @@ func convertBamboo(cfg CIConfig, data []byte, opts Options) (*ConversionResult, 
 		}
 
 		jobNames := stringSliceFromAny(stageInfo["jobs"])
+		if len(jobNames) < bambooStageJobEntryCount(stageInfo["jobs"]) {
+			result.NeedsReview = append(result.NeedsReview,
+				fmt.Sprintf("Stage %q has `jobs:` entries that are not plain job-name strings → those jobs were not converted; rewrite `jobs:` as a list of job names", stageName))
+		}
 		var stageJobIDs []string
 		for _, jobName := range jobNames {
 			jobDef, _ := spec[jobName].(map[string]any)
@@ -212,6 +216,17 @@ func bambooStageEntry(entry any) (string, map[string]any, bool) {
 		info = map[string]any{}
 	}
 	return name, info, true
+}
+
+// bambooStageJobEntryCount counts raw entries under a stage's `jobs:` key regardless of YAML shape, so dropped entries are detectable.
+func bambooStageJobEntryCount(v any) int {
+	switch jobs := v.(type) {
+	case string:
+		return 1
+	case map[string]any:
+		return len(jobs)
+	}
+	return len(anySlice(v))
 }
 
 type bambooTask struct {

--- a/internal/migrate/bamboo_test.go
+++ b/internal/migrate/bamboo_test.go
@@ -394,6 +394,43 @@ J2:
 	assert.Equal(t, []string{"A_J1"}, result.Pipeline.Jobs[1].Dependencies)
 }
 
+func TestBambooMapFormStageJobsSurfaceAsReview(t *testing.T) {
+	t.Parallel()
+
+	result := convertBambooSpec(t, `
+stages:
+  - 'S':
+      jobs:
+        Build: x
+Build:
+  tasks:
+    - script: echo hi
+`)
+	// Map-form jobs yield no usable job names; the loss must surface instead of a clean empty conversion.
+	assert.Empty(t, result.Pipeline.Jobs)
+	reviews := strings.Join(result.NeedsReview, "\n")
+	assert.Contains(t, reviews, `Stage "S"`)
+	assert.Contains(t, reviews, "not plain job-name strings")
+}
+
+func TestBambooNonStringStageJobEntrySurfacesAsReview(t *testing.T) {
+	t.Parallel()
+
+	result := convertBambooSpec(t, `
+stages:
+  - 'S':
+      jobs:
+        - Build
+        - 123
+Build:
+  tasks:
+    - script: echo hi
+`)
+	// The string job converts; the dropped non-string entry must be flagged.
+	require.Len(t, result.Pipeline.Jobs, 1)
+	assert.Contains(t, strings.Join(result.NeedsReview, "\n"), `Stage "S"`)
+}
+
 func TestBambooDisabledJobBecomesNoOp(t *testing.T) {
 	t.Parallel()
 

--- a/internal/migrate/bamboo_test.go
+++ b/internal/migrate/bamboo_test.go
@@ -188,6 +188,32 @@ Job:
 	assert.NotContains(t, step.ScriptContent, "hunter2", "secret-looking stub fields must be redacted")
 }
 
+func TestBambooUnknownTaskNestedSecretRedacted(t *testing.T) {
+	t.Parallel()
+
+	result := convertBambooSpec(t, `
+stages:
+  - 'Build':
+      jobs:
+        - Job
+Job:
+  tasks:
+    - made-up-task:
+        configuration:
+          password: hunter2
+          url: https://example.com
+        servers:
+          - host: a
+            api_token: leaky-token
+`)
+	require.Len(t, result.Pipeline.Jobs[0].Steps, 1)
+	step := result.Pipeline.Jobs[0].Steps[0]
+	assert.NotContains(t, result.YAML, "hunter2", "secrets nested in maps must not leak into the generated YAML")
+	assert.NotContains(t, result.YAML, "leaky-token", "secrets nested in lists of maps must not leak")
+	assert.Contains(t, step.ScriptContent, "REDACTED")
+	assert.Contains(t, step.ScriptContent, "https://example.com", "non-secret nested values pass through")
+}
+
 func TestBambooNoPlanSurfacesAsReview(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Two confirmed Bamboo converter bugs hid data loss behind a clean report. A stage whose `jobs:` entries aren't plain strings (e.g. map form) converted to `jobs: {}` while printing "✓ Fully converted, exit 0"; and secrets nested inside unknown-task fields (`configuration: {password: ...}`) were stringified into the generated stub unredacted, despite top-level redaction. Both reproduced before the fix; both now surface/redact correctly.

## Changes

- Stage conversion compares usable job names against the raw `jobs:` entry count and appends a NeedsReview entry naming the stage when entries were dropped (new `bambooStageJobEntryCount` helper handles string/map/list shapes)
- `flattenStringMap` routes values through a new `redactSecretLeaves` walker that recurses nested maps/lists and replaces values under secret-looking keys with the existing `REDACTED` placeholder

## Design Decisions

Surfacing over supporting: map-form stage `jobs:` stays unconverted (it's not canonical Bamboo Specs) — the fix makes the loss visible instead of building speculative support. Redaction reuses the established `bambooLooksSecret` + placeholder convention from top-level fields.

## Example

```bash
teamcity migrate --dry-run   # spec with map-form stage jobs
...
    ⚠ Partial conversion — 1 to review     # previously: ✓ Fully converted
Needs review:
  • Stage "S" has `jobs:` entries that are not plain job-name strings → those jobs were not converted; rewrite `jobs:` as a list of job names
```

```yaml
# unknown-task stub, nested secret — previously: map[password:hunter2 ...]
#   configuration: map[password:REDACTED url:https://example.com]
```

## Test Plan

- [x] Unit tests pass (`just unit`) — adds TestBambooMapFormStageJobsSurfaceAsReview, TestBambooNonStringStageJobEntrySurfacesAsReview, TestBambooUnknownTaskNestedSecretRedacted
- [ ] Linter passes (`just lint`) — N/A locally: golangci-lint binary targets Go 1.25 < 1.26; gofmt + `go vet` clean, CI Lint covers it
- [ ] Acceptance tests pass (`just acceptance`) — N/A — experimental command has no acceptance coverage (matches `run diff` precedent)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [x] If modifying `--json` output: no field removals/renames (additive only) — only new entries in the existing `needsReview` array
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — report-only additions
- [ ] External contributors: links a `status:finalized` issue — N/A — maintainer session

https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246)_