### PR TITLE
fix(tests): retry sandbox test on seatbelt proxyconnect EPERM flake

### DIFF
--- a/api/sandbox_test.go
+++ b/api/sandbox_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,13 +60,27 @@ exec "$@"
 `), 0o755))
 
 	sandboxCmd := func(env []string, args ...string) *exec.Cmd {
-		// Pin the version so CI doesn't float with srt releases; SRT_DEBUG streams
-		// seatbelt violations to stderr so proxy EPERM failures are diagnosable.
+		// Pin the version so CI doesn't float with srt releases; SRT_DEBUG surfaces srt's init and proxy-filter decisions (kernel seatbelt denials are never streamed under npx).
 		full := []string{"-y", "@anthropic-ai/sandbox-runtime@0.0.54", "-s", settings, wrapper}
 		full = append(full, args...)
 		cmd := exec.Command(npx, full...)
 		cmd.Env = append(os.Environ(), append([]string{"SRT_DEBUG=1"}, env...)...)
 		return cmd
+	}
+
+	// macOS seatbelt intermittently denies the child's connect to srt's own proxy port (EPERM) even though the profile allows it — ~13% of Sonoma CI runs, uncorrelated with srt version or agent, not reproducible locally. Each attempt gets a fresh sandbox; any other failure returns immediately.
+	runSandboxed := func(t *testing.T, mk func() *exec.Cmd) (string, string, error) {
+		for attempt := 1; ; attempt++ {
+			var stdout, stderr bytes.Buffer
+			cmd := mk()
+			cmd.Stdout, cmd.Stderr = &stdout, &stderr
+			err := cmd.Run()
+			flaky := strings.Contains(stderr.String(), "proxyconnect") && strings.Contains(stderr.String(), "operation not permitted")
+			if err == nil || !flaky || attempt == 3 {
+				return stdout.String(), stderr.String(), err
+			}
+			t.Logf("retrying after seatbelt proxyconnect EPERM flake (attempt %d/3)", attempt)
+		}
 	}
 
 	// Probe: verify sandbox-runtime works on this host (bwrap may fail on restricted VMs).
@@ -75,29 +90,29 @@ exec "$@"
 	}
 
 	T.Run("guest API call", func(T *testing.T) {
-		cmd := sandboxCmd(
-			[]string{"TEAMCITY_URL=https://cli.teamcity.com", "TEAMCITY_GUEST=1", "NO_COLOR=1"},
-			binary, "api", "/app/rest/server",
-		)
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		require.NoError(T, cmd.Run(), "sandbox command failed: stdout=%s stderr=%s", stdout.String(), stderr.String())
+		stdout, stderr, err := runSandboxed(T, func() *exec.Cmd {
+			return sandboxCmd(
+				[]string{"TEAMCITY_URL=https://cli.teamcity.com", "TEAMCITY_GUEST=1", "NO_COLOR=1"},
+				binary, "api", "/app/rest/server",
+			)
+		})
+		require.NoError(T, err, "sandbox command failed: stdout=%s stderr=%s", stdout, stderr)
 
 		var resp map[string]any
-		require.NoError(T, json.Unmarshal(stdout.Bytes(), &resp), "response is not JSON: %s", stdout.String())
+		require.NoError(T, json.Unmarshal([]byte(stdout), &resp), "response is not JSON: %s", stdout)
 		assert.NotEmpty(T, resp["buildNumber"], "expected buildNumber in server response")
 	})
 
 	T.Run("blocked domain", func(T *testing.T) {
-		cmd := sandboxCmd(
-			[]string{"TEAMCITY_URL=https://not-allowed.example.com", "TEAMCITY_GUEST=1", "NO_COLOR=1"},
-			binary, "api", "/app/rest/server",
-		)
-		out, _ := cmd.CombinedOutput()
+		stdout, stderr, _ := runSandboxed(T, func() *exec.Cmd {
+			return sandboxCmd(
+				[]string{"TEAMCITY_URL=https://not-allowed.example.com", "TEAMCITY_GUEST=1", "NO_COLOR=1"},
+				binary, "api", "/app/rest/server",
+			)
+		})
 		// The renderer surfaces the raw transport error plus the category-default
 		// sandbox hint. Assert on the hint phrasing — it's the signal that the
 		// CLI recognised this as a sandbox block rather than a generic network error.
-		assert.Contains(T, string(out), "sandbox allowlist")
+		assert.Contains(T, stdout+stderr, "sandbox allowlist")
 	})
 }


### PR DESCRIPTION
## Summary

`TestSandboxGuestAuth/guest_API_call` fails on ~13% of macOS CI runs (28/207 since 2026-05-22, 25% on main) with `proxyconnect tcp: dial tcp 127.0.0.1:<port>: connect: operation not permitted` — macOS seatbelt denies the sandboxed CLI's connect to sandbox-runtime's own HTTP proxy even though the generated profile allows it. The deny is kernel-side on the Sonoma CI agents and outside this repo's control: srt's port/env/profile state is provably consistent per run, Go always dials the proxy with a pure AF_INET socket, and 160 local iterations can't reproduce it. Since each srt invocation is an independent sandbox, the fix retries up to 3× on exactly this failure signature, taking expected red builds from ~1-in-7 to ~1-in-400 while keeping every other failure loud.

## Changes

- `api/sandbox_test.go`: add `runSandboxed` helper — reruns the sandboxed command (fresh sandbox per attempt, max 3) only when stderr matches `proxyconnect` + `operation not permitted`; both subtests use it
- Correct the `SRT_DEBUG` comment: it only surfaces srt's init/proxy-filter lines; kernel seatbelt denials are never streamed under `npx` (the log monitor is embedder-only)

## Design Decisions

- Retry on signature, not unconditionally, so genuine regressions still fail on first attempt.
- Rejected `network.allowLocalBinding: true` (the upstream-sanctioned knob for loopback EPERM): experimentally verified it lets the sandboxed child connect directly to external IPs (1.1.1.1:443), defeating the egress isolation the test exists to exercise (anthropic-experimental/sandbox-runtime#225).
- Root cause can't be fixed here: seatbelt SBPL IP filters only accept `localhost`/`*` hosts, and srt's `(allow network-outbound (remote ip "localhost:PORT"))` proxy rule is the fragile piece — an upstream issue is the escalation path if the residual rate is still noticeable.

## Example

N/A — not user-visible (test-only change).

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A: test-only change; ran `go test -tags=sandbox -run TestSandboxGuestAuth ./api` end-to-end instead (passes, 4.2s)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A
- [ ] External contributors: links a `status:finalized` issue — N/A: maintainer