### PR TITLE
fix(migrate): produce runnable JVM pipelines

### DIFF
--- a/internal/cmd/migrate/migrate.go
+++ b/internal/cmd/migrate/migrate.go
@@ -382,27 +382,33 @@ func resolveSchema(client api.ClientInterface) []byte {
 	return schema
 }
 
-// resolveRunnerMap derives runner names from the validation schema's hosted-agent enum (so emitted runs-on passes that schema), then cloud images, then defaults (nil).
+// resolveRunnerMap uses server-reported hosted images when connected, falling back to the schema when offline.
 func resolveRunnerMap(client api.ClientInterface, schemaData []byte) map[string]string {
+	if m, known := resolveCloudRunners(client); known {
+		return m
+	}
 	if names := pipelineschema.HostedAgentNames(schemaData); len(names) > 0 {
 		if m := migrate.BuildRunnerMap(names); m != nil {
 			return m
 		}
 	}
-	return resolveCloudRunners(client)
+	return nil
 }
 
-func resolveCloudRunners(client api.ClientInterface) map[string]string {
+func resolveCloudRunners(client api.ClientInterface) (map[string]string, bool) {
 	if client == nil {
-		return nil
+		return nil, false
 	}
 	list, _, err := client.GetCloudImages(api.CloudImagesOptions{})
-	if err != nil || len(list.Images) == 0 {
-		return nil
+	if err != nil {
+		return nil, false
+	}
+	if len(list.Images) == 0 {
+		return map[string]string{}, true
 	}
 	names := make([]string, 0, len(list.Images))
 	for _, img := range list.Images {
 		names = append(names, img.Name)
 	}
-	return migrate.BuildRunnerMap(names)
+	return migrate.BuildRunnerMap(names), true
 }

--- a/internal/cmd/migrate/migrate.go
+++ b/internal/cmd/migrate/migrate.go
@@ -96,9 +96,6 @@ func runMigrate(f *cmdutil.Factory, opts *migrateOptions) error {
 			return fmt.Errorf("scanning for CI configurations: %w", err)
 		}
 		configs = detected
-		for _, path := range migrate.DetectUnsupported(".") {
-			f.Printer.Warn("Detected unsupported CI configuration %s; it was not migrated", path)
-		}
 	}
 
 	if len(configs) == 0 {
@@ -406,12 +403,13 @@ func resolveCloudRunners(client api.ClientInterface) (map[string]string, bool) {
 	if err != nil {
 		return nil, false
 	}
-	if len(list.Images) == 0 {
-		return map[string]string{}, true
-	}
 	names := make([]string, 0, len(list.Images))
 	for _, img := range list.Images {
 		names = append(names, img.Name)
 	}
-	return migrate.BuildRunnerMap(names), true
+	if m := migrate.BuildRunnerMap(names); m != nil {
+		return m, true
+	}
+	// No usable images (none, or none OS-classifiable): empty map omits runs-on instead of emitting agents the server doesn't have.
+	return map[string]string{}, true
 }

--- a/internal/cmd/migrate/migrate.go
+++ b/internal/cmd/migrate/migrate.go
@@ -96,6 +96,9 @@ func runMigrate(f *cmdutil.Factory, opts *migrateOptions) error {
 			return fmt.Errorf("scanning for CI configurations: %w", err)
 		}
 		configs = detected
+		for _, path := range migrate.DetectUnsupported(".") {
+			f.Printer.Warn("Detected unsupported CI configuration %s; it was not migrated", path)
+		}
 	}
 
 	if len(configs) == 0 {

--- a/internal/migrate/convert.go
+++ b/internal/migrate/convert.go
@@ -157,7 +157,7 @@ func (o Options) MapRunner(label string) string {
 	return mapped
 }
 
-// ResolveRunner maps a CI runner label to a TC agent name; unknown labels resolve to "self-hosted" with ok=false (non-GitHub-hosted labels name self-hosted runners).
+// ResolveRunner maps a CI runner label to a TC agent name; ok=false flags labels needing manual setup — "" for hosted labels the server has no image for, "self-hosted" for custom labels.
 func (o Options) ResolveRunner(label string) (mapped string, ok bool) {
 	if mapped, ok := o.RunnerMap[label]; ok {
 		return mapped, true
@@ -165,7 +165,7 @@ func (o Options) ResolveRunner(label string) (mapped string, ok bool) {
 	if mapped, ok := RunnerMap[label]; ok {
 		// A non-nil RunnerMap is server truth: a hosted label missing there has no matching agent, so omit runs-on rather than emit a name the server can't run.
 		if o.RunnerMap != nil {
-			return "", true
+			return "", false
 		}
 		return mapped, true
 	}
@@ -174,11 +174,11 @@ func (o Options) ResolveRunner(label string) (mapped string, ok bool) {
 	}
 	switch classifyOS(label) {
 	case "linux":
-		return o.MapRunner("ubuntu-latest"), true
+		return o.ResolveRunner("ubuntu-latest")
 	case "mac":
-		return o.MapRunner("macos-latest"), true
+		return o.ResolveRunner("macos-latest")
 	case "windows":
-		return o.MapRunner("windows-latest"), true
+		return o.ResolveRunner("windows-latest")
 	}
 	return "self-hosted", false
 }

--- a/internal/migrate/convert.go
+++ b/internal/migrate/convert.go
@@ -153,9 +153,6 @@ func condense(s string) string {
 }
 
 func (o Options) MapRunner(label string) string {
-	if o.RunnerMap != nil {
-		return o.RunnerMap[label]
-	}
 	mapped, _ := o.ResolveRunner(label)
 	return mapped
 }
@@ -165,10 +162,11 @@ func (o Options) ResolveRunner(label string) (mapped string, ok bool) {
 	if mapped, ok := o.RunnerMap[label]; ok {
 		return mapped, true
 	}
-	if o.RunnerMap != nil {
-		return "", true
-	}
 	if mapped, ok := RunnerMap[label]; ok {
+		// A non-nil RunnerMap is server truth: a hosted label missing there has no matching agent, so omit runs-on rather than emit a name the server can't run.
+		if o.RunnerMap != nil {
+			return "", true
+		}
 		return mapped, true
 	}
 	if label == "self-hosted" {

--- a/internal/migrate/convert.go
+++ b/internal/migrate/convert.go
@@ -153,6 +153,9 @@ func condense(s string) string {
 }
 
 func (o Options) MapRunner(label string) string {
+	if o.RunnerMap != nil {
+		return o.RunnerMap[label]
+	}
 	mapped, _ := o.ResolveRunner(label)
 	return mapped
 }
@@ -161,6 +164,9 @@ func (o Options) MapRunner(label string) string {
 func (o Options) ResolveRunner(label string) (mapped string, ok bool) {
 	if mapped, ok := o.RunnerMap[label]; ok {
 		return mapped, true
+	}
+	if o.RunnerMap != nil {
+		return "", true
 	}
 	if mapped, ok := RunnerMap[label]; ok {
 		return mapped, true

--- a/internal/migrate/convert_test.go
+++ b/internal/migrate/convert_test.go
@@ -145,6 +145,16 @@ jobs:
 	assert.Equal(t, 1, strings.Count(manuals, "runs on a Windows runner with no explicit shell"))
 }
 
+func TestEmptyRunnerMapOmitsRunsOn(t *testing.T) {
+	t.Parallel()
+
+	wf := "on: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: echo hi\n"
+	result, err := Convert(CIConfig{Source: GitHubActions, File: ".github/workflows/ci.yml"}, []byte(wf), Options{RunnerMap: map[string]string{}})
+	require.NoError(t, err)
+
+	assert.NotContains(t, result.YAML, "runs-on:")
+}
+
 func TestMapGHAExpressions(t *testing.T) {
 	t.Parallel()
 	tests := []struct{ input, want string }{

--- a/internal/migrate/convert_test.go
+++ b/internal/migrate/convert_test.go
@@ -155,6 +155,17 @@ func TestEmptyRunnerMapOmitsRunsOn(t *testing.T) {
 	assert.NotContains(t, result.YAML, "runs-on:")
 }
 
+func TestPartialRunnerMapFlagsUnmatchedHostedLabel(t *testing.T) {
+	t.Parallel()
+
+	wf := "on: push\njobs:\n  test:\n    runs-on: windows-latest\n    steps:\n      - run: echo hi\n"
+	result, err := Convert(CIConfig{Source: GitHubActions, File: ".github/workflows/ci.yml"}, []byte(wf), Options{RunnerMap: map[string]string{"ubuntu-latest": "linux-large"}})
+	require.NoError(t, err)
+
+	assert.NotContains(t, result.YAML, "runs-on:")
+	assert.Contains(t, strings.Join(result.ManualSetup, "\n"), `Job "test" runs-on "windows-latest" has no matching agent image`)
+}
+
 func TestSetupJavaPinsJavaHome(t *testing.T) {
 	t.Parallel()
 

--- a/internal/migrate/convert_test.go
+++ b/internal/migrate/convert_test.go
@@ -155,6 +155,27 @@ func TestEmptyRunnerMapOmitsRunsOn(t *testing.T) {
 	assert.NotContains(t, result.YAML, "runs-on:")
 }
 
+func TestSetupJavaPinsJavaHome(t *testing.T) {
+	t.Parallel()
+
+	wf := `on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - run: ./mvnw verify
+`
+	result, err := Convert(CIConfig{Source: GitHubActions, File: ".github/workflows/ci.yml"}, []byte(wf), Options{})
+	require.NoError(t, err)
+
+	assert.Contains(t, result.YAML, `env.JAVA_HOME: "%env.JDK_17_0%"`)
+	assert.Contains(t, result.YAML, "./mvnw verify")
+}
+
 func TestMapGHAExpressions(t *testing.T) {
 	t.Parallel()
 	tests := []struct{ input, want string }{

--- a/internal/migrate/detect.go
+++ b/internal/migrate/detect.go
@@ -21,19 +21,6 @@ var ciPatterns = map[SourceCI][]string{
 	},
 }
 
-var unsupportedCIFiles = []string{"Jenkinsfile", ".gitlab-ci.yml", ".circleci/config.yml"}
-
-// DetectUnsupported returns CI configurations present in the repository that migrate does not convert.
-func DetectUnsupported(dir string) []string {
-	found := []string{}
-	for _, name := range unsupportedCIFiles {
-		if info, err := os.Stat(filepath.Join(dir, filepath.FromSlash(name))); err == nil && !info.IsDir() {
-			found = append(found, name)
-		}
-	}
-	return found
-}
-
 func Detect(dir string, filterSource SourceCI) ([]CIConfig, error) {
 	configs := []CIConfig{}
 

--- a/internal/migrate/detect.go
+++ b/internal/migrate/detect.go
@@ -21,6 +21,19 @@ var ciPatterns = map[SourceCI][]string{
 	},
 }
 
+var unsupportedCIFiles = []string{"Jenkinsfile", ".gitlab-ci.yml", ".circleci/config.yml"}
+
+// DetectUnsupported returns CI configurations present in the repository that migrate does not convert.
+func DetectUnsupported(dir string) []string {
+	found := []string{}
+	for _, name := range unsupportedCIFiles {
+		if info, err := os.Stat(filepath.Join(dir, filepath.FromSlash(name))); err == nil && !info.IsDir() {
+			found = append(found, name)
+		}
+	}
+	return found
+}
+
 func Detect(dir string, filterSource SourceCI) ([]CIConfig, error) {
 	configs := []CIConfig{}
 

--- a/internal/migrate/detect_test.go
+++ b/internal/migrate/detect_test.go
@@ -90,14 +90,3 @@ func TestAnalyzeFileMissingSourceCannotInfer(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot infer CI source")
 }
-
-func TestDetectUnsupported(t *testing.T) {
-	t.Parallel()
-
-	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "Jenkinsfile"), []byte("pipeline {}"), 0644))
-	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".circleci"), 0755))
-	require.NoError(t, os.WriteFile(filepath.Join(dir, ".circleci", "config.yml"), []byte("version: 2.1"), 0644))
-
-	assert.Equal(t, []string{"Jenkinsfile", ".circleci/config.yml"}, DetectUnsupported(dir))
-}

--- a/internal/migrate/detect_test.go
+++ b/internal/migrate/detect_test.go
@@ -90,3 +90,14 @@ func TestAnalyzeFileMissingSourceCannotInfer(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot infer CI source")
 }
+
+func TestDetectUnsupported(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Jenkinsfile"), []byte("pipeline {}"), 0644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".circleci"), 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".circleci", "config.yml"), []byte("version: 2.1"), 0644))
+
+	assert.Equal(t, []string{"Jenkinsfile", ".circleci/config.yml"}, DetectUnsupported(dir))
+}

--- a/internal/migrate/github.go
+++ b/internal/migrate/github.go
@@ -258,7 +258,11 @@ func convertGHAJob(id string, job *actionlint.Job, result *ConversionResult, opt
 		} else {
 			mapped, known := opts.ResolveRunner(raw)
 			j.RunsOn = mapped
-			if !known {
+			switch {
+			case !known && mapped == "":
+				result.ManualSetup = append(result.ManualSetup,
+					fmt.Sprintf("Job %q runs-on %q has no matching agent image on the server → runs-on omitted; add a matching image or set runs-on manually", id, raw))
+			case !known:
 				result.ManualSetup = append(result.ManualSetup,
 					fmt.Sprintf("Job %q runs-on %q is not a GitHub-hosted runner → emitted `self-hosted`; configure matching agent requirements in TeamCity", id, raw))
 			}

--- a/internal/migrate/github.go
+++ b/internal/migrate/github.go
@@ -349,6 +349,12 @@ func convertGHAJob(id string, job *actionlint.Job, result *ConversionResult, opt
 				fmt.Sprintf("Step %q sets timeout-minutes: %s → no per-step timeout in TeamCity; configure an execution timeout in the job's failure conditions", stepName, ghaFloatString(step.TimeoutMinutes)))
 		}
 		stepResults = append(stepResults, transformGHAStep(step, acc)...)
+		if javaHome := setupJavaHome(step); javaHome != "" {
+			if j.Parameters == nil {
+				j.Parameters = map[string]string{}
+			}
+			j.Parameters["JAVA_HOME"] = javaHome
+		}
 	}
 
 	steps, artifacts, cache := applyResults(stepResults, result)
@@ -361,11 +367,30 @@ func convertGHAJob(id string, job *actionlint.Job, result *ConversionResult, opt
 
 	if job.Env != nil {
 		if params := extractGHAEnvParams(job.Env, result); len(params) > 0 {
-			j.Parameters = params
+			if j.Parameters == nil {
+				j.Parameters = map[string]string{}
+			}
+			maps.Copy(j.Parameters, params)
 		}
 	}
 
 	return j
+}
+
+var javaVersionRe = regexp.MustCompile(`^\s*(\d+)`)
+
+// setupJavaHome maps a literal setup-java version to TeamCity's conventional JDK parameter.
+func setupJavaHome(step *actionlint.Step) string {
+	exec, ok := step.Exec.(*actionlint.ExecAction)
+	if !ok || exec.Uses == nil || !strings.HasPrefix(exec.Uses.Value, "actions/setup-java@") {
+		return ""
+	}
+	version := collectActionInputs(exec)["java-version"]
+	match := javaVersionRe.FindStringSubmatch(version)
+	if len(match) == 0 {
+		return ""
+	}
+	return "%env.JDK_" + match[1] + "_0%"
 }
 
 // redactLiteralSecret replaces a literal value under a secret-looking key; expressions stay so mapping/flagging see them.


### PR DESCRIPTION
## Summary

Make GitHub Actions migrations more likely to run on the target TeamCity server by deriving `runs-on` from the agents the server actually reports, preserving the requested Java version, and warning when unsupported CI configuration remains outside the migration.

## Changes

- Derive `runs-on` from server-reported cloud images when connected; when the server reports none (or none OS-classifiable), omit `runs-on` so jobs run on any agent instead of queueing forever on nonexistent hosted names. Offline keeps the schema/builtin defaults.
- Flag hosted runner labels the server has no matching image for as manual setup instead of silently omitting `runs-on`.
- Map literal `actions/setup-java` versions to TeamCity's `env.JAVA_HOME` convention.
- Warn when Jenkins, GitLab CI, or CircleCI configuration is present but not migrated.

## Design Decisions

Keep Maven and Gradle wrapper commands as script steps so projects continue using their pinned build-tool versions.

## Example

```bash
$ teamcity migrate
Warning: Detected unsupported CI configuration Jenkinsfile; it was not migrated
...
parameters:
  env.JAVA_HOME: "%env.JDK_17_0%"
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A: no live-server acceptance coverage for the experimental migrate command.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A: no command or flag added.
- [ ] If adding a data-producing command: includes `--json` support — N/A: no command added.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A: JSON output is unchanged.
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A: migrate is experimental and intentionally undocumented.
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A: not an external contribution.
