### PR TITLE
Added checks and tasks to evaluate working with teamcity.toml and the link command

### DIFF
--- a/evals/checks.py
+++ b/evals/checks.py
@@ -436,25 +436,30 @@ def did_not_modify_teamcity_toml(runner: EvalRunner) -> None:
 
 
 def used_project_from_repository_link(runner: EvalRunner) -> None:
-    """Pass if a build query relied on the teamcity.toml binding — no project/job
-    given, or the linked one named explicitly. An override to a different
-    project/job does not count. Grades the command, not server output, so it
-    doesn't depend on a specific error message or on the IDs being nonexistent."""
+    inspected = (
+        any(p.endswith("teamcity.toml") for p in runner.events.files_read)
+        or any("teamcity.toml" in c for c in runner.commands)
+    )
+    if not inspected:
+        runner.failed("Did not inspect the teamcity.toml binding")
+        return
+    relied = False
     for argv in runner.teamcity_argvs():
         if EvalRunner.subcommand_tokens(argv)[:2] not in (["run", "list"], ["run", "view"]):
             continue
-        proj = _flag_value(argv, "--project", "-p")
-        job = _flag_value(argv, "--job", "-j")
-        if proj in (None, _LINKED_PROJECT_ID) and job in (None, _LINKED_JOB_ID):
-            runner.passed("Ran a build query that relied on the linked project/job")
+        if _flag_value(argv, "--project", "-p") not in (None, _LINKED_PROJECT_ID):
+            runner.failed("Overrode the build query with a project other than the linked one")
             return
-    runner.failed("Did not use the linked project/job from teamcity.toml")
+        relied = True
+    if relied:
+        runner.passed("Inspected the binding and queried within the linked project")
+    else:
+        runner.failed("Did not run a build query relying on the linked project")
 
 
-# Linked IDs seeded by the use-repository-link task's setup_files. Checks
-# receive only the runner, so these must be kept in sync with tasks.json.
-_LINKED_PROJECT_ID = "Project_uipBGpvQua"
-_LINKED_JOB_ID = "FooJob"
+# Linked project seeded by the use-repository-link task's setup_files. Checks
+# receive only the runner, so this must be kept in sync with tasks.json.
+_LINKED_PROJECT_ID = "JBR"
 
 
 def _flag_value(argv: list[str], *names: str) -> str | None:

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -326,7 +326,13 @@ def uses_run_not_build(runner: EvalRunner) -> None:
 # repository binding
 # ---------------------------------------------------------------------------
 
+_TOML_MUTATION = re.compile(
+    r"(>>?|\b(?:tee|rm|unlink|cp|mv)\b|\bsed\b[^|;&]*-i)[^|;&]*teamcity\.toml", re.IGNORECASE
+)
+
+
 def checked_repository_link(runner: EvalRunner) -> None:
+    """Assumes the skill names teamcity.toml: only a direct mention counts, not Glob discovery."""
     read_files = [p for p in runner.events.files_read if p.endswith("teamcity.toml")]
     inspected_via_shell = any("teamcity.toml" in c for c in runner.commands)
     if read_files or inspected_via_shell:
@@ -374,7 +380,7 @@ def added_repository_link_with_project_and_without_job(runner: EvalRunner) -> No
 
 def did_not_add_repository_link(runner: EvalRunner) -> None:
     """Guardrail: must not touch `link` on work that shouldn't bind a repo.
-    Any invocation counts — even `link --help` — as off-task drift."""
+    Settled policy: any invocation counts, even `link --help`. Do not relax."""
     if runner.has_subcommand("link"):
         runner.failed("Invoked 'teamcity link' where no repo binding was warranted")
     else:
@@ -389,41 +395,19 @@ def mentioned_teamcity_toml(runner: EvalRunner) -> None:
 
 
 def did_not_modify_teamcity_toml(runner: EvalRunner) -> None:
+    """Write/Edit covers how agents really edit files; shell mutation is one regex."""
     modified = [
         p for p in runner.events.files_created + runner.events.files_modified
         if p.endswith("teamcity.toml")
     ]
-    suspicious_patterns = (
-        # Shell redirections and in-place editors
-        "> teamcity.toml",
-        "> ./teamcity.toml",
-        ">teamcity.toml",
-        ">./teamcity.toml",
-        ">> teamcity.toml",
-        ">> ./teamcity.toml",
-        ">>teamcity.toml",
-        ">>./teamcity.toml",
-        "tee teamcity.toml",
-        "tee ./teamcity.toml",
-        "tee -a teamcity.toml",
-        "tee -a ./teamcity.toml",
-        "sed -i",
-        "perl -pi",
-        # Removal commands (rm, git rm, unlink); outer teamcity.toml guard prevents false positives
-        "rm ",
-        "unlink ",
-    )
-    suspicious_shell = [
-        c for c in runner.commands
-        if "teamcity.toml" in c.lower() and any(pattern in c.lower() for pattern in suspicious_patterns)
-    ]
-    if modified or suspicious_shell:
+    if modified or any(_TOML_MUTATION.search(c) for c in runner.commands):
         runner.failed("Modified or removed the teamcity.toml file manually")
     else:
         runner.passed("Did not modify teamcity.toml")
 
 
 def used_project_from_repository_link(runner: EvalRunner) -> None:
+    """Reliance on the binding is unobservable, so an explicit --project JBR also passes."""
     inspected = (
         any(p.endswith("teamcity.toml") for p in runner.events.files_read)
         or any("teamcity.toml" in c for c in runner.commands)
@@ -448,10 +432,6 @@ def used_project_from_repository_link(runner: EvalRunner) -> None:
 # JBR project id: used by use-repository-link and find-builds.
 _LINKED_PROJECT_ID = "JBR"
 
-# link --project takes an ID, not the display name.
-_LOCATE_AND_LINK_PROJECT_IDS = frozenset({"JBR"})
-
-
 def _flag_value(argv: list[str], *names: str) -> str | None:
     """Value of --flag=x / --flag x / -f x in an argv, or None if the flag is absent."""
     toks = argv[1:]
@@ -468,34 +448,29 @@ _PROJECT_DISCOVERY = (("project", "list"), ("project", "view"), ("project", "tre
 
 
 def located_project_before_link(runner: EvalRunner) -> None:
-    """Pass if the agent discovered a project before binding to it.
+    """Pass if the agent resolved the project itself and bound it by id.
 
-    The prompt names a project but gives no id, so a genuine `teamcity link`
-    binding attempt must be preceded — in execution order — by a project
-    discovery command (`project list/view/tree`). The link must bind the located
-    project with `--project` — `--auto` binds from git remotes, not the located
-    project. Linking first, or never running discovery, fails. Grades the command
-    sequence, not server output, so it doesn't depend on the id or on success."""
+    The prompt names a project but gives no id, so two independent things must
+    show up in the session: a project discovery command (`project list/view/
+    tree`), and a `link --project <id>` — not `--auto`, which binds from git
+    remotes and ignores the located project. Order is not graded: agents retry
+    and reorder, and the harness only records that commands ran."""
     discovered = False
+    linked = False
     for argv in runner.teamcity_argvs():
         sub = EvalRunner.subcommand_tokens(argv)
         if tuple(sub[:2]) in _PROJECT_DISCOVERY:
             discovered = True
-            continue
-        if sub[:1] == ["link"]:
-            if not discovered:
-                continue
-            project_val = _flag_value(argv, "--project", "-p")
-            if project_val is None:
-                continue
-            if project_val in _LOCATE_AND_LINK_PROJECT_IDS:
-                runner.passed("Located the project before linking")
-                return
-            runner.failed(
-                f"Linked with project {project_val!r}, not the discovered JetBrains Runtime project"
-            )
-            return
-    runner.failed("Did not locate the project before linking")
+        elif sub[:1] == ["link"]:
+            flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
+            if not flags & {"--auto", "-a"} and _flag_value(argv, "--project", "-p"):
+                linked = True
+    if not discovered:
+        runner.failed("Did not run a project discovery command to resolve the project id")
+    elif not linked:
+        runner.failed("Did not link with a discovered project id")
+    else:
+        runner.passed("Discovered the project and linked it by id")
 
 
 # ---------------------------------------------------------------------------

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -342,10 +342,6 @@ def added_repository_link(runner: EvalRunner) -> None:
         runner.failed("Did not attempt to link the repository to a TeamCity job / project")
 
 
-# Flags that make `teamcity link` a genuine binding attempt (vs. bare/usage-only).
-_LINK_BINDING_FLAGS = frozenset({"--auto", "-a", "--project", "-p", "--job", "-j", "--jobs"})
-
-
 def _attempted_repository_link(runner: EvalRunner) -> bool:
     """True if the agent invoked `teamcity link` with real binding arguments.
 
