### PR TITLE
feat(run): add --settings to override versioned-settings source

### DIFF
--- a/acceptance/testdata/run/run-start.txtar
+++ b/acceptance/testdata/run/run-start.txtar
@@ -28,6 +28,10 @@ exec teamcity run start $JOB_ID --dry-run --no-input
 stdout 'dry-run'
 ! stderr 'Error'
 
+# --settings (dry-run, shows the versioned-settings source)
+exec teamcity run start $JOB_ID --settings vcs --dry-run --no-input
+stdout 'Settings: from VCS'
+
 exec teamcity run start $JOB_ID --comment 'acceptance test' --tag acceptance-$RANDOM_STRING --json --no-input
 stdout '"id"'
 

--- a/api/builds.go
+++ b/api/builds.go
@@ -270,6 +270,7 @@ type RunBuildOptions struct {
 	PersonalChangeID          string
 	Revision                  string
 	SnapshotDependencies      []int
+	FreezeSettings            *bool // nil = build configuration default; true = settings from VCS; false = current server settings
 }
 
 // RunBuild runs a new build with full options
@@ -302,12 +303,13 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 
 	req.Personal = opts.Personal
 
-	if opts.CleanSources || opts.RebuildDependencies || opts.QueueAtTop || opts.RebuildFailedDependencies {
+	if opts.CleanSources || opts.RebuildDependencies || opts.QueueAtTop || opts.RebuildFailedDependencies || opts.FreezeSettings != nil {
 		req.TriggeringOptions = &TriggeringOptions{
 			CleanSources:              opts.CleanSources,
 			RebuildAllDependencies:    opts.RebuildDependencies,
 			QueueAtTop:                opts.QueueAtTop,
 			RebuildFailedOrIncomplete: opts.RebuildFailedDependencies,
+			FreezeSettings:            opts.FreezeSettings,
 		}
 	}
 

--- a/api/types.go
+++ b/api/types.go
@@ -261,6 +261,8 @@ type TriggeringOptions struct {
 	RebuildAllDependencies    bool `json:"rebuildAllDependencies,omitempty"`
 	QueueAtTop                bool `json:"queueAtTop,omitempty"`
 	RebuildFailedOrIncomplete bool `json:"rebuildFailedOrIncompleteDependencies,omitempty"`
+	// FreezeSettings overrides the versioned-settings source: true loads settings from VCS, false uses current server settings, nil keeps the build configuration default.
+	FreezeSettings *bool `json:"freezeSettings,omitempty"`
 }
 
 // AgentRef is a reference to an agent

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -368,6 +368,18 @@ teamcity run start MyProject_Build --top
 teamcity run start MyProject_Build --agent 5
 ```
 
+### Versioned settings source
+
+When a build configuration uses versioned settings, `--settings` chooses where the run's settings come from. Without the flag, the job's configured mode applies.
+
+```Shell
+# Load settings from the VCS revision
+teamcity run start MyProject_Build --settings vcs
+
+# Use the settings currently on the server
+teamcity run start MyProject_Build --settings current
+```
+
 ### Tags and comments
 
 ```Shell

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -229,6 +229,39 @@ func TestRunStartDryRunNonExistentJob(T *testing.T) {
 	assert.Contains(T, err.Error(), "not found")
 }
 
+func TestRunStartSettingsSendsFreezeSettings(T *testing.T) {
+	cases := []struct {
+		flag string
+		want bool
+	}{
+		{"vcs", true},
+		{"current", false},
+	}
+	for _, tc := range cases {
+		T.Run(tc.flag, func(T *testing.T) {
+			ts := cmdtest.SetupMockClient(T)
+			var captured api.TriggerBuildRequest
+			ts.Handle("POST /app/rest/buildQueue", func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				require.NoError(T, json.Unmarshal(body, &captured))
+				cmdtest.JSON(w, api.Build{ID: 777, BuildTypeID: testJob, WebURL: "https://example/build/777"})
+			})
+
+			cmdtest.RunCmdWithFactory(T, ts.Factory, "run", "start", testJob, "--settings", tc.flag)
+
+			require.NotNil(T, captured.TriggeringOptions)
+			require.NotNil(T, captured.TriggeringOptions.FreezeSettings)
+			assert.Equal(T, tc.want, *captured.TriggeringOptions.FreezeSettings)
+		})
+	}
+}
+
+func TestRunStartSettingsInvalid(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	err := cmdtest.CaptureErr(T, ts.Factory, "run", "start", testJob, "--settings", "bogus")
+	assert.Contains(T, err.Error(), "invalid --settings value")
+}
+
 func TestRunCancel(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -126,6 +126,35 @@ func afterQueue(f *cmdutil.Factory, build *api.Build, web bool, wf *watchFlags) 
 	return nil
 }
 
