### PR TITLE
feat(auth): align PKCE login scopes with CLI functionality

### DIFF
--- a/api/permissions.go
+++ b/api/permissions.go
@@ -1,18 +1,25 @@
 package api
 
 // KnownPermissions maps TeamCity permission enum names to their server-provided descriptions.
-// Keys mirror ALLOWED_PERMISSIONS in oauth-server/.../OAuthServerConstants.java; values are
-// verbatim from server-model/.../Permission.java. Keep in sync when either list changes.
+// Keys are the permissions the CLI requests (see fallbackScopes in pkce.go); values are verbatim
+// from server-model/.../Permission.java. Keep in sync with fallbackScopes when either changes.
 var KnownPermissions = map[string]string{
 	"VIEW_PROJECT":                       "View project and all parent projects",
 	"VIEW_BUILD_CONFIGURATION_SETTINGS":  "View build configuration settings",
+	"VIEW_BUILD_RUNTIME_DATA":            "View build runtime parameters and data",
 	"VIEW_AGENT_DETAILS":                 "View agent details",
+	"VIEW_AGENT_DETAILS_FOR_PROJECT":     "View project agents details",
+	"VIEW_AGENT_CLOUDS":                  "View cloud images and instances",
 	"RUN_BUILD":                          "Run build",
 	"CANCEL_BUILD":                       "Stop build / remove from queue",
 	"TAG_BUILD":                          "Tag build",
 	"COMMENT_BUILD":                      "Comment build",
+	"ASSIGN_INVESTIGATION":               "Assign / unassign investigation",
+	"MANAGE_BUILD_PROBLEMS":              "Mute / unmute problems and tests in project",
 	"PIN_UNPIN_BUILD":                    "Pin / unpin build",
 	"PATCH_BUILD_SOURCES":                "Change build source code with a custom patch",
+	"CUSTOMIZE_BUILD_PARAMETERS":         "Customize build parameters",
+	"CUSTOMIZE_BUILD_REVISIONS":          "Customize build revisions",
 	"REORDER_BUILD_QUEUE":                "Reorder builds in queue",
 	"PAUSE_ACTIVATE_BUILD_CONFIGURATION": "Pause / activate build configuration",
 	"EDIT_PROJECT":                       "Edit project",
@@ -23,6 +30,7 @@ var KnownPermissions = map[string]string{
 	"AUTHORIZE_AGENT":                    "Authorize agent",
 	"ADMINISTER_AGENT":                   "Administer build agent machines (e.g. reboot, view agent logs, etc.)",
 	"MANAGE_AGENT_POOLS":                 "Manage agent pools",
+	"START_STOP_CLOUD_AGENT":             "Start / Stop cloud agent",
 }
 
 var permissionByDescription = func() map[string]string {

--- a/api/pkce.go
+++ b/api/pkce.go
@@ -26,15 +26,22 @@ var fallbackScopes = []string{
 	// Read
 	"VIEW_PROJECT",
 	"VIEW_BUILD_CONFIGURATION_SETTINGS",
+	"VIEW_BUILD_RUNTIME_DATA",
 	"VIEW_AGENT_DETAILS",
+	"VIEW_AGENT_DETAILS_FOR_PROJECT",
+	"VIEW_AGENT_CLOUDS",
 
 	// Build actions (daily developer workflow)
 	"RUN_BUILD",
 	"CANCEL_BUILD",
 	"TAG_BUILD",
 	"COMMENT_BUILD",
+	"ASSIGN_INVESTIGATION",
+	"MANAGE_BUILD_PROBLEMS",
 	"PIN_UNPIN_BUILD",
 	"PATCH_BUILD_SOURCES",
+	"CUSTOMIZE_BUILD_PARAMETERS",
+	"CUSTOMIZE_BUILD_REVISIONS",
 	"REORDER_BUILD_QUEUE",
 
 	// Project administration
@@ -49,6 +56,7 @@ var fallbackScopes = []string{
 	"AUTHORIZE_AGENT",
 	"ADMINISTER_AGENT",
 	"MANAGE_AGENT_POOLS",
+	"START_STOP_CLOUD_AGENT",
 }
 
 // TokenResponse is TeamCity's reply to a successful PKCE token exchange.

--- a/api/projects.go
+++ b/api/projects.go
@@ -121,7 +121,7 @@ func (c *Client) CreateSecureToken(projectID, value string) (string, error) {
 }
 
 // GetSecureValue retrieves the original value for a secure token.
-// Requires CHANGE_SERVER_SETTINGS permission (System Administrator only).
+// Requires VIEW_SERVER_SETTINGS permission (System Administrator only).
 func (c *Client) GetSecureValue(projectID, token string) (string, error) {
 	path := fmt.Sprintf("/app/rest/projects/%s/secure/values/%s", url.PathEscape(projectID), url.PathEscape(token))
 

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -293,7 +293,7 @@ func newProjectTokenGetCmd(f *cmdutil.Factory) *cobra.Command {
 		ValidArgsFunction: cmdutil.CompleteOwnerID(completion.LinkedProjects()),
 		Long: `Retrieve the original value for a secure token.
 
-This operation requires CHANGE_SERVER_SETTINGS permission,
+This operation requires VIEW_SERVER_SETTINGS permission,
 which is only available to System Administrators.`,
 		Example: `  teamcity project token get Falcon "credentialsJSON:abc123..."
   teamcity project token get Falcon "abc123..."`,


### PR DESCRIPTION
## Summary

The browser (PKCE) login requested a permission set that had drifted from the CLI's actual command surface: cloud, build parameter/revision customization, and project-scoped agent views were never requested, so PKCE-minted tokens silently lacked them (e.g. cloud reads failing with `missing "View cloud images and instances"`). This maps every command to its server-enforced permission and requests exactly the set the CLI needs — no admin-only or `teamcity api`-only scopes beyond the two triage permissions users already drive through the API. Refs #376.

## Changes

- Request 8 more permissions on PKCE login (`fallbackScopes` + `KnownPermissions`): `VIEW_BUILD_RUNTIME_DATA`, `VIEW_AGENT_DETAILS_FOR_PROJECT`, `VIEW_AGENT_CLOUDS`, `CUSTOMIZE_BUILD_PARAMETERS`, `CUSTOMIZE_BUILD_REVISIONS`, `START_STOP_CLOUD_AGENT`, `ASSIGN_INVESTIGATION`, `MANAGE_BUILD_PROBLEMS`.
- Fix `project token get` permission reference: `VIEW_SERVER_SETTINGS` (was `CHANGE_SERVER_SETTINGS`).
- Refresh the stale `KnownPermissions` doc comment.

## Design Decisions

- Each scope maps to a permission a shipped command actually requires (least-privilege), verified against server-side enforcement.
- Excluded admin-only / no-command permissions from the default request: `VIEW_SERVER_SETTINGS` (only `project token get`, admin-only), `CREATE_USER` and `CHANGE_OWN_PROFILE` (no backing command). `project token get` still works for users who separately hold the admin permission.
- Kept `ASSIGN_INVESTIGATION` and `MANAGE_BUILD_PROBLEMS` despite no dedicated command — users perform these via `teamcity api`.
- Kept the global agent/pool permissions rather than the `*_FOR_PROJECT` variants: the PKCE flow can't request per-project scopes.
- The grantable set is governed server-side by `teamcity.internal.server.oauth.pkce.allowedPermissions`, which defaults to all permissions; un-allowlisted scopes are silently dropped, so this is safe on any server and takes effect wherever the scope is allowed.

## Example

N/A — affects the permission set requested during `teamcity auth login` (browser PKCE consent); no standalone command output.

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A — change is to the static PKCE scope list; no command behavior to exercise e2e.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag.
- [ ] If adding a data-producing command: includes `--json` support — N/A.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A.
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — scope list isn't in the generated command reference.
- [ ] External contributors: links a `status:finalized` issue — N/A — maintainer change.
