### PR TITLE
Fix skill references

### DIFF
--- a/skills/teamcity-cli/references/output.md
+++ b/skills/teamcity-cli/references/output.md
@@ -57,7 +57,7 @@ teamcity run list --status failure --plain --no-header | awk '{print $2}'
 
 **JSON with jq:**
 ```bash
-teamcity run list --json | jq '.[] | {id, status, branch}'
+teamcity run list --json | jq '.[] | {id, status, branchName}'
 ```
 
 **Get build IDs that failed (JSON):**
@@ -72,7 +72,7 @@ teamcity run list --json=id,status,branchName | jq -r '.[] | [.id,.status,.branc
 
 **Filter builds by pattern:**
 ```bash
-teamcity run list --json | jq '.[] | select(.branch | contains("feature"))'
+teamcity run list --json | jq '.[] | select(.branchName | contains("feature"))'
 ```
 
 **Count builds by status:**

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -467,7 +467,7 @@ VCS roots and build features that reference the deleted connection break — cle
 
 **Gotchas:**
 - `vcs create --auth token` test connection returns "Malformed request" if the user hasn't authorized yet. The CLI prints a tip pointing at `connection authorize`. Run that, then retry.
-- The App's per-repo install (step 2) is mandatory; without it, clones return 404 even with a valid connection.
+- The App's per-repo install (step 3) is mandatory; without it, clones return 404 even with a valid connection.
 - Connections in a parent project are inherited by sub-projects — don't recreate the same connection in nested projects.
 - For Docker on AWS-managed ECR, prefer an AWS connection with role-based federation over Docker credentials.
 


### PR DESCRIPTION
<!-- Keep this lean. Every section stays — write "N/A — <reason>" instead of removing one. The diff carries the details; this body explains what you can't read from the diff. -->

## Summary

<!-- One paragraph. What does this PR do, and why? Link related issues with "Fixes #123". -->

Fixes some wrong references in the `teamcity-cli` skill.

## Changes

<!-- Short bullet list of key changes; group by area if useful. Keep terse. -->

- Proper argument name is `branchName`, fix wrong references in commands.
- Reference correct per-repo install section.

## Design Decisions

<!-- Non-obvious choices and trade-offs. Write "Straightforward." if there are none. -->

## Example

<!-- For CLI changes: show command + output. Write "N/A — not user-visible." if not applicable. -->

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [ ] Unit tests pass (`just unit`)
- [ ] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only)
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change)