@@ -358,7 +354,7 @@ def _attempted_repository_link(runner: EvalRunner) -> bool:
         if EvalRunner.subcommand_tokens(argv)[:1] != ["link"]:
             continue
         flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
-        if flags & _LINK_BINDING_FLAGS:
+        if flags & {"--auto", "-a"} or _flag_value(argv, "--project", "-p", "--job", "-j", "--jobs"):
             return True
     return False
 
@@ -368,10 +364,12 @@ def added_repository_link_with_project_and_without_job(runner: EvalRunner) -> No
         if EvalRunner.subcommand_tokens(argv)[:1] != ["link"]:
             continue
         flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
-        if (flags & {"--project", "-p"}) and not (flags & {"--job", "-j", "--jobs"}):
-            runner.passed("Linked the repository using only the project argument")
+        if flags & {"--job", "-j", "--jobs", "--auto", "-a"}:
+            continue
+        if _flag_value(argv, "--project", "-p") == _LINKED_PROJECT_ID:
+            runner.passed(f"Linked the repository to the {_LINKED_PROJECT_ID} project only")
             return
-    runner.failed("Did not link the repository using only the project argument")
+    runner.failed(f"Did not link the repository to the {_LINKED_PROJECT_ID} project (project-only)")
 
 
 def did_not_add_repository_link(runner: EvalRunner) -> None:
@@ -447,12 +445,11 @@ def used_project_from_repository_link(runner: EvalRunner) -> None:
         runner.failed("Did not run a build query relying on the linked project")
 
 
-# Linked project seeded by the use-repository-link task's setup_files. Checks
-# receive only the runner, so this must be kept in sync with tasks.json.
+# JBR project id: used by use-repository-link and find-builds.
 _LINKED_PROJECT_ID = "JBR"
 
-# Acceptable --project values for the locate-and-link task (ID or full name).
-_LOCATE_AND_LINK_PROJECT_IDS = frozenset({"JBR", "JetBrains Runtime"})
+# link --project takes an ID, not the display name.
+_LOCATE_AND_LINK_PROJECT_IDS = frozenset({"JBR"})
 
 
 def _flag_value(argv: list[str], *names: str) -> str | None:

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -364,28 +364,14 @@ def _attempted_repository_link(runner: EvalRunner) -> bool:
 
 
 def added_repository_link_with_project_and_without_job(runner: EvalRunner) -> None:
-    project_flag = re.compile(r"(^|\s)(--project|-p)(\s|=)")
-    job_flag = re.compile(r"(^|\s)(--job|-j)(\s|=)")
-    for cmd in runner.commands:
-        if (
-            _has_repository_link_command(cmd) and
-            project_flag.search(cmd) and
-            not job_flag.search(cmd)
-        ):
+    for argv in runner.teamcity_argvs():
+        if EvalRunner.subcommand_tokens(argv)[:1] != ["link"]:
+            continue
+        flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
+        if (flags & {"--project", "-p"}) and not (flags & {"--job", "-j"}):
             runner.passed("Linked the repository using only the project argument")
             return
     runner.failed("Did not link the repository using only the project argument")
-
-
-_LINK_INVOCATION = re.compile(r"(?:^|[;&|]\s*)(teamcity\s+link(?:\s+[^;&|]+)*)", re.IGNORECASE)
-_HELP_FLAG = re.compile(r"(^|\s)(--help|-h)(\s|$)")
-
-
-def _has_repository_link_command(cmd: str) -> bool:
-    return any(
-        not _HELP_FLAG.search(match.group(1))
-        for match in _LINK_INVOCATION.finditer(cmd)
-    )
 
 
 def did_not_add_repository_link(runner: EvalRunner) -> None:
@@ -482,9 +468,10 @@ def located_project_before_link(runner: EvalRunner) -> None:
 
     The prompt names a project but gives no id, so a genuine `teamcity link`
     binding attempt must be preceded — in execution order — by a project
-    discovery command (`project list/view/tree`). Linking first, or never
-    running discovery, fails. Grades the command sequence, not server output,
-    so it doesn't depend on the located id or on the link succeeding."""
+    discovery command (`project list/view/tree`). The link must bind the located
+    project with `--project` — `--auto` binds from git remotes, not the located
+    project. Linking first, or never running discovery, fails. Grades the command
+    sequence, not server output, so it doesn't depend on the id or on success."""
     discovered = False
     for argv in runner.teamcity_argvs():
         sub = EvalRunner.subcommand_tokens(argv)
@@ -493,7 +480,7 @@ def located_project_before_link(runner: EvalRunner) -> None:
             continue
         if sub[:1] == ["link"]:
             flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
