### PR TITLE
chore(issue-template): add migrate issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/migrate_issue.yml
+++ b/.github/ISSUE_TEMPLATE/migrate_issue.yml
@@ -1,0 +1,84 @@
+name: Migrate Issue
+description: Report a problem with `teamcity migrate` (CI config conversion)
+title: "[migrate] "
+labels: ["migrate", "bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        `teamcity migrate` is an experimental, heuristic converter. To fix
+        a conversion, we need to see the source CI file (or a minimal
+        reproducer). Please redact any secrets or private URLs before pasting.
+
+        For higher-quality conversions, try the bundled `migrate-to-teamcity`
+        skill under an AI agent — it does a semantic review the CLI can't.
+
+  - type: input
+    id: version
+    attributes:
+      label: CLI version
+      description: Run `teamcity --version`
+      placeholder: "v0.2.0"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: source
+    attributes:
+      label: Source CI system
+      options:
+        - GitHub Actions
+        - Bamboo
+        - GitLab CI
+        - Jenkins
+        - CircleCI
+        - Azure DevOps
+        - Travis CI
+        - Bitbucket Pipelines
+    validations:
+      required: true
+
+  - type: textarea
+    id: source-file
+    attributes:
+      label: Source CI file
+      description: Paste the original (or a minimal reproducer). Redact secrets.
+      render: yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: generated
+    attributes:
+      label: Generated `.tc.yml`
+      description: Contents of the generated TeamCity pipeline YAML.
+      render: yaml
+
+  - type: textarea
+    id: command-output
+    attributes:
+      label: Command output
+      description: Output of `teamcity migrate --dry-run` (or the full run, with `--json` if useful).
+      render: shell
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: How should the converted pipeline have looked or behaved?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What went wrong? (missing step, wrong dependency, broken script, crash, etc.)
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Anything else?
+      description: Workarounds tried, related issues, or additional context.


### PR DESCRIPTION
## Summary

Split out of #226. Adds the GitHub issue form for reporting `teamcity migrate` conversion problems, so bug reports arrive with the source CI file, generated `.tc.yml`, and command output already structured.

## Changes

- Add `.github/ISSUE_TEMPLATE/migrate_issue.yml` (labels `migrate`, `bug`; both already exist in the repo).

## Design Decisions

Straightforward.

## Example

N/A — not user-visible (GitHub issue form).

## Test Plan

- [ ] Unit tests pass (`just unit`) — N/A — no code change
- [ ] Linter passes (`just lint`) — N/A — no code change
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no code change
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — issue template only
- [ ] External contributors: links a `status:finalized` issue — N/A