### PR TITLE
fix(migrate): shell-quote k8s-deploy manifest paths

### DIFF
--- a/internal/migrate/convert_test.go
+++ b/internal/migrate/convert_test.go
@@ -428,3 +428,16 @@ jobs:
 	assert.Contains(t, manuals, `Job "exp" has continue-on-error: ${{ matrix.experimental }}`)
 	assert.Contains(t, manuals, `Step "" has continue-on-error: ${{ matrix.experimental }}`)
 }
+
+func TestK8sDeployManifestsQuoted(t *testing.T) {
+	t.Parallel()
+
+	transformer, ok := LookupActionTransformer("azure/k8s-deploy@v5")
+	require.True(t, ok)
+	r := transformer("Deploy", map[string]string{"manifests": "deploy/prod;rm\nk8s/$(whoami).yml"})
+	require.Len(t, r.Steps, 1)
+	script := r.Steps[0].ScriptContent
+	// Each manifest token must be an inert single-quoted shell word.
+	assert.Contains(t, script, "-f 'deploy/prod;rm'")
+	assert.Contains(t, script, "-f 'k8s/$(whoami).yml'")
+}

--- a/internal/migrate/github_actions.go
+++ b/internal/migrate/github_actions.go
@@ -218,7 +218,7 @@ func initActionRegistry() map[string]actionTransformer {
 		// `manifests:` is a newline-separated list; emit one -f per entry so a multiline value can't spill onto a new shell line.
 		for f := range strings.FieldsSeq(cmp.Or(inputs["manifests"], "k8s/")) {
 			cmd.WriteString(" -f ")
-			cmd.WriteString(f)
+			cmd.WriteString(shellQuote(f))
 		}
 		return Converted([]Step{{Name: cmp.Or(name, "Kubernetes deploy"), ScriptContent: cmd.String()}})
 	}


### PR DESCRIPTION
## Summary

Last live Codex finding on #226: `azure/k8s-deploy` manifest tokens were appended bare into the generated `kubectl apply` command, so a value containing shell metacharacters (`deploy/prod;rm`, `$(...)`) would be interpreted by the shell in the migrated step instead of passed inertly. Every sibling transformer already quotes its inputs; this routes each `-f` token through the existing `shellQuote`.

## Changes

- `azure/k8s-deploy` transformer: `shellQuote` each manifests token
- Test: metacharacter and command-substitution tokens emit as inert single-quoted words

## Design Decisions

Straightforward.

## Example

```bash
# manifests: "deploy/prod;rm" — previously: kubectl apply -f deploy/prod;rm
kubectl apply -f 'deploy/prod;rm'
```

## Test Plan

- [x] Unit tests pass (`just unit`) — adds TestK8sDeployManifestsQuoted
- [ ] Linter passes (`just lint`) — N/A locally: golangci-lint binary targets Go 1.25 < 1.26; gofmt + `go vet` clean, CI Lint covers it
- [ ] Acceptance tests pass (`just acceptance`) — N/A — experimental command has no acceptance coverage
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — output hardening only
- [ ] External contributors: links a `status:finalized` issue — N/A — maintainer session

https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbdKaW4r5re1gXoT9uw246)_