-            if discovered and flags & _LINK_BINDING_FLAGS:
+            if discovered and flags & {"--project", "-p"}:
                 runner.passed("Located the project before linking")
                 return
     runner.failed("Did not locate the project before linking")

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -468,6 +468,32 @@ def _flag_value(argv: list[str], *names: str) -> str | None:
     return None
 
 
+# Project-discovery commands that resolve a name to an id before binding.
+_PROJECT_DISCOVERY = (("project", "list"), ("project", "view"), ("project", "tree"))
+
+
+def located_project_before_link(runner: EvalRunner) -> None:
+    """Pass if the agent discovered a project before binding to it.
+
+    The prompt names a project but gives no id, so a genuine `teamcity link`
+    binding attempt must be preceded — in execution order — by a project
+    discovery command (`project list/view/tree`). Linking first, or never
+    running discovery, fails. Grades the command sequence, not server output,
+    so it doesn't depend on the located id or on the link succeeding."""
+    discovered = False
+    for argv in runner.teamcity_argvs():
+        sub = EvalRunner.subcommand_tokens(argv)
+        if tuple(sub[:2]) in _PROJECT_DISCOVERY:
+            discovered = True
+            continue
+        if sub[:1] == ["link"]:
+            flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
+            if discovered and flags & _LINK_BINDING_FLAGS:
+                runner.passed("Located the project before linking")
+                return
+    runner.failed("Did not locate the project before linking")
+
+
 # ---------------------------------------------------------------------------
 # cross-project
 # ---------------------------------------------------------------------------
