### PR TITLE
fix(api): emit empty pipeline and reason arrays as [] in --json

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -150,7 +150,7 @@ type CompatibilityList struct {
 
 // IncompatibleReasons contains reasons why an agent can't run a build type
 type IncompatibleReasons struct {
-	Reasons []string `json:"reason,omitempty"`
+	Reasons []string `json:"reason,omitzero"`
 }
 
 // UnmetRequirements holds the human-readable incompatibility description (may be multi-line).
@@ -561,7 +561,7 @@ type Pipeline struct {
 // PipelineJobs represents the jobs within a pipeline
 type PipelineJobs struct {
 	Count int           `json:"count"`
-	Job   []PipelineJob `json:"job,omitempty"`
+	Job   []PipelineJob `json:"job,omitzero"`
 }
 
 // PipelineJob represents a single job in a pipeline (uses YAML keys, not generated IDs)
@@ -574,7 +574,7 @@ type PipelineJob struct {
 type PipelineList struct {
 	Count     int        `json:"count"`
 	NextHref  string     `json:"nextHref,omitempty"`
-	Pipelines []Pipeline `json:"pipeline,omitempty"`
+	Pipelines []Pipeline `json:"pipeline,omitzero"`
 }
 
 // ProjectRef is a lightweight reference to a project

--- a/internal/cmd/agent/agent.go
+++ b/internal/cmd/agent/agent.go
@@ -214,8 +214,12 @@ func runAgentView(f *cmdutil.Factory, nameOrID string, opts *cmdutil.ViewOptions
 	}
 
 	if agent.Build != nil {
+		jobName := agent.Build.BuildTypeID
+		if agent.Build.BuildType != nil {
+			jobName = agent.Build.BuildType.Name
+		}
 		_, _ = fmt.Fprintf(p.Out, "\nCurrent build: %s %d  #%s (%s)\n",
-			agent.Build.BuildType.Name,
+			jobName,
 			agent.Build.ID,
 			agent.Build.Number,
 			agent.Build.Status)


### PR DESCRIPTION
## Summary

Two small robustness fixes around server responses. Follow-up to b3eda8e: `collectPages` now returns non-nil empty slices, but the `omitempty` tag on `PipelineList.Pipelines` also drops empty non-nil slices, so `teamcity pipeline list --json` with zero pipelines emitted `{"count":0}` with no `pipeline` key. Switching the tag to `omitzero` keeps nil slices omitted while serializing decoded/constructed empty slices as `[]`; same fix applied to `PipelineJobs.Job` and `IncompatibleReasons.Reasons`, which re-marshal server responses verbatim. Separately, `teamcity agent view` dereferenced `agent.Build.BuildType.Name` without a nil check and could panic when the API omits `buildType` (e.g. queued builds).

## Changes

- `api/types.go`: `omitempty` → `omitzero` on the `PipelineList.Pipelines`, `PipelineJobs.Job`, and `IncompatibleReasons.Reasons` slice fields
- `internal/cmd/agent/agent.go`: fall back to `BuildTypeID` when the current build's `BuildType` is nil

## Design Decisions

`omitzero` over dropping the option entirely: a nil slice (key absent in the server response) stays omitted, so output remains faithful to what the server sent; only genuinely-present empty arrays round-trip as `[]`. The nil-`BuildType` fallback follows the existing pattern in `run/tree.go`, `run/diff.go`, and `run/watch.go`.

## Example

```bash
teamcity pipeline list --json
{"count":0,"pipeline":[]}
```

Previously emitted `{"count":0}`.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — not run; serialization and display-fallback changes only
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A, no new command
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A, no docs-visible change
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A, maintainer