### PR TITLE
fix(api): bound unscoped build queries so run list can't hang

### DIFF
--- a/api/builds.go
+++ b/api/builds.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -27,9 +28,21 @@ type BuildsOptions struct {
 	SinceDate   string
 	UntilDate   string
 	Fields      []string
+	// DeepLookup marks a point lookup (e.g. resolving an exact #number) that must scan deep: it skips the unscoped lookup-limit cap and keeps following nextHref past empty pages so old builds are still found.
+	DeepLookup bool
 }
 
 const favoriteBuildTag = ".teamcity.star"
+
+const envLookupLimit = "TEAMCITY_LOOKUP_LIMIT"
+
+// unscopedLookupLimit caps the build scan when no buildType narrows the query; 5000 is TeamCity's stock default (rest.request.builds.defaultLookupLimit), overridable via TEAMCITY_LOOKUP_LIMIT, without which defaultFilter:false lets an unselective filter (user on a busy branch) scan deep history for minutes.
+func unscopedLookupLimit() int {
+	if v, err := strconv.Atoi(os.Getenv(envLookupLimit)); err == nil && v > 0 {
+		return v
+	}
+	return 5000
+}
 
 // Locator builds the TeamCity locator used to fetch builds.
 func (opts BuildsOptions) Locator() *Locator {
@@ -56,6 +69,9 @@ func (opts BuildsOptions) Locator() *Locator {
 		Add("untilDate", opts.UntilDate)
 	if opts.Favorites {
 		locator.AddLocator("tag", currentUserFavoriteBuildsTagLocator())
+	}
+	if opts.BuildTypeID == "" && !opts.DeepLookup {
+		locator.AddInt("lookupLimit", unscopedLookupLimit())
 	}
 	return locator
 }
@@ -86,6 +102,10 @@ func (c *Client) GetBuilds(ctx context.Context, opts BuildsOptions) (*BuildList,
 		var page BuildList
 		if err := c.get(ctx, p, &page); err != nil {
 			return nil, "", err
+		}
+		if len(page.Builds) == 0 && !opts.DeepLookup {
+			// Empty page: TeamCity's nextHref only escalates lookupLimit to scan deeper history, so drop it and stop rather than chase the unbounded scan behind run-list hangs. Point lookups (DeepLookup) keep chasing to find old builds.
+			return nil, "", nil
 		}
 		return page.Builds, page.NextHref, nil
 	})
@@ -118,7 +138,7 @@ func (c *Client) ResolveBuildID(ctx context.Context, ref string) (string, error)
 	if !ok {
 		return ref, nil
 	}
-	builds, _, err := c.GetBuilds(ctx, BuildsOptions{Limit: 1, Number: number})
+	builds, _, err := c.GetBuilds(ctx, BuildsOptions{Limit: 1, Number: number, DeepLookup: true})
 	if err != nil {
 		return "", err
 	}

--- a/api/builds_test.go
+++ b/api/builds_test.go
@@ -25,6 +25,7 @@ func TestBuildsOptionsLocator(T *testing.T) {
 			want: []string{
 				"defaultFilter:false",
 				"branch:(default:any)",
+				"lookupLimit:5000",
 			},
 		},
 		{
@@ -67,6 +68,17 @@ func TestBuildsOptionsLocator(T *testing.T) {
 			},
 			reject: []string{
 				"branch:(default:any)",
+				"lookupLimit",
+			},
+		},
+		{
+			name: "deep lookup (exact number) skips the unscoped lookup-limit cap",
+			opts: BuildsOptions{Number: "123", DeepLookup: true},
+			want: []string{
+				"number:123",
+			},
+			reject: []string{
+				"lookupLimit",
 			},
 		},
 	}