@@ -680,6 +706,7 @@ CHECK_REGISTRY: dict[str, callable] = {
     "did_not_add_repository_link": did_not_add_repository_link,
     "did_not_modify_teamcity_toml": did_not_modify_teamcity_toml,
     "used_project_from_repository_link": used_project_from_repository_link,
+    "located_project_before_link": located_project_before_link,
     # cross-project
     "finds_subprojects": finds_subprojects,
     "lists_jobs": lists_jobs,

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -368,7 +368,7 @@ def added_repository_link_with_project_and_without_job(runner: EvalRunner) -> No
         if EvalRunner.subcommand_tokens(argv)[:1] != ["link"]:
             continue
         flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
-        if (flags & {"--project", "-p"}) and not (flags & {"--job", "-j"}):
+        if (flags & {"--project", "-p"}) and not (flags & {"--job", "-j", "--jobs"}):
             runner.passed("Linked the repository using only the project argument")
             return
     runner.failed("Did not link the repository using only the project argument")
@@ -431,7 +431,7 @@ def used_project_from_repository_link(runner: EvalRunner) -> None:
         return
     relied = False
     for argv in runner.teamcity_argvs():
-        if EvalRunner.subcommand_tokens(argv)[:2] not in (["run", "list"], ["run", "view"]):
+        if EvalRunner.subcommand_tokens(argv)[:2] not in (["run", "list"], ["run", "log"]):
             continue
         if _flag_value(argv, "--project", "-p") not in (None, _LINKED_PROJECT_ID):
             runner.failed("Overrode the build query with a project other than the linked one")

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -323,6 +323,152 @@ def uses_run_not_build(runner: EvalRunner) -> None:
 
 
 # ---------------------------------------------------------------------------
+# repository binding
+# ---------------------------------------------------------------------------
+
+def checked_repository_link(runner: EvalRunner) -> None:
+    read_files = [p for p in runner.events.files_read if p.endswith("teamcity.toml")]
+    inspected_via_shell = any("teamcity.toml" in c for c in runner.commands)
+    if read_files or inspected_via_shell:
+        runner.passed("Checked teamcity.toml")
+    else:
+        runner.failed("Did not check for an existing teamcity.toml binding")
+
+
+def added_repository_link(runner: EvalRunner) -> None:
+    if _attempted_repository_link(runner):
+        runner.passed("Attempted to link the repository to a TeamCity job / project")
+    else:
+        runner.failed("Did not attempt to link the repository to a TeamCity job / project")
+
+
+# Flags that make `teamcity link` a genuine binding attempt (vs. bare/usage-only).
+_LINK_BINDING_FLAGS = frozenset({"--auto", "-a", "--project", "-p", "--job", "-j", "--jobs"})
+
+
+def _attempted_repository_link(runner: EvalRunner) -> bool:
+    """True if the agent invoked `teamcity link` with real binding arguments.
+
+    Whether the call succeeded is intentionally ignored: a link can fail for
+    server or connectivity reasons unrelated to agent quality, and this is a
+    skill eval. What we grade is that the agent issued a genuine binding attempt
+    — not a bare, usage-only, or --help invocation.
+    """
+    for argv in runner.teamcity_argvs():
+        if EvalRunner.subcommand_tokens(argv)[:1] != ["link"]:
+            continue
+        flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
+        if flags & _LINK_BINDING_FLAGS:
+            return True
+    return False
+
+
+def added_repository_link_with_project_and_without_job(runner: EvalRunner) -> None:
+    project_flag = re.compile(r"(^|\s)(--project|-p)(\s|=)")
+    job_flag = re.compile(r"(^|\s)(--job|-j)(\s|=)")
+    for cmd in runner.commands:
+        if (
+            _has_repository_link_command(cmd) and
+            project_flag.search(cmd) and
+            not job_flag.search(cmd)
+        ):
+            runner.passed("Linked the repository using only the project argument")
+            return
+    runner.failed("Did not link the repository using only the project argument")
+
+
+_LINK_INVOCATION = re.compile(r"(?:^|[;&|]\s*)(teamcity\s+link(?:\s+[^;&|]+)*)", re.IGNORECASE)
+_HELP_FLAG = re.compile(r"(^|\s)(--help|-h)(\s|$)")
+
+
+def _has_repository_link_command(cmd: str) -> bool:
+    return any(
+        not _HELP_FLAG.search(match.group(1))
+        for match in _LINK_INVOCATION.finditer(cmd)
+    )
+
+
+def did_not_add_repository_link(runner: EvalRunner) -> None:
+    """Guardrail: must not touch `link` on work that shouldn't bind a repo.
+    Any invocation counts — even `link --help` — as off-task drift."""
+    if runner.has_subcommand("link"):
+        runner.failed("Invoked 'teamcity link' where no repo binding was warranted")
+    else:
+        runner.passed("Did not invoke 'teamcity link'")
+
+
+def mentioned_teamcity_toml(runner: EvalRunner) -> None:
+    if runner.has_text("teamcity.toml"):
+        runner.passed("Mentioned teamcity.toml")
+    else:
+        runner.failed("Did not mention the teamcity.toml binding file")
+
+
+def did_not_modify_teamcity_toml(runner: EvalRunner) -> None:
+    modified = [
+        p for p in runner.events.files_created + runner.events.files_modified
+        if p.endswith("teamcity.toml")
+    ]
+    obvious_writes = (
+        "> teamcity.toml",
+        "> ./teamcity.toml",
+        ">teamcity.toml",
+        ">./teamcity.toml",
+        ">> teamcity.toml",
+        ">> ./teamcity.toml",
+        ">>teamcity.toml",
+        ">>./teamcity.toml",
+        "tee teamcity.toml",
+        "tee ./teamcity.toml",
+        "tee -a teamcity.toml",
+        "tee -a ./teamcity.toml",
+        "sed -i",
+        "perl -pi",
+    )
+    suspicious_shell = [
+        c for c in runner.commands
+        if "teamcity.toml" in c.lower() and any(pattern in c.lower() for pattern in obvious_writes)
+    ]
+    if modified or suspicious_shell:
+        runner.failed("Modified the teamcity.toml file manually")
+    else:
+        runner.passed("Did not modify teamcity.toml")
+
+
+def used_project_from_repository_link(runner: EvalRunner) -> None:
+    """Pass if a build query relied on the teamcity.toml binding — no project/job
+    given, or the linked one named explicitly. An override to a different
+    project/job does not count. Grades the command, not server output, so it
+    doesn't depend on a specific error message or on the IDs being nonexistent."""
+    for argv in runner.teamcity_argvs():
+        if EvalRunner.subcommand_tokens(argv)[:2] not in (["run", "list"], ["run", "view"]):
+            continue
+        proj = _flag_value(argv, "--project", "-p")
+        job = _flag_value(argv, "--job", "-j")
+        if proj in (None, _LINKED_PROJECT_ID) and job in (None, _LINKED_JOB_ID):
+            runner.passed("Ran a build query that relied on the linked project/job")
+            return
+    runner.failed("Did not use the linked project/job from teamcity.toml")
+
+
+# Linked IDs seeded by the use-repository-link task's setup_files. Checks
+# receive only the runner, so these must be kept in sync with tasks.json.
+_LINKED_PROJECT_ID = "Project_uipBGpvQua"
+_LINKED_JOB_ID = "FooJob"
+
+
+def _flag_value(argv: list[str], *names: str) -> str | None:
+    """Value of --flag=x / --flag x / -f x in an argv, or None if the flag is absent."""
+    toks = argv[1:]
+    for i, tok in enumerate(toks):
+        if tok.split("=", 1)[0] in names:
+            if "=" in tok:
+                return tok.split("=", 1)[1]
+            return toks[i + 1] if i + 1 < len(toks) else ""
+    return None
+
+
+# ---------------------------------------------------------------------------
 # cross-project
 # ---------------------------------------------------------------------------
 
@@ -526,6 +672,14 @@ CHECK_REGISTRY: dict[str, callable] = {
     "filters_by_project": filters_by_project,
     "uses_json": uses_json,
     "uses_run_not_build": uses_run_not_build,
+    # repository binding
+    "checked_repository_link": checked_repository_link,
+    "added_repository_link": added_repository_link,
+    "added_repository_link_with_project_and_without_job": added_repository_link_with_project_and_without_job,
+    "mentioned_teamcity_toml": mentioned_teamcity_toml,
+    "did_not_add_repository_link": did_not_add_repository_link,
+    "did_not_modify_teamcity_toml": did_not_modify_teamcity_toml,
+    "used_project_from_repository_link": used_project_from_repository_link,
     # cross-project
     "finds_subprojects": finds_subprojects,
     "lists_jobs": lists_jobs,

--- a/evals/checks.py
+++ b/evals/checks.py
@@ -395,7 +395,8 @@ def did_not_modify_teamcity_toml(runner: EvalRunner) -> None:
         p for p in runner.events.files_created + runner.events.files_modified
         if p.endswith("teamcity.toml")
     ]
-    obvious_writes = (
+    suspicious_patterns = (
+        # Shell redirections and in-place editors
         "> teamcity.toml",
         "> ./teamcity.toml",
         ">teamcity.toml",
@@ -410,13 +411,16 @@ def did_not_modify_teamcity_toml(runner: EvalRunner) -> None:
         "tee -a ./teamcity.toml",
         "sed -i",
         "perl -pi",
+        # Removal commands (rm, git rm, unlink); outer teamcity.toml guard prevents false positives
+        "rm ",
+        "unlink ",
     )
     suspicious_shell = [
         c for c in runner.commands
-        if "teamcity.toml" in c.lower() and any(pattern in c.lower() for pattern in obvious_writes)
+        if "teamcity.toml" in c.lower() and any(pattern in c.lower() for pattern in suspicious_patterns)
     ]
     if modified or suspicious_shell:
-        runner.failed("Modified the teamcity.toml file manually")
+        runner.failed("Modified or removed the teamcity.toml file manually")
     else:
         runner.passed("Did not modify teamcity.toml")
 
@@ -431,7 +435,7 @@ def used_project_from_repository_link(runner: EvalRunner) -> None:
         return
     relied = False
     for argv in runner.teamcity_argvs():
-        if EvalRunner.subcommand_tokens(argv)[:2] not in (["run", "list"], ["run", "log"]):
+        if EvalRunner.subcommand_tokens(argv)[:2] != ["run", "list"]:
             continue
         if _flag_value(argv, "--project", "-p") not in (None, _LINKED_PROJECT_ID):
             runner.failed("Overrode the build query with a project other than the linked one")
@@ -446,6 +450,9 @@ def used_project_from_repository_link(runner: EvalRunner) -> None:
 # Linked project seeded by the use-repository-link task's setup_files. Checks
 # receive only the runner, so this must be kept in sync with tasks.json.
 _LINKED_PROJECT_ID = "JBR"
+
+# Acceptable --project values for the locate-and-link task (ID or full name).
+_LOCATE_AND_LINK_PROJECT_IDS = frozenset({"JBR", "JetBrains Runtime"})
 
 
 def _flag_value(argv: list[str], *names: str) -> str | None:
@@ -479,10 +486,18 @@ def located_project_before_link(runner: EvalRunner) -> None:
             discovered = True
             continue
         if sub[:1] == ["link"]:
-            flags = {t.split("=", 1)[0] for t in EvalRunner.flag_tokens(argv)}
-            if discovered and flags & {"--project", "-p"}:
+            if not discovered:
+                continue
+            project_val = _flag_value(argv, "--project", "-p")
+            if project_val is None:
+                continue
+            if project_val in _LOCATE_AND_LINK_PROJECT_IDS:
                 runner.passed("Located the project before linking")
                 return
+            runner.failed(
+                f"Linked with project {project_val!r}, not the discovered JetBrains Runtime project"
+            )
+            return
     runner.failed("Did not locate the project before linking")
 
 

--- a/evals/scaffold/claude.py
+++ b/evals/scaffold/claude.py
@@ -45,17 +45,31 @@ _PROPAGATE_KEYS = (
 def _setup_workspace(
     work_dir: Path,
     treatment: Treatment,
+    setup_files: dict[str, str] | None = None,
 ) -> None:
     """Create a pristine .claude dir with only the treatment's skill.
 
     Nothing is copied from the real ~/.claude/ — user settings, plugins,
     and hooks (or a local API proxy config) would leak into both arms.
     Auth comes from ANTHROPIC_API_KEY / CLAUDE_CODE_OAUTH_TOKEN env vars.
+
+    A task's `setup_files` (path -> content) are written into the workspace
+    root — the agent's CWD — with ${VAR} references expanded from the
+    environment, so a task can seed files like teamcity.toml that it depends
+    on. Both treatment arms get the same files; only the skill differs.
     """
     (work_dir / ".claude").mkdir(parents=True, exist_ok=True)
     if treatment.skill_dir and treatment.skill_dir.exists():
         dest = work_dir / ".claude" / "skills" / "teamcity-cli"
         shutil.copytree(treatment.skill_dir, dest)
+
+    root = work_dir.resolve()
+    for rel_path, content in (setup_files or {}).items():
+        dest = (work_dir / rel_path).resolve()
+        if not dest.is_relative_to(root):
+            raise ValueError(f"setup_files path escapes workspace: {rel_path!r}")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(os.path.expandvars(content))
 
 
 def _build_isolated_env(work_dir: Path) -> dict[str, str]:
@@ -97,13 +111,14 @@ def run_claude(
     *,
     model: str | None = None,
     timeout: int = 600,
+    setup_files: dict[str, str] | None = None,
 ) -> ClaudeResult:
     """Run Claude Code CLI locally in a temp directory with isolated config."""
     model = model or os.environ.get("BENCH_CC_MODEL", DEFAULT_MODEL)
 
     with tempfile.TemporaryDirectory(prefix="tc-eval-") as tmp:
         work_dir = Path(tmp)
-        _setup_workspace(work_dir, treatment)
+        _setup_workspace(work_dir, treatment, setup_files)
         env = _build_isolated_env(work_dir)
 
         cmd = [
@@ -147,13 +162,14 @@ def run_claude_docker(
     model: str | None = None,
     timeout: int = 600,
     image: str = "tc-skill-eval",
+    setup_files: dict[str, str] | None = None,
 ) -> ClaudeResult:
     """Run Claude Code CLI inside a Docker container (fully isolated)."""
     model = model or os.environ.get("BENCH_CC_MODEL", DEFAULT_MODEL)
 
     with tempfile.TemporaryDirectory(prefix="tc-eval-") as tmp:
         work_dir = Path(tmp)
-        _setup_workspace(work_dir, treatment)
+        _setup_workspace(work_dir, treatment, setup_files)
 
         env_flags: list[str] = []
         for key in _PROPAGATE_KEYS:

--- a/evals/scaffold/tasks.py
+++ b/evals/scaffold/tasks.py
@@ -16,6 +16,7 @@ class TaskConfig:
     checks: list[str] = field(default_factory=list)
     llm_grade: bool = False
     default_treatments: list[str] = field(default_factory=lambda: ["CONTROL", "CURRENT"])
+    setup_files: dict[str, str] = field(default_factory=dict)
 
 
 def _load_all() -> list[dict]:
@@ -32,6 +33,7 @@ def load_task(task_name: str) -> TaskConfig:
                 checks=t.get("checks", []),
                 llm_grade=t.get("llm_grade", False),
                 default_treatments=t.get("treatments", ["CONTROL", "CURRENT"]),
+                setup_files=t.get("setup_files", {}),
             )
     raise KeyError(f"Task '{task_name}' not found in {TASKS_FILE}")
 

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -14,18 +14,18 @@
   {
     "id": "composite-failure",
     "prompt": "The job `ijplatform_master_Idea_Test_Ultimate_Aggregator` is a composite build with many snapshot dependencies. Find its most recent failed run, then:\n\n1. Show me the dependency tree for this job\n2. Find which child build(s) actually failed\n3. Get the test failures from those child builds",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "provides_diagnosis", "added_repository_link", "mentioned_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "provides_diagnosis", "added_repository_link", "mentioned_teamcity_toml", "did_not_modify_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "inspect-url",
     "prompt": "What's going on with this build configuration? Show me recent builds and their status.\n\nhttps://buildserver.labs.intellij.net/buildConfiguration/ijplatform_master_CIDR_CLion_CLionTrunkHeavyTests_TestsUbuntu2404x86_64",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "added_repository_link", "mentioned_teamcity_toml", "executes_commands", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "added_repository_link", "mentioned_teamcity_toml", "did_not_modify_teamcity_toml", "executes_commands", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "find-builds",
     "prompt": "Find the 10 most recent failed builds in the JetBrains Runtime project (project ID: JBR). Give me their IDs, statuses, and branch names in JSON format.",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "added_repository_link", "added_repository_link_with_project_and_without_job", "mentioned_teamcity_toml", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "added_repository_link", "added_repository_link_with_project_and_without_job", "mentioned_teamcity_toml", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "use-repository-link",

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -14,18 +14,18 @@
   {
     "id": "composite-failure",
     "prompt": "The job `ijplatform_master_Idea_Test_Ultimate_Aggregator` is a composite build with many snapshot dependencies. Find its most recent failed run, then:\n\n1. Show me the dependency tree for this job\n2. Find which child build(s) actually failed\n3. Get the test failures from those child builds",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "provides_diagnosis", "added_repository_link", "mentioned_teamcity_toml", "did_not_modify_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "provides_diagnosis", "added_repository_link", "did_not_modify_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "inspect-url",
     "prompt": "What's going on with this build configuration? Show me recent builds and their status.\n\nhttps://buildserver.labs.intellij.net/buildConfiguration/ijplatform_master_CIDR_CLion_CLionTrunkHeavyTests_TestsUbuntu2404x86_64",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "added_repository_link", "mentioned_teamcity_toml", "did_not_modify_teamcity_toml", "executes_commands", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "added_repository_link", "did_not_modify_teamcity_toml", "executes_commands", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "find-builds",
     "prompt": "Find the 10 most recent failed builds in the JetBrains Runtime project (project ID: JBR). Give me their IDs, statuses, and branch names in JSON format.",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "added_repository_link", "added_repository_link_with_project_and_without_job", "mentioned_teamcity_toml", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "added_repository_link_with_project_and_without_job", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "use-repository-link",

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -36,6 +36,11 @@
     }
   },
   {
+    "id": "locate-and-link",
+    "prompt": "I want this repository to track CI for the JetBrains Runtime project. Set that up for me.",
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "located_project_before_link", "added_repository_link", "mentioned_teamcity_toml", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"]
+  },
+  {
     "id": "cross-project",
     "prompt": "I'm trying to understand the CI setup for the CEF/JCEF part of JetBrains Runtime. Can you:\n\n1. Find the JCEF-related subprojects under JetBrains Runtime\n2. List the build jobs in those projects\n3. Show me the recent build history — are things generally green or are there frequent failures?\n4. Find if there are any builds currently in the queue for these projects\n\nGive me a summary of the CI health for this area.",
     "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_subprojects", "lists_jobs", "views_build_history", "checks_queue", "provides_health_summary", "checked_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -32,7 +32,7 @@
     "prompt": "When did the last build finish?",
     "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "used_project_from_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"],
     "setup_files": {
-      "teamcity.toml": "[[server]]\nurl = \"${TEAMCITY_URL}\"\nproject = \"Project_uipBGpvQua\"\njob = \"FooJob\"\n"
+      "teamcity.toml": "[[server]]\nurl = \"${TEAMCITY_URL}\"\nproject = \"JBR\"\n"
     }
   },
   {

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -8,7 +8,7 @@
   {
     "id": "daily-loop",
     "prompt": "Show me the last 5 builds on the `master` branch and check if any of them failed.\n\nFor any failure you find:\n1. Show me the failure details and what tests broke\n2. Tell me what changes went into that build",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "lists_builds", "investigates_failure", "views_changes", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "did_not_modify_teamcity_toml", "lists_builds", "investigates_failure", "views_changes", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -2,41 +2,49 @@
   {
     "id": "investigate-failure",
     "prompt": "Find a recent failed build on this TeamCity server and investigate what went wrong.\n\nTell me:\n1. Which build failed and in which job\n2. What the build log says about the failure\n3. Which tests failed (if any)\n4. What changes triggered the build",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "found_failed_build", "viewed_log", "viewed_tests", "viewed_changes", "produced_diagnosis", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "found_failed_build", "viewed_log", "viewed_tests", "viewed_changes", "produced_diagnosis", "checked_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "daily-loop",
     "prompt": "Show me the last 5 builds on the `master` branch and check if any of them failed.\n\nFor any failure you find:\n1. Show me the failure details and what tests broke\n2. Tell me what changes went into that build",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "lists_builds", "investigates_failure", "views_changes", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "lists_builds", "investigates_failure", "views_changes", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "composite-failure",
     "prompt": "The job `ijplatform_master_Idea_Test_Ultimate_Aggregator` is a composite build with many snapshot dependencies. Find its most recent failed run, then:\n\n1. Show me the dependency tree for this job\n2. Find which child build(s) actually failed\n3. Get the test failures from those child builds",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "multi_step", "no_thrashing", "provides_diagnosis", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_composite", "explores_dependencies", "drills_into_child", "provides_diagnosis", "added_repository_link", "mentioned_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "inspect-url",
     "prompt": "What's going on with this build configuration? Show me recent builds and their status.\n\nhttps://buildserver.labs.intellij.net/buildConfiguration/ijplatform_master_CIDR_CLion_CLionTrunkHeavyTests_TestsUbuntu2404x86_64",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "executes_commands", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "extracts_config_id", "lists_config_builds", "provides_answer", "added_repository_link", "mentioned_teamcity_toml", "executes_commands", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "find-builds",
     "prompt": "Find the 10 most recent failed builds in the JetBrains Runtime project (project ID: JBR). Give me their IDs, statuses, and branch names in JSON format.",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "uses_run_list", "filters_by_status", "filters_by_project", "uses_json", "uses_run_not_build", "added_repository_link", "added_repository_link_with_project_and_without_job", "mentioned_teamcity_toml", "valid_commands", "no_hallucinations"]
+  },
+  {
+    "id": "use-repository-link",
+    "prompt": "When did the last build finish?",
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "checked_repository_link", "used_project_from_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"],
+    "setup_files": {
+      "teamcity.toml": "[[server]]\nurl = \"${TEAMCITY_URL}\"\nproject = \"Project_uipBGpvQua\"\njob = \"FooJob\"\n"
+    }
   },
   {
     "id": "cross-project",
     "prompt": "I'm trying to understand the CI setup for the CEF/JCEF part of JetBrains Runtime. Can you:\n\n1. Find the JCEF-related subprojects under JetBrains Runtime\n2. List the build jobs in those projects\n3. Show me the recent build history — are things generally green or are there frequent failures?\n4. Find if there are any builds currently in the queue for these projects\n\nGive me a summary of the CI health for this area.",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_subprojects", "lists_jobs", "views_build_history", "checks_queue", "provides_health_summary", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "finds_subprojects", "lists_jobs", "views_build_history", "checks_queue", "provides_health_summary", "checked_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "multi_step", "no_thrashing", "valid_commands", "no_hallucinations"],
     "llm_grade": true
   },
   {
     "id": "explore-infrastructure",
     "prompt": "I'm new to this TeamCity server. Can you give me an overview?\n\n1. What top-level projects are there?\n2. How many agent pools exist and what are the main ones?\n3. Show me the project hierarchy tree for the JetBrains Runtime project",
-    "checks": ["ran_teamcity_commands", "no_auth_failure", "lists_projects", "lists_pools", "shows_tree", "provides_overview", "valid_commands", "no_hallucinations"]
+    "checks": ["ran_teamcity_commands", "no_auth_failure", "lists_projects", "lists_pools", "shows_tree", "provides_overview", "checked_repository_link", "did_not_add_repository_link", "did_not_modify_teamcity_toml", "valid_commands", "no_hallucinations"]
   },
   {
     "id": "hallucination-resistance",

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -210,6 +210,17 @@ def test_used_project_from_repository_link():
                          runner_for(["teamcity project list"]))
 
 
+def test_located_project_before_link():
+    assert run_check(checks.located_project_before_link,
+                     runner_for(["teamcity project list", "teamcity link --project JBR"]))
+    assert not run_check(checks.located_project_before_link,
+                         runner_for(["teamcity link --project JBR", "teamcity project list"]))
+    assert not run_check(checks.located_project_before_link,
+                         runner_for(["teamcity project list"]))
+    assert not run_check(checks.located_project_before_link,
+                         runner_for(["teamcity project list", "teamcity link --help"]))
+
+
 # ---------------------------------------------------------------------------
 # Gate statistics
 # ---------------------------------------------------------------------------

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -198,16 +198,23 @@ def test_did_not_modify_teamcity_toml():
 
 
 def test_used_project_from_repository_link():
-    # Relied on the binding: no project/job, or the linked one named explicitly.
+    # Must inspect teamcity.toml AND query within the linked project — via shell...
     assert run_check(checks.used_project_from_repository_link,
-                     runner_for(["teamcity run list -n 1"]))
+                     runner_for(["cat teamcity.toml", "teamcity run list -n 1"]))
+    # ...or via a file read, with the linked project named explicitly.
     assert run_check(checks.used_project_from_repository_link,
-                     runner_for(["teamcity run view --job FooJob"]))
-    # Overriding to a different project, or never running a build query, fails.
+                     runner_for(commands=["teamcity run list --project JBR -n 1"],
+                                files_read=["/repo/teamcity.toml"]))
+    # A no-skill agent that never consults the binding fails — even though the
+    # bare query is auto-scoped by the CLI. This is what isolates the skill.
     assert not run_check(checks.used_project_from_repository_link,
-                         runner_for(["teamcity run list --project SomethingElse"]))
+                         runner_for(["teamcity run list -n 1"]))
+    # Inspected, but overrode to a different project → fail.
     assert not run_check(checks.used_project_from_repository_link,
-                         runner_for(["teamcity project list"]))
+                         runner_for(["cat teamcity.toml", "teamcity run list --project SomethingElse"]))
+    # Inspected, but never ran a build query → fail.
+    assert not run_check(checks.used_project_from_repository_link,
+                         runner_for(["cat teamcity.toml", "teamcity project list"]))
 
 
 def test_located_project_before_link():

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -204,13 +204,22 @@ def test_did_not_modify_teamcity_toml():
     # files_created path (Write tool)
     assert not run_check(checks.did_not_modify_teamcity_toml,
                          runner_for(files_created=["/repo/teamcity.toml"]))
