### PR TITLE
refactor(pipeline): extract pipelineschema package and shared schema cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/JetBrains/teamcity-cli
 go 1.26
 
 require (
-	github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260504151718-1802d9bffbd3
+	github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260529130422-2c411082a674
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/buildkite/shellwords v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260504151718-1802d9bffbd3 h1:1a5K1WC30mBqEG6vRc4a7IWW7CB8QzlTGlSiP59X1vc=
-github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260504151718-1802d9bffbd3/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
+github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260529130422-2c411082a674 h1:0+gxkXi3gvEUPNJ4TDhcdf/M/y/Eq0dX0kNcRNDIgZY=
+github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260529130422-2c411082a674/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/internal/cmd/pipeline/schema.go
+++ b/internal/cmd/pipeline/schema.go
@@ -1,92 +1,13 @@
 package pipeline
 
 import (
-	"crypto/sha256"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
-	"time"
 
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
-	"github.com/JetBrains/teamcity-cli/schemas"
 	"github.com/spf13/cobra"
 )
-
-const schemaTTL = 24 * time.Hour
-
-func schemaDir() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", err
-	}
-	configHome := os.Getenv("XDG_CONFIG_HOME")
-	if configHome == "" {
-		configHome = filepath.Join(home, ".config")
-	}
-	return filepath.Join(configHome, "tc"), nil
-}
-
-func schemaPath(serverURL string) (string, error) {
-	dir, err := schemaDir()
-	if err != nil {
-		return "", err
-	}
-	h := sha256.Sum256([]byte(serverURL))
-	return filepath.Join(dir, fmt.Sprintf("pipeline-schema-%x.json", h[:4])), nil
-}
-
-func loadCachedSchema(serverURL string) ([]byte, error) {
-	path, err := schemaPath(serverURL)
-	if err != nil {
-		return nil, err
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return nil, err
-	}
-
-	if time.Since(info.ModTime()) > schemaTTL {
-		return nil, errors.New("schema cache expired")
-	}
-
-	return os.ReadFile(path)
-}
-
-func saveSchemaCache(serverURL string, schema []byte) error {
-	path, err := schemaPath(serverURL)
-	if err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		return err
-	}
-
-	return os.WriteFile(path, schema, 0600)
-}
-
-// fetchOrCacheSchema returns the schema, whether it came from the on-disk cache, and whether the embedded fallback was used.
-func fetchOrCacheSchema(client *api.Client, refresh bool) ([]byte, bool, bool, error) {
-	if !refresh {
-		if cached, err := loadCachedSchema(client.BaseURL); err == nil {
-			return cached, true, false, nil
-		}
-	}
-
-	schema, err := client.GetPipelineSchema()
-	if err == nil {
-		_ = saveSchemaCache(client.BaseURL, schema)
-		return schema, false, false, nil
-	}
-
-	if !refresh && errors.Is(err, api.ErrPipelineSchemaUnsupported) {
-		return schemas.Pipeline, false, true, nil
-	}
-	return nil, false, false, fmt.Errorf("failed to fetch pipeline schema from server: %w", err)
-}
 
 func newPipelineSchemaCmd(f *cmdutil.Factory) *cobra.Command {
 	var refresh bool
@@ -113,7 +34,7 @@ a warning is written to stderr; pass --refresh to require a live server fetch.`,
 				return errors.New("schema requires a real API client")
 			}
 
-			data, _, fallback, err := fetchOrCacheSchema(c, refresh)
+			data, _, fallback, err := cmdutil.FetchOrCachePipelineSchema(c, refresh)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/pipeline/validate.go
+++ b/internal/cmd/pipeline/validate.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -11,6 +10,7 @@ import (
 	"github.com/JetBrains/teamcity-cli/internal/analytics"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/JetBrains/teamcity-cli/internal/pipelineschema"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -117,7 +117,12 @@ func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, bool, error)
 
 	client, err := f.Client()
 	if err != nil {
-		return nil, false, err
+		// --refresh-schema explicitly asks for a server fetch, so don't mask the auth failure.
+		if opts.refreshSchema {
+			return nil, false, err
+		}
+		f.Printer.Warn("Not authenticated - validating against the embedded schema; run 'teamcity auth login' to use your server's schema")
+		return pipelineschema.Bytes, false, nil
 	}
 
 	c, ok := client.(*api.Client)
@@ -125,7 +130,7 @@ func loadSchema(f *cmdutil.Factory, opts *validateOptions) ([]byte, bool, error)
 		return nil, false, errors.New("schema caching requires a real API client")
 	}
 
-	data, fromCache, _, err := fetchOrCacheSchema(c, opts.refreshSchema)
+	data, fromCache, _, err := cmdutil.FetchOrCachePipelineSchema(c, opts.refreshSchema)
 	return data, fromCache, err
 }
 
@@ -135,23 +140,12 @@ type validationError struct {
 }
 
 func validateAgainstSchema(schemaData []byte, doc any) ([]validationError, error) {
-	var schemaDoc any
-	if err := json.Unmarshal(schemaData, &schemaDoc); err != nil {
-		return nil, fmt.Errorf("invalid JSON schema: %w", err)
-	}
-
-	compiler := jsonschema.NewCompiler()
-	if err := compiler.AddResource("schema.json", schemaDoc); err != nil {
-		return nil, fmt.Errorf("failed to compile schema: %w", err)
-	}
-
-	schema, err := compiler.Compile("schema.json")
+	schema, err := pipelineschema.Compile(schemaData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to compile schema: %w", err)
 	}
 
-	converted := convertYAMLToJSON(doc)
-	err = schema.Validate(converted)
+	err = schema.Validate(pipelineschema.ConvertYAMLToJSON(doc))
 	if err == nil {
 		return nil, nil
 	}
@@ -189,34 +183,6 @@ func flattenValidationErrors(ve *jsonschema.ValidationError, prefix string) []va
 	}
 
 	return result
-}
-
-// convertYAMLToJSON converts YAML-parsed values to JSON-compatible types.
-// yaml.v3 uses map[string]any for mappings, which jsonschema expects,
-// but integer keys and other edge cases need conversion.
-func convertYAMLToJSON(v any) any {
-	switch val := v.(type) {
-	case map[string]any:
-		result := make(map[string]any, len(val))
-		for k, v := range val {
-			result[k] = convertYAMLToJSON(v)
-		}
-		return result
-	case map[any]any:
-		result := make(map[string]any, len(val))
-		for k, v := range val {
-			result[fmt.Sprint(k)] = convertYAMLToJSON(v)
-		}
-		return result
-	case []any:
-		result := make([]any, len(val))
-		for i, v := range val {
-			result[i] = convertYAMLToJSON(v)
-		}
-		return result
-	default:
-		return v
-	}
 }
 
 // findLineNumber walks the YAML node tree to find the line number for a JSON pointer path.

--- a/internal/cmd/pipeline/validate_test.go
+++ b/internal/cmd/pipeline/validate_test.go
@@ -57,48 +57,6 @@ jobs:
 	})
 }
 
-func TestConvertYAMLToJSON(t *testing.T) {
-	t.Parallel()
-
-	t.Run("string keys passthrough", func(t *testing.T) {
-		in := map[string]any{"k": "v"}
-		got := convertYAMLToJSON(in)
-		assert.Equal(t, map[string]any{"k": "v"}, got)
-	})
-
-	t.Run("integer keys stringified", func(t *testing.T) {
-		// jsonschema only accepts string keys, so map[any]any keys must stringify.
-		in := map[any]any{1: "one", "two": 2}
-		got := convertYAMLToJSON(in)
-		want := map[string]any{"1": "one", "two": 2}
-		assert.Equal(t, want, got)
-	})
-
-	t.Run("nested arrays and maps", func(t *testing.T) {
-		in := map[string]any{
-			"jobs": map[any]any{
-				"build": map[string]any{
-					"steps": []any{
-						map[any]any{"script": "go build"},
-					},
-				},
-			},
-		}
-		got := convertYAMLToJSON(in).(map[string]any)
-		jobs := got["jobs"].(map[string]any)
-		build := jobs["build"].(map[string]any)
-		steps := build["steps"].([]any)
-		assert.Equal(t, "go build", steps[0].(map[string]any)["script"])
-	})
-
-	t.Run("scalars unchanged", func(t *testing.T) {
-		assert.Equal(t, "x", convertYAMLToJSON("x"))
-		assert.Equal(t, 42, convertYAMLToJSON(42))
-		assert.Equal(t, true, convertYAMLToJSON(true))
-		assert.Equal(t, nil, convertYAMLToJSON(nil))
-	})
-}
-
 func TestValidateAgainstSchema(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmdutil/schema_cache.go
+++ b/internal/cmdutil/schema_cache.go
@@ -1,0 +1,80 @@
+package cmdutil
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/JetBrains/teamcity-cli/internal/pipelineschema"
+)
+
+const schemaCacheTTL = 24 * time.Hour
+
+// FetchOrCachePipelineSchema returns (schema, fromCache, fellBackToEmbedded, err); refresh=true bypasses the 24h cache.
+func FetchOrCachePipelineSchema(client *api.Client, refresh bool) ([]byte, bool, bool, error) {
+	if !refresh {
+		if cached, err := loadSchemaCache(client.BaseURL); err == nil {
+			return cached, true, false, nil
+		}
+	}
+
+	schema, err := client.GetPipelineSchema()
+	if err == nil {
+		_ = saveSchemaCache(client.BaseURL, schema)
+		return schema, false, false, nil
+	}
+
+	if !refresh && errors.Is(err, api.ErrPipelineSchemaUnsupported) {
+		return pipelineschema.Bytes, false, true, nil
+	}
+	return nil, false, false, fmt.Errorf("failed to fetch pipeline schema from server: %w", err)
+}
+
+func schemaCachePath(serverURL string) (string, error) {
+	dir, err := config.ConfigDir()
+	if err != nil {
+		return "", err
+	}
+	h := sha256.Sum256([]byte(serverURL))
+	return filepath.Join(dir, fmt.Sprintf("pipeline-schema-%x.json", h[:4])), nil
+}
+
+func loadSchemaCache(serverURL string) ([]byte, error) {
+	path, err := schemaCachePath(serverURL)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+	if time.Since(info.ModTime()) > schemaCacheTTL {
+		return nil, errors.New("schema cache expired")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	// A torn write leaves invalid JSON with a fresh mtime; treat it as a miss so it self-heals.
+	if !json.Valid(data) {
+		return nil, errors.New("schema cache corrupt")
+	}
+	return data, nil
+}
+
+func saveSchemaCache(serverURL string, schema []byte) error {
+	path, err := schemaCachePath(serverURL)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, schema, 0600)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,17 +67,24 @@ var (
 	dslServerURL  string
 )
 
-func Init() error {
+// ConfigDir returns the teamcity-cli config directory ($XDG_CONFIG_HOME/tc or ~/.config/tc).
+func ConfigDir() (string, error) {
 	home, err := userHomeDirFn()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return "", fmt.Errorf("failed to get home directory: %w", err)
 	}
-
 	configHome := os.Getenv("XDG_CONFIG_HOME")
 	if configHome == "" {
 		configHome = filepath.Join(home, ".config")
 	}
-	configDir := filepath.Join(configHome, "tc")
+	return filepath.Join(configHome, "tc"), nil
+}
+
+func Init() error {
+	configDir, err := ConfigDir()
+	if err != nil {
+		return err
+	}
 	configPath = filepath.Join(configDir, "config.yml")
 
 	if err := os.MkdirAll(configDir, 0700); err != nil {

--- a/internal/pipelineschema/schema.go
+++ b/internal/pipelineschema/schema.go
@@ -1,0 +1,94 @@
+package pipelineschema
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/JetBrains/teamcity-cli/schemas"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+var Bytes = schemas.Pipeline
+
+// HostedAgentNames extracts the JetBrains-hosted agent enum from a schema's runs-on definition; nil when the schema doesn't constrain agent names.
+func HostedAgentNames(schemaData []byte) []string {
+	var s struct {
+		Definitions struct {
+			RunOn struct {
+				AnyOf []struct {
+					Enum []string `json:"enum"`
+				} `json:"anyOf"`
+			} `json:"runOn"`
+		} `json:"definitions"`
+	}
+	if err := json.Unmarshal(schemaData, &s); err != nil {
+		return nil
+	}
+	for _, opt := range s.Definitions.RunOn.AnyOf {
+		if len(opt.Enum) == 1 && opt.Enum[0] == "self-hosted" {
+			continue
+		}
+		if len(opt.Enum) > 0 {
+			return opt.Enum
+		}
+	}
+	return nil
+}
+
+// ValidateWithSchema checks TC pipeline YAML against the given JSON schema; returns "" if valid.
+func ValidateWithSchema(yamlData string, schemaData []byte) string {
+	var doc any
+	if err := yaml.Unmarshal([]byte(yamlData), &doc); err != nil {
+		return fmt.Sprintf("invalid YAML: %s", err)
+	}
+
+	schema, err := Compile(schemaData)
+	if err != nil {
+		return fmt.Sprintf("internal error: %s", err)
+	}
+
+	if err := schema.Validate(ConvertYAMLToJSON(doc)); err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+// Compile parses and compiles a pipeline JSON schema document.
+func Compile(schemaData []byte) (*jsonschema.Schema, error) {
+	var schemaDoc any
+	if err := json.Unmarshal(schemaData, &schemaDoc); err != nil {
+		return nil, fmt.Errorf("invalid schema: %w", err)
+	}
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", schemaDoc); err != nil {
+		return nil, err
+	}
+	return compiler.Compile("schema.json")
+}
+
+// ConvertYAMLToJSON normalizes YAML-decoded values to JSON-compatible types.
+func ConvertYAMLToJSON(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(val))
+		for k, v := range val {
+			result[k] = ConvertYAMLToJSON(v)
+		}
+		return result
+	case map[any]any:
+		result := make(map[string]any, len(val))
+		for k, v := range val {
+			result[fmt.Sprint(k)] = ConvertYAMLToJSON(v)
+		}
+		return result
+	case []any:
+		result := make([]any, len(val))
+		for i, v := range val {
+			result[i] = ConvertYAMLToJSON(v)
+		}
+		return result
+	default:
+		return v
+	}
+}

--- a/internal/pipelineschema/schema_test.go
+++ b/internal/pipelineschema/schema_test.go
@@ -1,0 +1,50 @@
+package pipelineschema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHostedAgentNames(t *testing.T) {
+	t.Parallel()
+
+	// Shape of the 2026.2 server schema: hosted enum first, then self-hosted const and object forms.
+	server := []byte(`{"definitions": {"runOn": {"anyOf": [
+		{"type": "string", "title": "JetBrains-hosted agents", "enum": ["Windows-Small", "Mac-Medium", "Linux-Large"]},
+		{"type": "string", "title": "Self-hosted agents", "enum": ["self-hosted"]},
+		{"type": "object", "title": "Self-hosted agents"}
+	]}}}`)
+	assert.Equal(t, []string{"Windows-Small", "Mac-Medium", "Linux-Large"}, HostedAgentNames(server))
+
+	// Self-hosted-only enums never count as hosted agent names.
+	selfOnly := []byte(`{"definitions": {"runOn": {"anyOf": [{"type": "string", "enum": ["self-hosted"]}]}}}`)
+	assert.Nil(t, HostedAgentNames(selfOnly))
+
+	assert.Nil(t, HostedAgentNames(nil))
+	assert.Nil(t, HostedAgentNames([]byte("not json")))
+}
+
+func TestConvertYAMLToJSON(t *testing.T) {
+	t.Parallel()
+
+	// jsonschema only accepts string keys, so map[any]any keys must stringify.
+	assert.Equal(t,
+		map[string]any{"1": "one", "two": 2},
+		ConvertYAMLToJSON(map[any]any{1: "one", "two": 2}))
+
+	in := map[string]any{
+		"jobs": map[any]any{
+			"build": map[string]any{
+				"steps": []any{
+					map[any]any{"script": "go build"},
+				},
+			},
+		},
+	}
+	got := ConvertYAMLToJSON(in).(map[string]any)
+	jobs := got["jobs"].(map[string]any)
+	build := jobs["build"].(map[string]any)
+	steps := build["steps"].([]any)
+	assert.Equal(t, "go build", steps[0].(map[string]any)["script"])
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/JetBrains/teamcity-cli/internal/config"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/JetBrains/teamcity-cli/internal/version"
 	"golang.org/x/term"
@@ -40,11 +41,11 @@ func (s *State) IsStale(interval time.Duration) bool {
 }
 
 func stateFilePath() string {
-	home, err := os.UserHomeDir()
+	dir, err := config.ConfigDir()
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, ".config", "tc", stateFileName)
+	return filepath.Join(dir, stateFileName)
 }
 
 func LoadState() *State {


### PR DESCRIPTION
## Summary

Split out of #226 to keep that PR focused on `migrate`. Pulls the pipeline JSON-schema helpers out of `internal/cmd/pipeline` into a reusable `internal/pipelineschema` package and the on-disk schema cache into `cmdutil.FetchOrCachePipelineSchema`, so both `pipeline` and the upcoming `migrate` command share one definition. Adds `config.ConfigDir()` as the single source for the config-dir path, and makes `pipeline validate` fall back to the embedded schema when run unauthenticated instead of erroring.

## Changes

- New `internal/pipelineschema` package: `Bytes`, `Compile`, `ValidateWithSchema`, `ConvertYAMLToJSON`, `HostedAgentNames`.
- New `cmdutil.FetchOrCachePipelineSchema` (24h on-disk cache, embedded fallback, corrupt-cache self-heal); removes the duplicate cache logic from `pipeline/schema.go`.
- `config.ConfigDir()` extracted; `update` state path and schema cache now derive from it.
- `pipeline validate` validates against the embedded schema when not authenticated (warns instead of failing).
- Bump `fus-reporting-api-go`.

## Design Decisions

Straightforward.

## Example

```bash
$ teamcity pipeline validate .tc.yml   # no auth
⚠ Not authenticated - validating against the embedded schema; run 'teamcity auth login' to use your server's schema
✓ .tc.yml is valid
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no command/flag surface change
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — internal refactor + unauth fallback only
- [ ] External contributors: links a `status:finalized` issue — N/A — internal change