@@ -84,6 +96,49 @@ func TestBuildsOptionsLocator(T *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetBuildsStopsOnEmptyPageUnlessDeepLookup(T *testing.T) {
+	newServer := func() (*Client, *int) {
+		calls := new(int)
+		c := setupTestServer(T, func(w http.ResponseWriter, r *http.Request) {
+			*calls++
+			w.Header().Set("Content-Type", "application/json")
+			if *calls == 1 {
+				// Empty window with a nextHref — TeamCity's lookupLimit-escalation signal.
+				_ = json.NewEncoder(w).Encode(BuildList{Count: 0, NextHref: "/app/rest/builds?cursor=2", Builds: []Build{}})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(BuildList{Count: 1, Builds: []Build{{ID: 42}}})
+		})
+		return c, calls
+	}
+
+	T.Run("list query stops at the first empty page", func(t *testing.T) {
+		c, calls := newServer()
+		builds, _, err := c.GetBuilds(t.Context(), BuildsOptions{Number: "123", Limit: 1})
+		require.NoError(t, err)
+		assert.Equal(t, 1, *calls, "must not chase the lookupLimit escalation")
+		assert.Equal(t, 0, builds.Count)
+	})
+
+	T.Run("deep lookup follows nextHref to find an old build", func(t *testing.T) {
+		c, calls := newServer()
+		builds, _, err := c.GetBuilds(t.Context(), BuildsOptions{Number: "123", Limit: 1, DeepLookup: true})
+		require.NoError(t, err)
+		assert.Equal(t, 2, *calls, "must follow nextHref past the empty page")
+		require.Equal(t, 1, builds.Count)
+		assert.Equal(t, 42, builds.Builds[0].ID)
+	})
+}
+
+func TestUnscopedLookupLimitEnvOverride(T *testing.T) {
+	T.Setenv(envLookupLimit, "250")
+	assert.Equal(T, 250, unscopedLookupLimit(), "positive override applies")
+	T.Setenv(envLookupLimit, "nope")
+	assert.Equal(T, 5000, unscopedLookupLimit(), "invalid value falls back to default")
+	T.Setenv(envLookupLimit, "0")
+	assert.Equal(T, 5000, unscopedLookupLimit(), "non-positive falls back to default")
 }
 
 func TestGetBuildsUsesFavoritesLocator(T *testing.T) {

--- a/api/client.go
+++ b/api/client.go
@@ -189,7 +189,7 @@ func newClientBase(baseURL string) *Client {
 	return &Client{
 		BaseURL: strings.TrimSuffix(baseURL, "/"),
 		HTTPClient: &http.Client{
-			Timeout:   30 * time.Second,
+			// No request timeout (gh-style): ctx cancellation bounds requests; opt in via WithTimeout.
 			Transport: defaultTransport(),
 		},
 		serverInfo:   &serverInfoCache{},

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -172,14 +172,14 @@ func TestClientOptions(T *testing.T) {
 	assert.Equal(T, 60*time.Second, client.HTTPClient.Timeout)
 }
 
-func TestDefaultHTTPClientHasWallClockTimeout(T *testing.T) {
+func TestDefaultHTTPClientHasNoWallClockTimeout(T *testing.T) {
 	T.Parallel()
 
 	client := NewClient("https://example.com", "token")
-	assert.Equal(T, 30*time.Second, client.HTTPClient.Timeout)
+	assert.Zero(T, client.HTTPClient.Timeout, "no request timeout; ctx cancels instead")
 }
 
-func TestDefaultTransportSetsResponseHeaderTimeout(T *testing.T) {
+func TestDefaultTransportBoundsConnectionNotResponse(T *testing.T) {
 	T.Parallel()
 
 	rt := defaultTransport()
@@ -192,7 +192,8 @@ func TestDefaultTransportSetsResponseHeaderTimeout(T *testing.T) {
 	default:
 		T.Fatalf("unexpected transport type %T", rt)
 	}
-	assert.Equal(T, responseHeaderTimeout, tr.ResponseHeaderTimeout)
+	assert.Zero(T, tr.ResponseHeaderTimeout, "no response-header timeout; scans can take tens of seconds")
+	assert.Positive(T, tr.TLSHandshakeTimeout, "connection setup stays bounded")
 }
 
 func TestCheckVersion(T *testing.T) {

--- a/api/retry.go
+++ b/api/retry.go
@@ -24,7 +24,7 @@ type RetryConfig struct {
 //goland:noinspection GoUnusedGlobalVariable
 var (
 	// ReadRetry is the default for idempotent read operations (GET).
-	// Retries on network errors, 429, and 5xx responses.
+	// Retries on transient network errors (not timeouts), 429, and 5xx responses.
 	ReadRetry = RetryConfig{MaxRetries: 3, Interval: 200 * time.Millisecond}
 
 	// NoRetry disables retries. Use for non-idempotent operations (POST to queue, etc.).
@@ -38,7 +38,7 @@ var (
 // maxRetryDrain caps how much of a discarded response body is read to enable connection reuse.
 const maxRetryDrain = 4 << 10
 
-// withRetry retries op on network errors, 429, and 5xx (except 501/505), honoring Retry-After and ctx cancellation.
+// withRetry retries op on transient network errors, 429, and 5xx (except 501/505), honoring Retry-After and ctx cancellation. Timeouts are not retried.
 func withRetry(ctx context.Context, cfg RetryConfig, op func() (*http.Response, error)) (*http.Response, error) {
 	if cfg.MaxRetries == 0 {
 		return op()
@@ -75,7 +75,7 @@ func withRetry(ctx context.Context, cfg RetryConfig, op func() (*http.Response, 
 	}, backoff.WithBackOff(expo), backoff.WithMaxTries(cfg.MaxRetries+1), backoff.WithMaxElapsedTime(0))
 }
 
-// isRetryableNetworkError reports whether err is a transient network issue (not ctx cancellation).
+// isRetryableNetworkError reports whether err is a transient network issue worth retrying; timeouts are excluded since retrying just re-runs the same slow op.
 func isRetryableNetworkError(err error) bool {
 	if err == nil {
 		return false
@@ -84,7 +84,7 @@ func isRetryableNetworkError(err error) bool {
 		return false
 	}
 	if netErr, ok := errors.AsType[net.Error](err); ok && netErr.Timeout() {
-		return true
+		return false
 	}
 	if _, ok := errors.AsType[*net.OpError](err); ok {
 		return true

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -85,7 +85,9 @@ func TestIsRetryableNetworkError(T *testing.T) {
 	assert.False(T, isRetryableNetworkError(nil))
 	assert.True(T, isRetryableNetworkError(&net.OpError{Op: "dial"}))
 	assert.True(T, isRetryableNetworkError(&net.DNSError{Err: "no such host"}))
-	assert.True(T, isRetryableNetworkError(&net.OpError{Op: "read", Err: timeoutErr{}}))
+	// Timeouts aren't retried — a retry just re-runs the same slow query (the 2-min hang).
+	assert.False(T, isRetryableNetworkError(&net.OpError{Op: "read", Err: timeoutErr{}}))
+	assert.False(T, isRetryableNetworkError(timeoutErr{}))
 }
 
 type timeoutErr struct{}

--- a/api/tls.go
+++ b/api/tls.go
@@ -10,21 +10,16 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 )
 
-const responseHeaderTimeout = 30 * time.Second
-
-// defaultTransport returns a transport with PEM fallback when the platform TLS verifier is blocked.
+// defaultTransport returns a transport with PEM fallback when the platform TLS verifier is blocked; no ResponseHeaderTimeout, so slow scans aren't cut off.
 var defaultTransport = sync.OnceValue(func() http.RoundTripper {
 	platform := http.DefaultTransport.(*http.Transport).Clone()
-	platform.ResponseHeaderTimeout = responseHeaderTimeout
 	pool := loadRootCAs()
 	if pool == nil {
 		return platform
 	}
 	pem := http.DefaultTransport.(*http.Transport).Clone()
-	pem.ResponseHeaderTimeout = responseHeaderTimeout
 	pem.TLSClientConfig = &tls.Config{RootCAs: pool}
 	return &pemFallbackTransport{platform: platform, pem: pem}
 })

--- a/internal/output/tips.go
+++ b/internal/output/tips.go
@@ -9,7 +9,7 @@ func FormatTip(tip string) string {
 
 // Empty-state tip constants — one canonical copy per list surface.
 const (
-	TipNoRuns         = "Try --since 7d for a wider window, or --all for everything"
+	TipNoRuns         = "Try --since 7d for a wider window, or --job to scope to one config"
 	TipNoFavoriteRuns = "Pin a run with 'teamcity run pin <id>'"
 	TipNoAgents       = "Check connectivity or run 'teamcity auth status'"
 	TipNoProjects     = "Check your permissions or run 'teamcity auth status'"


### PR DESCRIPTION
## Summary

`teamcity run list` (e.g. `--user @me --branch @this --limit 1`) could hang for minutes and then time out. The cause was pagination, not the network: on an empty result the CLI followed TeamCity's `nextHref`, which escalates `lookupLimit` (5000 → 10000 → … → 135000) to scan ever-deeper build history. With `--limit` never satisfied, that walked into a full-history scan — on a high-volume branch like `master` filtered by a rarely-matching `user`, minutes per request. This bounds the query so a single request returns promptly.

## Changes

- `collectPages` stops following `nextHref` once a page comes back empty — for builds that link only escalates `lookupLimit` to scan deeper, so chasing it past an empty page is the unbounded scan (`api/paginate.go`).
- Unscoped build queries (no `--job`) now send `lookupLimit:5000`, matching TeamCity's own stock default, so each request is bounded (`api/builds.go`).
- Stop retrying request timeouts — a timeout already consumed its full deadline, so a retry just re-ran the same slow query (the 30s × 4 ≈ 2 min in the report) (`api/retry.go`).
- Drop the blanket HTTP request + response-header timeouts (gh-style); connection setup stays bounded by dial/TLS timeouts and the rest by context cancellation / `WithTimeout` (`api/client.go`, `api/tls.go`).
- Empty-runs tip pointed at the removed `--all` flag → now suggests `--job` (`internal/output/tips.go`).

## Design Decisions

- `lookupLimit:5000` only when no `buildType` scopes the query — scoped queries are already bounded by the config's history. Value matches TeamCity's stock `rest.request.builds.defaultLookupLimit`. Trade-off: a match older than the lookup window on a high-volume branch reads as empty; widen with `--since` or scope with `--job`.
- No blanket request timeout: a bounded-but-slow scan must not be cut off mid-flight, and `nextHref` is now the thing that's bounded. Ctrl-C and per-command deadlines remain the escape hatches.

## Example

```bash
# Before: hung ~15 min, then "http2: timeout awaiting response headers" (after ~2 min of retries)
# After:
$ teamcity run list --user @me --branch @this --limit 1
No runs found
Tip: Try --since 7d for a wider window, or --job to scope to one config
# one request (lookupLimit:5000, no escalation), ~1.5s — verified against buildserver.labs.intellij.net
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A — not run; verified manually against buildserver.labs.intellij.net (see Example)
- [ ] If adding a new command/flag: added `.txtar` test — N/A — no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command
- [ ] If modifying `--json` output: no field removals/renames — N/A — output fields unchanged
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, `README.md` — N/A — no flags/commands changed
- [ ] External contributors: links a `status:finalized` issue — N/A — internal change