-    # suspicious_shell path — shell redirects
+    # shell mutation path — redirect, tee, in-place sed, removal
     assert not run_check(checks.did_not_modify_teamcity_toml,
                          runner_for(["echo '[server]' > teamcity.toml"]))
+    assert not run_check(checks.did_not_modify_teamcity_toml,
+                         runner_for(["cat <<EOF > /tmp/work/teamcity.toml"]))
     assert not run_check(checks.did_not_modify_teamcity_toml,
                          runner_for(["tee teamcity.toml < config.txt"]))
     assert not run_check(checks.did_not_modify_teamcity_toml,
                          runner_for(["sed -i 's/old/new/' teamcity.toml"]))
+    assert not run_check(checks.did_not_modify_teamcity_toml,
+                         runner_for(["rm -f teamcity.toml"]))
+    # Innocent words ending in "rm", and read-only reads, must not trip it.
+    assert run_check(checks.did_not_modify_teamcity_toml,
+                     runner_for(["cat teamcity.toml # confirm the binding"]))
+    assert run_check(checks.did_not_modify_teamcity_toml,
+                     runner_for(["cat teamcity.toml 2>/dev/null", "rm -rf /tmp/scratch"]))
 
 
 def test_used_project_from_repository_link():
@@ -236,18 +245,22 @@ def test_used_project_from_repository_link():
 def test_located_project_before_link():
     assert run_check(checks.located_project_before_link,
                      runner_for(["teamcity project list", "teamcity link --project JBR"]))
