### PR TITLE
fix(pipeline): send both request shapes so update works on pre- and p…

### DIFF
--- a/api/pipelines.go
+++ b/api/pipelines.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -111,20 +112,27 @@ func (c *Client) UpdatePipelineYAML(id string, yamlContent string) error {
 		return fmt.Errorf("failed to get pipeline: %w", err)
 	}
 
-	update := map[string]any{
+	pipeline := map[string]any{
 		"name": raw["name"],
 		"yaml": yamlContent,
 	}
+
 	if vcsRoot, ok := raw["vcsRoot"].(map[string]any); ok {
 		if vcsID, ok := vcsRoot["id"].(string); ok {
-			update["vcsRoot"] = map[string]any{"externalVcsRootId": vcsID}
+			pipeline["vcsRoot"] = map[string]any{"externalVcsRootId": vcsID}
 		}
 	}
 	for _, key := range []string{"additionalVcsRoots", "triggers", "integrations", "notifications"} {
 		if v, ok := raw[key]; ok {
-			update[key] = v
+			pipeline[key] = v
 		}
 	}
+
+	// Support both versions with a single body:
+	// pre-2026.2 reads the top-level fields, 2026.2+ reads the nested "pipeline" object.
+	// Each server ignores the fields it does not recognize.
+	update := map[string]any{"pipeline": pipeline}
+	maps.Copy(update, pipeline)
 
 	body, err := json.Marshal(update)
 	if err != nil {

--- a/api/pipelines_test.go
+++ b/api/pipelines_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUpdatePipelineYAML verifies the update body carries both request shapes:
+// the flat top-level fields read by pre-2026.2 servers and the nested "pipeline"
+// object read by 2026.2+, each preserving the existing settings.
+func TestUpdatePipelineYAML(t *testing.T) {
+	t.Parallel()
+
+	const newYAML = "jobs:\n  build:\n    steps: []\n"
+	var body map[string]any
+
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/app/pipeline/CLI_CiCd", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"name":     "CI/CD",
+				"yaml":     "old",
+				"vcsRoot":  map[string]any{"id": "MyRepo"},
+				"triggers": []any{map[string]any{"type": "vcs"}},
+			})
+		case http.MethodPost:
+			raw, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(raw, &body))
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			t.Fatalf("unexpected method %s", r.Method)
+		}
+	})
+
+	require.NoError(t, client.UpdatePipelineYAML("CLI_CiCd", newYAML))
+
+	// Top-level shape for pre-2026.2 servers.
+	assert.Equal(t, "CI/CD", body["name"])
+	assert.Equal(t, newYAML, body["yaml"])
+	assert.Equal(t, map[string]any{"externalVcsRootId": "MyRepo"}, body["vcsRoot"])
+	assert.Contains(t, body, "triggers")
+
+	// Nested shape for 2026.2+ servers, carrying the same fields.
+	nested, ok := body["pipeline"].(map[string]any)
+	require.True(t, ok, "body must contain a nested pipeline object")
+	assert.Equal(t, "CI/CD", nested["name"])
+	assert.Equal(t, newYAML, nested["yaml"])
+	assert.Equal(t, map[string]any{"externalVcsRootId": "MyRepo"}, nested["vcsRoot"])
+	assert.Contains(t, nested, "triggers")
+}


### PR DESCRIPTION
## Summary

The pipeline update endpoint POST /pipeline/{id} changed its request body: it now expects the pipeline nested under a pipeline key instead of the pipeline object sent directly, so `teamcity pipeline push` is broken against updated servers. This sends a single body carrying both shapes—the nested pipeline object for updated servers and the flat top-level fields for older ones—so pushes succeed across the version boundary.


## Changes

- UpdatePipelineYAML wraps the payload under a pipeline key (new format) while keeping the flat top-level fields (legacy format) in the same body.
- Added api/pipelines_test.go asserting the body carries both shapes.

## Design Decisions

Chose one dual-shape body over branching on server version—no version lookup needed, and each server ignores the fields it doesn't recognize.

## Example

```bash
teamcity pipeline push CLI_CiCd .teamcity.yml
✓ Updated pipeline Milica_KmpBasic
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` N/A no new commands added
- [ ] If adding a data-producing command: includes `--json` support N/A no new commands added
- [ ] If modifying `--json` output: no field removals/renames (additive only) N/A `--json` output is not modified
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` N/A docs-visible behavior is not changed
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) N/A no issue to link
