### PR TITLE
docs: fix stale command references and add missing job/skill coverage

### DIFF
--- a/docs/topics/teamcity-cli-ai-agent-integration.md
+++ b/docs/topics/teamcity-cli-ai-agent-integration.md
@@ -10,6 +10,14 @@ You can also integrate TeamCity with AI agents via the [MCP server](ai-agent-int
 
 </tip>
 
+## Listing skills
+
+List the skills bundled with your `teamcity` release, with each one's version and which is installed by default:
+
+```Shell
+teamcity skill list
+```
+
 ## Installing the skill
 
 Install the skill for all detected AI agents:
@@ -109,6 +117,18 @@ Target agent(s). Can be repeated. Auto-detects installed agents if omitted.
 <td>
 
 Install to the current project instead of globally
+
+</td>
+</tr>
+<tr>
+<td>
+
+`--all`
+
+</td>
+<td>
+
+Apply to every bundled skill instead of only the default
 
 </td>
 </tr>

--- a/docs/topics/teamcity-cli-authentication.md
+++ b/docs/topics/teamcity-cli-authentication.md
@@ -117,7 +117,7 @@ Guest authentication provides read-only access. It uses the `/guestAuth/` API pr
 
 <img src="auth-login.gif" alt="Authenticating with guest access" border-effect="rounded"/>
 
-> Guest access must be [enabled in the TeamCity server settings](enabling-guest-login.md). Otherwise, the login will fail.
+> Guest access must be [enabled in the TeamCity server settings](https://www.jetbrains.com/help/teamcity/enabling-guest-login.html). Otherwise, the login will fail.
 >
 {style="note"}
 

--- a/docs/topics/teamcity-cli-glossary.md
+++ b/docs/topics/teamcity-cli-glossary.md
@@ -65,7 +65,7 @@ A TeamCity feature that synchronizes a project's configuration (jobs, parameters
 
 ```Shell
 teamcity project settings status MyProject
-teamcity project settings export MyProject --format kotlin
+teamcity project settings export MyProject --kotlin
 ```
 
 ## Build Queue

--- a/docs/topics/teamcity-cli-linking.md
+++ b/docs/topics/teamcity-cli-linking.md
@@ -2,7 +2,7 @@
 
 <show-structure for="chapter" depth="2"/>
 
-`teamcity link` binds a repository to one or more TeamCity projects and jobs by writing a small `teamcity.toml` file at the repo root. Once linked, commands like `teamcity run start`, `teamcity run watch`, and `teamcity job list` pick up the default project and job automatically — no `--project`/`--job` flags required.
+`teamcity link` binds a repository to one or more TeamCity projects and jobs by writing a small `teamcity.toml` file at the repo root. Once linked, commands like `teamcity run start`, `teamcity run list`, and `teamcity job list` pick up the default project and job automatically — no `--project`/`--job` flags required.
 
 `teamcity.toml` is meant to be committed alongside your code. It is portable across machines, CI agents, and AI coding agents, and it supports monorepos with per-path bindings and multi-server setups.
 
@@ -140,10 +140,10 @@ This means `teamcity.toml` provides the *defaults*, but any explicit flag or env
 Once `teamcity.toml` is in place, the following commands accept the linked defaults instead of requiring identifiers on every invocation:
 
 - `teamcity run start` — uses the default `job`
-- `teamcity run list`, `teamcity run watch`, `teamcity run log` — accept `--job` from the link
-- `teamcity job list`, `teamcity job tree` — scope to the linked `project`
+- `teamcity run list`, `teamcity run log` — accept `--job` from the link
+- `teamcity job list` — scopes to the linked `project`
+- `teamcity job tree`, `teamcity job view` — use the linked default `job`
 - `teamcity project view`, `teamcity project tree` — open the linked `project`
-- `teamcity pipeline pull`, `teamcity pipeline validate` — use the linked `project`
 
 Run `teamcity <command> --help` to see which flags accept the linked default.
 

--- a/docs/topics/teamcity-cli-managing-jobs.md
+++ b/docs/topics/teamcity-cli-managing-jobs.md
@@ -2,16 +2,34 @@
 
 <show-structure for="chapter" depth="2"/>
 
-Jobs represent build configurations in TeamCity. The `teamcity job` command group lets you list and view build configurations, pause and resume them, and manage their parameters.
+Jobs represent build configurations in TeamCity. The `teamcity job` command group lets you create, list, and view build configurations, manage their build steps, pause and resume them, and manage their parameters.
 
 > In TeamCity CLI, "job" is equivalent to "build configuration" in the TeamCity web interface. See the [Glossary](teamcity-cli-glossary.md) for the full terminology mapping.
 
+## Creating a job
+
+Create a new build configuration in a project. The parent project comes from `--project`, the `TEAMCITY_PROJECT` environment variable, or the linked project (see [Linking](teamcity-cli-linking.md)):
+
+```Shell
+teamcity job create Build --project MyProject
+```
+
+By default TeamCity derives the job ID from the name. Set an explicit ID with `--id`, or base the new job on an existing template with `--template`:
+
+```Shell
+teamcity job create Build --project MyProject --id MyProject_Build
+teamcity job create Build --project MyProject --template MyTemplate
+```
+
+Add `--web` to open the new job in your browser, or `--json` for machine-readable output.
+
 ## Listing jobs
 
-View all build configurations:
+List build configurations across all projects. Jobs backed by pipelines are hidden by default — pass `--all` to include them:
 
 ```Shell
 teamcity job list
+teamcity job list --all
 ```
 
 <img src="job-list.gif" alt="Listing and filtering jobs" border-effect="rounded"/>
@@ -60,6 +78,18 @@ Description
 <td>
 
 Filter by project ID
+
+</td>
+</tr>
+<tr>
+<td>
+
+`--all`
+
+</td>
+<td>
+
+Include jobs backed by pipelines (hidden by default)
 
 </td>
 </tr>
@@ -172,6 +202,32 @@ Show only `dependents` or `dependencies`
 </td>
 </tr>
 </table>
+
+## Managing build steps
+
+Build steps are the individual runners a job executes in order. List the steps on a job:
+
+```Shell
+teamcity job step list MyBuild
+```
+
+View one step's full configuration, including its parameter keys:
+
+```Shell
+teamcity job step view MyBuild RUNNER_1
+```
+
+Add a step. `--type` is the runner type ID used by TeamCity's REST API, which differs from the display name in the UI — Command Line is `simpleRunner`, Gradle is `gradle-runner`, Maven is `Maven2`. Repeat `--param key=value` for each runner setting:
+
+```Shell
+teamcity job step add MyBuild --type simpleRunner --name "Run Tests" --param use.custom.script=true --param script.content="./gradlew test"
+```
+
+Delete a step by its ID:
+
+```Shell
+teamcity job step delete MyBuild RUNNER_1
+```
 
 ## Pausing and resuming jobs
 

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -659,7 +659,7 @@ Watch the build after starting it
 </td>
 <td>
 
-Refresh interval in seconds when watching (default: 3)
+Refresh interval in seconds when watching (default: 5)
 
 </td>
 </tr>


### PR DESCRIPTION
## Summary

Fixes stale pages in `docs/topics/` that had drifted from the current CLI, found by auditing every topic page against live `--help` output and command source. Corrects wrong/removed flags and behavior claims, and adds missing coverage for already-shipped commands. Docs-only; no code or behavior changes.

## Changes

- **glossary**: `project settings export --format kotlin` → `--kotlin` (no `--format` flag exists)
- **managing-runs**: `run start --interval` default `3` → `5`
- **authentication**: dead `enabling-guest-login.md` link → JetBrains help URL
- **linking**: correct "Commands that use the link" — `run watch` takes a run ID (no `--job`); `job tree`/`job view` use the linked default *job*, not *project*; drop `pipeline pull`/`validate` (neither resolves the linked project)
- **managing-jobs**: add **Creating a job** (`job create`) and **Managing build steps** (`job step add/list/view/delete`) sections; document `job list --all` (pipeline-backed jobs hidden by default)
- **ai-agent-integration**: add **Listing skills** (`skill list`) section and the shared `--all` flag

## Design Decisions

Straightforward.

## Example

N/A — docs only, no user-visible CLI change.

## Test Plan

- [ ] Unit tests pass (`just unit`) — N/A — docs-only, no code changed
- [ ] Linter passes (`just lint`) — N/A — docs-only
- [ ] Acceptance tests pass (`just acceptance`) — N/A — docs-only
- [ ] If adding a new command/flag: added `.txtar` test — N/A — documents existing commands, none added
- [ ] If adding a data-producing command: includes `--json` support — N/A
- [ ] If modifying `--json` output: no field removals/renames — N/A
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — no behavior change; aligns existing docs with shipped behavior
- [ ] External contributors: links a `status:finalized` issue — N/A — internal, docs change