-    assert not run_check(checks.located_project_before_link,
-                         runner_for(["teamcity link --project JBR", "teamcity project list"]))
+    # Any id the agent resolved counts — the check is not pinned to one project.
+    assert run_check(checks.located_project_before_link,
+                     runner_for(["teamcity project view JBR_Master", "teamcity link -p JBR_Master"]))
+    # Order is not graded: a retry that links first still shows both signals.
+    assert run_check(checks.located_project_before_link,
+                     runner_for(["teamcity link --project JBR", "teamcity project list"]))
     assert not run_check(checks.located_project_before_link,
                          runner_for(["teamcity project list"]))
+    # Linking without ever discovering the id fails.
+    assert not run_check(checks.located_project_before_link,
+                         runner_for(["teamcity link --project JBR"]))
     assert not run_check(checks.located_project_before_link,
                          runner_for(["teamcity project list", "teamcity link --help"]))
     # --auto binds from git remotes, not the located project → not "located then linked".
     assert not run_check(checks.located_project_before_link,
                          runner_for(["teamcity project list", "teamcity link --auto"]))
-    # Display name is not the ID that link expects → fail.
-    assert not run_check(checks.located_project_before_link,
-                         runner_for(["teamcity project list", 'teamcity link --project "JetBrains Runtime"']))
 
 
 # ---------------------------------------------------------------------------

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -173,11 +173,14 @@ def test_added_repository_link():
 
 def test_added_repository_link_with_project_and_without_job():
     assert run_check(checks.added_repository_link_with_project_and_without_job,
-                     runner_for(["teamcity link --project Foo"]))
-    assert not run_check(checks.added_repository_link_with_project_and_without_job,
-                         runner_for(["teamcity link --project Foo --job Bar"]))
+                     runner_for(["teamcity link --project JBR"]))
     assert run_check(checks.added_repository_link_with_project_and_without_job,
-                     runner_for(["bin/teamcity link -p Foo"]))
+                     runner_for(["bin/teamcity link -p JBR"]))
+    assert not run_check(checks.added_repository_link_with_project_and_without_job,
+                         runner_for(["teamcity link --project JBR --job Bar"]))
+    # Linking a different project than requested must not earn the check.
+    assert not run_check(checks.added_repository_link_with_project_and_without_job,
+                         runner_for(["teamcity link --project Foo"]))
 
 
 def test_mentioned_teamcity_toml():
