### PR TITLE
fix(config): preserve context path in NormalizeURL

### DIFF
--- a/api/interface.go
+++ b/api/interface.go
@@ -146,6 +146,7 @@ type ClientInterface interface {
 	DeleteProjectFeature(projectID, featureID string) error
 
 	RawRequest(ctx context.Context, method, path string, body io.Reader, headers map[string]string) (*RawResponse, error)
+	NormalizePaginationPath(href string) string
 
 	SetCommandName(name string)
 	ServerURL() string

--- a/api/paginate.go
+++ b/api/paginate.go
@@ -26,18 +26,18 @@ func collectPages[T any](c *Client, path string, limit int, fetch func(string) (
 		}
 		all = append(all, items...)
 		if limit > 0 && len(all) >= limit {
-			truncated := len(all) > limit || c.normalizePaginationPath(nextHref) != ""
+			truncated := len(all) > limit || c.NormalizePaginationPath(nextHref) != ""
 			return all[:limit], truncated, nil
 		}
-		path = c.normalizePaginationPath(nextHref)
+		path = c.NormalizePaginationPath(nextHref)
 	}
 	return all, false, nil
 }
 
-// normalizePaginationPath converts a TeamCity NextHref value into a path
-// suitable for c.get. It strips the scheme/host, context path, guestAuth
-// prefix, and API version so that apiPath() can re-apply them consistently.
-func (c *Client) normalizePaginationPath(href string) string {
+// NormalizePaginationPath converts a TeamCity NextHref value into a path
+// suitable for c.get / RawRequest. It strips the scheme/host, context path,
+// guestAuth prefix, and API version so that apiPath() can re-apply them consistently.
+func (c *Client) NormalizePaginationPath(href string) string {
 	if href == "" {
 		return ""
 	}

--- a/api/paginate_test.go
+++ b/api/paginate_test.go
@@ -173,7 +173,7 @@ func TestNormalizePaginationPath(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &Client{BaseURL: tt.baseURL, APIVersion: tt.apiVersion}
-			got := c.normalizePaginationPath(tt.href)
+			got := c.NormalizePaginationPath(tt.href)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/cmd/api/api.go
+++ b/internal/cmd/api/api.go
@@ -319,7 +319,8 @@ func fetchAllPages(ctx context.Context, client api.ClientInterface, endpoint str
 			return pages, lastStatus, nil
 		}
 
-		currentEndpoint = nextHref
+		// nextHref carries the server's context path (e.g. /bs); strip it so RawRequest's BaseURL doesn't double it.
+		currentEndpoint = client.NormalizePaginationPath(nextHref)
 	}
 
 	return nil, lastStatus, fmt.Errorf("--paginate hit the page cap of %d with more pages still available; refine your query (e.g. add a locator filter)", maxPaginationPages)

--- a/internal/cmd/api/api_test.go
+++ b/internal/cmd/api/api_test.go
@@ -384,6 +384,47 @@ func TestAPICommandPaginate(T *testing.T) {
 	assert.Equal(T, 2, pageNum, "request count")
 }
 
+func TestAPICommandPaginateContextPath(T *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if len(paths) == 1 {
+			json.NewEncoder(w).Encode(map[string]any{
+				"count":    1,
+				"nextHref": "/bs/app/rest/builds?start=2",
+				"build":    []map[string]int{{"id": 1}},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"count": 1,
+			"build": []map[string]int{{"id": 2}},
+		})
+	}))
+	originalURL := os.Getenv("TEAMCITY_URL")
+	originalToken := os.Getenv("TEAMCITY_TOKEN")
+	os.Setenv("TEAMCITY_URL", server.URL+"/bs")
+	os.Setenv("TEAMCITY_TOKEN", "test-token")
+	config.Init()
+	T.Cleanup(func() {
+		server.Close()
+		os.Setenv("TEAMCITY_URL", originalURL)
+		os.Setenv("TEAMCITY_TOKEN", originalToken)
+		config.Init()
+	})
+
+	var out bytes.Buffer
+	rootCmd := createTestRootCmd()
+	rootCmd.SetArgs([]string{"api", "/app/rest/builds", "--paginate"})
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+
+	require.NoError(T, rootCmd.Execute())
+	assert.Equal(T, []string{"/bs/app/rest/builds", "/bs/app/rest/builds"}, paths,
+		"context path must appear exactly once per request, not doubled")
+}
+
 func TestAPICommandPaginatePreservesProxyErrorBody(T *testing.T) {
 	pageNum := 0
 	setupMockServerForAPI(T, func(w http.ResponseWriter, r *http.Request) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,7 +129,7 @@ func SortedServerURLs(c *Config) []string {
 	return urls
 }
 
-// NormalizeURL reduces a user-supplied URL to its origin (scheme + host + port), adding https:// if no scheme.
+// NormalizeURL canonicalizes a user-supplied URL to scheme + host + port + context path (preserving e.g. /bs), adding https:// if no scheme and dropping any query, fragment, and trailing slash.
 //
 //goland:noinspection HttpUrlsUsage
 func NormalizeURL(u string) string {
@@ -144,7 +144,7 @@ func NormalizeURL(u string) string {
 	if err != nil || parsed.Host == "" {
 		return strings.TrimSuffix(u, "/")
 	}
-	return parsed.Scheme + "://" + parsed.Host
+	return parsed.Scheme + "://" + parsed.Host + strings.TrimSuffix(parsed.Path, "/")
 }
 
 func keyringService(serverURL string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -58,6 +58,33 @@ func TestGetServerURLFromEnv(T *testing.T) {
 	assert.Equal(T, want, got)
 }
 
+func TestNormalizeURL(T *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain host", "https://tc.example.com", "https://tc.example.com"},
+		{"trailing slash", "https://tc.example.com/", "https://tc.example.com"},
+		{"no scheme", "tc.example.com", "https://tc.example.com"},
+		{"http scheme kept", "http://tc.example.com", "http://tc.example.com"},
+		{"port", "https://tc.example.com:8111", "https://tc.example.com:8111"},
+		{"context path", "https://tc.example.com/bs", "https://tc.example.com/bs"},
+		{"context path trailing slash", "https://tc.example.com/bs/", "https://tc.example.com/bs"},
+		{"context path with port", "https://tc.example.com:8111/bs", "https://tc.example.com:8111/bs"},
+		{"context path no scheme", "tc.example.com/bs", "https://tc.example.com/bs"},
+		{"nested context path", "https://tc.example.com/teamcity/bs", "https://tc.example.com/teamcity/bs"},
+		{"drops query and fragment", "https://tc.example.com/bs?foo=1#x", "https://tc.example.com/bs"},
+		{"whitespace", "  https://tc.example.com/bs  ", "https://tc.example.com/bs"},
+		{"empty", "", ""},
+	}
+	for _, tc := range tests {
+		T.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeURL(tc.in))
+		})
+	}
+}
+
 func TestGetTokenFromEnv(T *testing.T) {
 	want := "test-token-123"
 	T.Setenv(EnvToken, want)


### PR DESCRIPTION
## Summary

`teamcity auth login` dropped the context path from server URLs deployed under a sub-path (e.g. `https://teamcity.example.com/bs`), reducing the URL to scheme + host. The same happened to `TEAMCITY_URL`, since both flow through `config.NormalizeURL`. This made the CLI unusable against context-path deployments (TeamCity's default local IDEA dev build runs under `/bs`).

## Changes

- `NormalizeURL` now preserves the context path (`scheme + host + port + path`) while still trimming the trailing slash and dropping query/fragment.
- Added `TestNormalizeURL` covering context paths, ports, missing scheme, nested paths, and query/fragment stripping.

## Design Decisions

`NormalizeURL` only ever needed to strip the trailing slash and add a scheme — reducing to origin was an over-aggressive side effect that no test guarded. The API client builds requests as `BaseURL + path`, so preserving the path is sufficient for context-path deployments to work end-to-end. Fixing the one function covers every caller (`auth login`/`status`/`logout`, `link`, `config set`, and `TEAMCITY_URL` via `GetServerURL`).

## Example

```bash
$ teamcity auth login -s https://teamcity.example.com/bs --no-browser -t <token>
Checking https://teamcity.example.com/bs... ✓
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A, no server-facing behavior change
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A, no docs-visible change
- [ ] External contributors: links a `status:finalized` issue — N/A, maintainer change