+// buildSettingsModes maps the --settings flag value to its freezeSettings override and display label: vcs loads versioned settings from the build's VCS revision, current uses the settings on the server, and unset keeps the job's configured default.
+var buildSettingsModes = map[string]struct {
+	freeze bool
+	label  string
+}{
+	"vcs":     {true, "from VCS"},
+	"current": {false, "current on server"},
+}
+
+// resolveSettingsFlag turns --settings into the freezeSettings triggering option: nil when unset (job default), else a pointer to the mode's freeze value.
+func resolveSettingsFlag(settings string) (*bool, error) {
+	if settings == "" {
+		return nil, nil
+	}
+	mode, ok := buildSettingsModes[settings]
+	if !ok {
+		return nil, api.Validation(
+			fmt.Sprintf("invalid --settings value %q", settings),
+			"Use 'vcs' to load settings from VCS, or 'current' to use the settings on the server",
+		)
+	}
+	return &mode.freeze, nil
+}
+
+// settingsLabel returns the human-readable settings source, or "" when unset/unknown.
+func settingsLabel(settings string) string {
+	return buildSettingsModes[settings].label
+}
+
 type runStartOptions struct {
 	branch            string
 	revision          string
@@ -143,6 +172,7 @@ type runStartOptions struct {
 	agent             int
 	tags              []string
 	reuseDeps         []int
+	settings          string
 	watchFlags
 	web    bool
 	dryRun bool
@@ -173,6 +203,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run start Falcon_Build --local-changes changes.patch  # from file
   teamcity run start Falcon_Build --revision abc123def --branch main
   teamcity run start Falcon_Build --revision @head --branch @this
+  teamcity run start Falcon_Build --settings vcs    # load versioned settings from VCS
   teamcity run start Falcon_Build --dry-run`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			jobID, _, err := cmdutil.ResolveOwnerID("job", args, 0, f.ResolveDefaultJob)
@@ -200,6 +231,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().IntSliceVar(&opts.reuseDeps, "reuse-deps", nil, "Reuse existing as snapshot dependencies (IDs, comma-separated or repeated)")
 	cmd.Flags().BoolVar(&opts.queueAtTop, "top", false, "Add to top of queue")
 	cmd.Flags().IntVar(&opts.agent, "agent", 0, "Use specific agent (by ID)")
+	cmd.Flags().StringVar(&opts.settings, "settings", "", "Settings source: 'vcs' or 'current' (default: job's configured mode)")
 	opts.addToCmd(cmd)
 	cmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open in browser")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Preview without triggering")
@@ -209,6 +241,9 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	_ = cmd.RegisterFlagCompletionFunc("revision", completion.AtHead())
 	_ = cmd.RegisterFlagCompletionFunc("local-changes", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{"git", "-"}, cobra.ShellCompDirectiveDefault
+	})
+	_ = cmd.RegisterFlagCompletionFunc("settings", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+		return []string{"vcs", "current"}, cobra.ShellCompDirectiveNoFileComp
 	})
 
 	return cmd
@@ -227,6 +262,10 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		return err
 	}
 	opts.revision = revision
+	freezeSettings, err := resolveSettingsFlag(opts.settings)
+	if err != nil {
+		return err
+	}
 	if opts.dryRun {
 		client, err := f.Client()
 		if err != nil {
@@ -267,6 +306,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 				QueueAtTop        bool              `json:"queue_at_top,omitempty"`
 				Agent             int               `json:"agent_id,omitempty"`
 				ReuseDeps         []int             `json:"reuse_deps,omitempty"`
+				Settings          string            `json:"settings,omitempty"`
 			}{
 				DryRun:            true,
 				Job:               jobID,
@@ -285,6 +325,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 				QueueAtTop:        opts.queueAtTop,
 				Agent:             opts.agent,
 				ReuseDeps:         opts.reuseDeps,
+				Settings:          opts.settings,
 			})
 		}
 
@@ -342,6 +383,9 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		}
 		if opts.agent > 0 {
 			_, _ = fmt.Fprintf(p.Out, "  Agent ID: %d\n", opts.agent)
+		}
+		if l := settingsLabel(opts.settings); l != "" {
+			_, _ = fmt.Fprintf(p.Out, "  Settings: %s\n", l)
 		}
 		return nil
 	}
@@ -424,6 +468,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		PersonalChangeID:          personalChangeID,
 		Revision:                  opts.revision,
 		SnapshotDependencies:      opts.reuseDeps,
+		FreezeSettings:            freezeSettings,
 	})
 	if err != nil {
 		return err
@@ -465,6 +510,9 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 	}
 	if len(opts.tags) > 0 {
 		p.Info("  Tags: %s", strings.Join(opts.tags, ", "))
+	}
+	if l := settingsLabel(opts.settings); l != "" {
+		p.Info("  Settings: %s", l)
 	}
 	if len(opts.reuseDeps) > 0 {
 		printReuseDeps(p, fetchReuseDeps(f.Context(), client, opts.reuseDeps))

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -94,6 +94,7 @@ Shows all branches and all build states (including canceled, personal, composite
 - `--rebuild-failed-deps` - Rebuild failed/incomplete dependencies
 - `--reuse-deps <id,...>` - Reuse existing builds as snapshot dependencies (comma-separated IDs)
 - `--top` - Add to top of queue
+- `--settings <vcs|current>` - Versioned-settings source: `vcs` loads settings from VCS, `current` uses the settings on the server (default: the job's configured mode)
 - `--dry-run` - Show what would be triggered without running
 - `--json` - Output as JSON (for scripting)
 - `-w, --web` - Open run in browser


### PR DESCRIPTION
## Summary

`teamcity run start` had no way to control the versioned-settings source, so triggering a build with "Use settings: from VCS" was impossible via the CLI. As #330 notes, the `versionedSettingsConfig.buildSettingsMode` / `versionedSettingsRevision` fields are silently ignored — they don't exist on the trigger model. The real REST control is `triggeringOptions.freezeSettings`, which maps to the same `BuildCustomizerEx.setFreezeSettings(...)` the Run Custom Build dialog uses. This wires a `--settings vcs|current` flag to it. Fixes #330.

## Changes

- Add `--settings vcs|current` to `run start`, mapping to `triggeringOptions.freezeSettings` (`vcs`→true, `current`→false; unset omits the field → job's configured default).
- Add `FreezeSettings *bool` to `TriggeringOptions` and `RunBuildOptions`.
- Surface the chosen source in the queued-run output and in `--dry-run` (human + `--json`).
- Docs (skills command reference), acceptance txtar, and unit tests.

## Design Decisions

Three-state flag rather than a bool, because the server default is per-config: a config in PREFER_VCS already defaults to VCS, one in PREFER_CURRENT defaults to current. So each value is a real override only on the opposite config, and "unset" is the only thing that means *default* — a `*bool` lets us send `true`/`false` or omit. Pinning a specific settings revision is out of scope: `versionedSettingsRevision` is read-only in REST and would need a server change.

## Example

```bash
$ teamcity run start MyBuild --settings vcs --dry-run
[dry-run] Would trigger run for MyBuild
  Settings: from VCS
```

## Test Plan

- [x] Unit tests pass (`just unit`) — 392 pass, incl. new `TestRunBuildFreezeSettings` and `TestRunStartSettings*`
- [x] Linter passes (`just lint`) — 0 issues
- [ ] Acceptance tests pass (`just acceptance`) — not run locally (needs live server); added txtar coverage, and smoke-tested manually on cli.teamcity.com (server accepts `freezeSettings:true` and queues the build)
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — `run-start.txtar` (dry-run) + `run-validation.txtar` (bad value)
- [x] If adding a data-producing command: includes `--json` support — N/A new command; `--dry-run --json` gains an additive `settings` field
- [x] If modifying `--json` output: no field removals/renames (additive only) — only added `settings` to the dry-run document
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — skills reference updated; `--help` is automatic; generated command reference lists commands only (no per-flag entries); README has no per-flag list
- [ ] External contributors: links a `status:finalized` issue — N/A internal; #330 is `status:finalized`