@@ -242,6 +245,9 @@ def test_located_project_before_link():
     # --auto binds from git remotes, not the located project → not "located then linked".
     assert not run_check(checks.located_project_before_link,
                          runner_for(["teamcity project list", "teamcity link --auto"]))
+    # Display name is not the ID that link expects → fail.
+    assert not run_check(checks.located_project_before_link,
+                         runner_for(["teamcity project list", 'teamcity link --project "JetBrains Runtime"']))
 
 
 # ---------------------------------------------------------------------------

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -153,6 +153,64 @@ def test_runner_resets_current_check_after_run():
 
 
 # ---------------------------------------------------------------------------
+# repository binding
+# ---------------------------------------------------------------------------
+
+def test_checked_repository_link():
+    assert run_check(checks.checked_repository_link, runner_for(["cat teamcity.toml"]))
+    # Fails cleanly on real signal — not a masked AttributeError (has_command bug).
+    r = runner_for(["teamcity run list"])
+    assert not run_check(checks.checked_repository_link, r)
+    assert "Exception" not in r._results[-1].message
+
+
+def test_added_repository_link():
+    # Grades the attempt, not its exit status — a binding call is a pass.
+    assert run_check(checks.added_repository_link, runner_for(["teamcity link --project Foo"]))
+    # Usage-only (bare / --help) is not a binding attempt.
+    assert not run_check(checks.added_repository_link, runner_for(["teamcity link --help"]))
+
+
+def test_added_repository_link_with_project_and_without_job():
+    assert run_check(checks.added_repository_link_with_project_and_without_job,
+                     runner_for(["teamcity link --project Foo"]))
+    assert not run_check(checks.added_repository_link_with_project_and_without_job,
+                         runner_for(["teamcity link --project Foo --job Bar"]))
+
+
+def test_mentioned_teamcity_toml():
+    assert run_check(checks.mentioned_teamcity_toml,
+                     runner_for(text="I updated teamcity.toml with the binding."))
+    assert not run_check(checks.mentioned_teamcity_toml,
+                         runner_for(text="I ran the link command."))
+
+
+def test_did_not_add_repository_link():
+    assert run_check(checks.did_not_add_repository_link, runner_for(["teamcity run list"]))
+    # Any link touch is off-task drift — including help-only.
+    assert not run_check(checks.did_not_add_repository_link, runner_for(["teamcity link --help"]))
+
+
+def test_did_not_modify_teamcity_toml():
+    assert run_check(checks.did_not_modify_teamcity_toml, runner_for(["cat teamcity.toml"]))
+    assert not run_check(checks.did_not_modify_teamcity_toml,
+                         runner_for(files_modified=["/tmp/teamcity.toml"]))
+
+
+def test_used_project_from_repository_link():
+    # Relied on the binding: no project/job, or the linked one named explicitly.
+    assert run_check(checks.used_project_from_repository_link,
+                     runner_for(["teamcity run list -n 1"]))
+    assert run_check(checks.used_project_from_repository_link,
+                     runner_for(["teamcity run view --job FooJob"]))
+    # Overriding to a different project, or never running a build query, fails.
+    assert not run_check(checks.used_project_from_repository_link,
+                         runner_for(["teamcity run list --project SomethingElse"]))
+    assert not run_check(checks.used_project_from_repository_link,
+                         runner_for(["teamcity project list"]))
+
+
+# ---------------------------------------------------------------------------
 # Gate statistics
 # ---------------------------------------------------------------------------
 

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -195,8 +195,19 @@ def test_did_not_add_repository_link():
 
 def test_did_not_modify_teamcity_toml():
     assert run_check(checks.did_not_modify_teamcity_toml, runner_for(["cat teamcity.toml"]))
+    # files_modified path (Edit tool)
     assert not run_check(checks.did_not_modify_teamcity_toml,
                          runner_for(files_modified=["/tmp/teamcity.toml"]))
+    # files_created path (Write tool)
+    assert not run_check(checks.did_not_modify_teamcity_toml,
+                         runner_for(files_created=["/repo/teamcity.toml"]))
+    # suspicious_shell path — shell redirects
+    assert not run_check(checks.did_not_modify_teamcity_toml,
+                         runner_for(["echo '[server]' > teamcity.toml"]))
+    assert not run_check(checks.did_not_modify_teamcity_toml,
+                         runner_for(["tee teamcity.toml < config.txt"]))
+    assert not run_check(checks.did_not_modify_teamcity_toml,
+                         runner_for(["sed -i 's/old/new/' teamcity.toml"]))
 
 
 def test_used_project_from_repository_link():

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -176,6 +176,8 @@ def test_added_repository_link_with_project_and_without_job():
                      runner_for(["teamcity link --project Foo"]))
     assert not run_check(checks.added_repository_link_with_project_and_without_job,
                          runner_for(["teamcity link --project Foo --job Bar"]))
+    assert run_check(checks.added_repository_link_with_project_and_without_job,
+                     runner_for(["bin/teamcity link -p Foo"]))
 
 
 def test_mentioned_teamcity_toml():
@@ -226,6 +228,9 @@ def test_located_project_before_link():
                          runner_for(["teamcity project list"]))
     assert not run_check(checks.located_project_before_link,
                          runner_for(["teamcity project list", "teamcity link --help"]))
+    # --auto binds from git remotes, not the located project → not "located then linked".
+    assert not run_check(checks.located_project_before_link,
+                         runner_for(["teamcity project list", "teamcity link --auto"]))
 
 
 # ---------------------------------------------------------------------------

--- a/evals/tests/test_tasks.py
+++ b/evals/tests/test_tasks.py
@@ -53,6 +53,7 @@ def test_task(
         treatment=treatment_config,
         model=model,
         timeout=timeout,
+        setup_files=task_config.setup_files,
     )
 
     # --- Parse events ---


### PR DESCRIPTION
## Summary
Adds eval coverage for teamcity link / repository binding behavior. Eight new check functions grade whether the agent inspects the existing teamcity.toml binding, issues a genuine link attempt, avoids touching the file manually, and uses the linked project when querying builds. Two new tasks exercise the core skill scenarios (use-repository-link, locate-and-link), and binding-related guardrail checks are wired into seven existing tasks. The scaffold gains a setup_files mechanism so tasks can seed files like teamcity.toml into the workspace before the agent runs.

## Changes
• evals/checks.py — 8 new check functions: checked_repository_link, added_repository_link, added_repository_link_with_project_and_without_job, did_not_add_repository_link, mentioned_teamcity_toml, did_not_modify_teamcity_toml, used_project_from_repository_link, located_project_before_link
• evals/tasks.json — new use-repository-link and locate-and-link tasks; binding checks added to 7 existing tasks
• evals/scaffold/tasks.py — setup_files field on TaskConfig
• evals/scaffold/claude.py — setup_files threaded through _setup_workspace, run_claude, and run_claude_docker; path-escape guard added
• evals/tests/test_checks.py — 8 new test functions covering the new checks

## Design Decisions
`used_project_from_repository_link` requires the agent to explicitly inspect teamcity.toml even though the CLI already auto-scopes queries to the linked project. This is intentional: the check isolates whether the agent actually exercised the skill, not whether it got the right answer by accident.
`did_not_add_repository_link` treats any link invocation — including --help — as off-task drift, because even exploratory use is noise on tasks that shouldn't touch binding. added_repository_link is the inverse but stricter: it requires a binding flag (--project, --job, --auto, etc.) to distinguish a genuine attempt from a usage-only call.
`_LINKED_PROJECT_ID` is hardcoded in checks.py in sync with the setup_files in tasks.json because checks receive only the runner with no access to task config at call time.

## Test Plan

<!-- For conditional checkboxes that don't apply, leave unchecked and note "N/A — <reason>" inline. -->

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` N/A
- [ ] If adding a data-producing command: includes `--json` support N/A
- [ ] If modifying `--json` output: no field removals/renames (additive only)  N/A
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`  N/A
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change)  N/A
