### PR TITLE
feat(run): pin branch and revision per VCS root in run start

### DIFF
--- a/api/builds.go
+++ b/api/builds.go
@@ -273,8 +273,10 @@ type RunBuildOptions struct {
 	Tags                      []string
 	PersonalChangeID          string
 	Revisions                 []RevisionSpec // revision pins; a spec with empty VcsRootID applies to every VCS root
-	SnapshotDependencies      []int
-	FreezeSettings            *bool // nil = build configuration default; true = settings from VCS; false = current server settings
+	// Deprecated: use Revisions. Revision pins every VCS root to one SHA; ignored when Revisions is set.
+	Revision             string
+	SnapshotDependencies []int
+	FreezeSettings       *bool // nil = build configuration default; true = settings from VCS; false = current server settings
 }
 
 // RunBuild runs a new build with full options
@@ -345,8 +347,12 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 		req.SnapshotDependencies = &SnapshotDepBuilds{Build: refs}
 	}
 
-	if len(opts.Revisions) > 0 {
-		revisions, err := c.resolveRevisionSpecs(buildTypeID, opts.Revisions, opts.Branch)
+	revSpecs := opts.Revisions
+	if len(revSpecs) == 0 && opts.Revision != "" {
+		revSpecs = []RevisionSpec{{Version: opts.Revision}}
+	}
+	if len(revSpecs) > 0 {
+		revisions, err := c.resolveRevisionSpecs(buildTypeID, revSpecs, opts.Branch)
 		if err != nil {
 			return nil, err
 		}

--- a/api/builds.go
+++ b/api/builds.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -49,14 +50,10 @@ func (opts BuildsOptions) Locator() *Locator {
 	locator := NewLocator().
 		Add("buildType", opts.BuildTypeID).
 		Add("defaultFilter", "false")
-	switch {
-	case opts.Branch == "":
+	if opts.Branch == "" {
 		locator.AddLocator("branch", NewLocator().Add("default", "any"))
-	case strings.ContainsAny(opts.Branch, ":,()$"):
-		// branch's value is a nested locator, so the server re-parses even a base64-decoded bare value; route the name through the value condition (verified live against TeamCity 2026.1).
-		locator.AddRaw("branch", "("+nameValueLocator(opts.Branch)+")")
-	default:
-		locator.Add("branch", opts.Branch)
+	} else {
+		locator.AddBranchName(opts.Branch)
 	}
 	locator.
 		AddUpper("status", opts.Status).
@@ -253,6 +250,13 @@ func (c *Client) getFinishedBuild(ctx context.Context, id string) (*Build, error
 	return c.GetBuild(ctx, id) // final attempt
 }
 
+// RevisionSpec pins VCS roots to a revision when triggering a build.
+type RevisionSpec struct {
+	VcsRootID string `json:"vcs_root,omitempty"` // VCS root ID to pin; empty = every VCS root of the job
+	Version   string `json:"version,omitempty"`  // commit SHA; empty = resolve the head of Branch via the changes endpoint
+	Branch    string `json:"branch,omitempty"`   // VCS branch name recorded on the revision
+}
+
 // RunBuildOptions represents options for running a build
 type RunBuildOptions struct {
 	Branch                    string
@@ -268,7 +272,7 @@ type RunBuildOptions struct {
 	AgentID                   int
 	Tags                      []string
 	PersonalChangeID          string
-	Revision                  string
+	Revisions                 []RevisionSpec // revision pins; a spec with empty VcsRootID applies to every VCS root
 	SnapshotDependencies      []int
 	FreezeSettings            *bool // nil = build configuration default; true = settings from VCS; false = current server settings
 }
@@ -341,39 +345,12 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 		req.SnapshotDependencies = &SnapshotDepBuilds{Build: refs}
 	}
 
-	if opts.Revision != "" {
-		entries, err := c.GetVcsRootEntries(buildTypeID)
+	if len(opts.Revisions) > 0 {
+		revisions, err := c.resolveRevisionSpecs(buildTypeID, opts.Revisions, opts.Branch)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get VCS root entries: %w", err)
+			return nil, err
 		}
-		if entries.Count == 0 {
-			return nil, fmt.Errorf("build configuration %s has no VCS roots; cannot pin revision", buildTypeID)
-		}
-
-		branch := opts.Branch
-		if branch != "" && !strings.HasPrefix(branch, "refs/") {
-			branch = "refs/heads/" + branch
-		}
-
-		var revisions []Revision
-		for _, entry := range entries.VcsRootEntry {
-			vcsRootID := ""
-			if entry.VcsRoot != nil {
-				vcsRootID = entry.VcsRoot.ID
-			}
-			if vcsRootID == "" {
-				continue
-			}
-			rev := Revision{
-				Version:         opts.Revision,
-				VcsBranchName:   branch,
-				VcsRootInstance: &VcsRootInstanceRef{VcsRootID: vcsRootID},
-			}
-			revisions = append(revisions, rev)
-		}
-		if len(revisions) > 0 {
-			req.Revisions = &Revisions{Revision: revisions}
-		}
+		req.Revisions = &Revisions{Revision: revisions}
 	}
 
 	body, err := json.Marshal(req)
@@ -387,6 +364,113 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 	}
 
 	return &build, nil
+}
+
+// refBranch qualifies a branch name as a full Git ref for revision payloads.
+func refBranch(branch string) string {
+	if branch == "" || strings.HasPrefix(branch, "refs/") {
+		return branch
+	}
+	return "refs/heads/" + branch
+}
+
+// resolveRevisionSpecs expands revision specs into per-root payloads, validating root IDs and resolving branch-only specs to the branch head TeamCity knows.
+func (c *Client) resolveRevisionSpecs(buildTypeID string, specs []RevisionSpec, defaultBranch string) ([]Revision, error) {
+	entries, err := c.GetVcsRootEntries(buildTypeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get VCS root entries: %w", err)
+	}
+	roots := make([]string, 0, len(entries.VcsRootEntry))
+	for _, entry := range entries.VcsRootEntry {
+		if entry.VcsRoot != nil && entry.VcsRoot.ID != "" {
+			roots = append(roots, entry.VcsRoot.ID)
+		}
+	}
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("build configuration %s has no VCS roots; cannot pin revision", buildTypeID)
+	}
+
+	var revisions []Revision
+	for _, spec := range specs {
+		switch {
+		case spec.VcsRootID == "":
+			for _, rootID := range roots {
+				revisions = append(revisions, Revision{
+					Version:         spec.Version,
+					VcsBranchName:   refBranch(defaultBranch),
+					VcsRootInstance: &VcsRootInstanceRef{VcsRootID: rootID},
+				})
+			}
+		case !slices.Contains(roots, spec.VcsRootID):
+			return nil, Validation(
+				fmt.Sprintf("VCS root %q is not attached to %s", spec.VcsRootID, buildTypeID),
+				"Available VCS roots: "+strings.Join(roots, ", "),
+			)
+		default:
+			version := spec.Version
+			if version == "" {
+				if version, err = c.latestBranchRevision(buildTypeID, spec.VcsRootID, spec.Branch); err != nil {
+					return nil, err
+				}
+			}
+			revisions = append(revisions, Revision{
+				Version:         version,
+				VcsBranchName:   refBranch(spec.Branch),
+				VcsRootInstance: &VcsRootInstanceRef{VcsRootID: spec.VcsRootID},
+			})
+		}
+	}
+	return revisions, nil
+}
+
+// latestBranchRevision resolves a branch to its current revision from the repository state fetched by the job's VCS root instance.
+func (c *Client) latestBranchRevision(buildTypeID, vcsRootID, branch string) (string, error) {
+	state, err := c.vcsRootRepositoryState(buildTypeID, vcsRootID)
+	if err != nil {
+		return "", err
+	}
+	ref := refBranch(branch)
+	for _, b := range state.Branch {
+		if (b.Name == ref || b.Name == branch) && b.Version != "" {
+			return b.Version, nil
+		}
+	}
+	return "", Validation(
+		fmt.Sprintf("branch %q not found in VCS root %s", branch, vcsRootID),
+		"TeamCity has not fetched this branch (check the branch specification), or pass an explicit SHA: ROOT=SHA@BRANCH",
+	)
+}
+
+// vcsRootRepositoryState returns the branch heads fetched by the instance of vcsRootID in the build configuration.
+func (c *Client) vcsRootRepositoryState(buildTypeID, vcsRootID string) (*RepositoryState, error) {
+	path := fmt.Sprintf("/app/rest/buildTypes/id:%s/vcs-root-instances?fields=vcs-root-instance(id,vcs-root-id)", url.PathEscape(buildTypeID))
+	var instances VcsRootInstanceList
+	if err := c.get(c.ctx(), path, &instances); err != nil {
+		return nil, err
+	}
+	instanceID := ""
+	for _, inst := range instances.VcsRootInstance {
+		if inst.VcsRootID == vcsRootID {
+			instanceID = inst.ID
+			break
+		}
+	}
+	if instanceID == "" {
+		return nil, fmt.Errorf("no VCS root instance for %s in %s", vcsRootID, buildTypeID)
+	}
+
+	path = fmt.Sprintf("/app/rest/vcs-root-instances/id:%s?fields=repositoryState(branch(name,version))", url.PathEscape(instanceID))
+	var inst VcsRootInstance
+	if err := c.get(c.ctx(), path, &inst); err != nil {
+		return nil, err
+	}
+	if inst.RepositoryState == nil || len(inst.RepositoryState.Branch) == 0 {
+		return nil, Validation(
+			"repository state unavailable for VCS root instance "+instanceID,
+			"Pass an explicit SHA instead: ROOT=SHA@BRANCH",
+		)
+	}
+	return inst.RepositoryState, nil
 }
 
 // CancelBuild cancels a running or queued build (accepts ID or #number)

--- a/api/builds_test.go
+++ b/api/builds_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -197,4 +198,130 @@ func TestRunBuildOmitsEmptySnapshotDependencies(T *testing.T) {
 	_, err := client.RunBuild("MyBuild", RunBuildOptions{})
 	require.NoError(T, err)
 	assert.NotContains(T, string(rawBody), "snapshot-dependencies")
+}
+
+// revisionTestClient serves vcs-root entries/instances for roots, branchHeads as each instance's fetched repository state, and captures the buildQueue POST.
+func revisionTestClient(T *testing.T, roots []string, branchHeads map[string]string, captured *TriggerBuildRequest) *Client {
+	T.Helper()
+	return setupTestServer(T, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/vcs-root-entries"):
+			entries := VcsRootEntries{Count: len(roots)}
+			for _, id := range roots {
+				entries.VcsRootEntry = append(entries.VcsRootEntry, VcsRootEntry{VcsRoot: &VcsRoot{ID: id}})
+			}
+			_ = json.NewEncoder(w).Encode(entries)
+		case strings.Contains(r.URL.Path, "/buildTypes/") && strings.Contains(r.URL.Path, "/vcs-root-instances"):
+			list := VcsRootInstanceList{}
+			for _, id := range roots {
+				list.VcsRootInstance = append(list.VcsRootInstance, VcsRootInstance{ID: "i-" + id, VcsRootID: id})
+			}
+			_ = json.NewEncoder(w).Encode(list)
+		case strings.Contains(r.URL.Path, "/vcs-root-instances/id:"):
+			state := &RepositoryState{}
+			for name, version := range branchHeads {
+				state.Branch = append(state.Branch, RepositoryBranch{Name: name, Version: version})
+			}
+			_ = json.NewEncoder(w).Encode(VcsRootInstance{RepositoryState: state})
+		default:
+			body, err := io.ReadAll(r.Body)
+			require.NoError(T, err)
+			require.NoError(T, json.Unmarshal(body, captured))
+			_ = json.NewEncoder(w).Encode(Build{ID: 1})
+		}
+	})
+}
+
+func TestRunBuildPinsSingleVcsRoot(T *testing.T) {
+	T.Parallel()
+
+	var captured TriggerBuildRequest
+	client := revisionTestClient(T, []string{"Repo1", "Repo2"}, nil, &captured)
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{
+		Revisions: []RevisionSpec{{VcsRootID: "Repo2", Version: "abc123", Branch: "feature/x"}},
+	})
+	require.NoError(T, err)
+
+	require.NotNil(T, captured.Revisions)
+	require.Len(T, captured.Revisions.Revision, 1)
+	rev := captured.Revisions.Revision[0]
+	assert.Equal(T, "abc123", rev.Version)
+	assert.Equal(T, "refs/heads/feature/x", rev.VcsBranchName)
+	require.NotNil(T, rev.VcsRootInstance)
+	assert.Equal(T, "Repo2", rev.VcsRootInstance.VcsRootID)
+}
+
+func TestRunBuildBareRevisionAppliesToAllRoots(T *testing.T) {
+	T.Parallel()
+
+	var captured TriggerBuildRequest
+	client := revisionTestClient(T, []string{"Repo1", "Repo2"}, nil, &captured)
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{
+		Branch:    "main",
+		Revisions: []RevisionSpec{{Version: "abc123"}},
+	})
+	require.NoError(T, err)
+
+	require.NotNil(T, captured.Revisions)
+	require.Len(T, captured.Revisions.Revision, 2)
+	for i, rootID := range []string{"Repo1", "Repo2"} {
+		rev := captured.Revisions.Revision[i]
+		assert.Equal(T, "abc123", rev.Version)
+		assert.Equal(T, "refs/heads/main", rev.VcsBranchName)
+		require.NotNil(T, rev.VcsRootInstance)
+		assert.Equal(T, rootID, rev.VcsRootInstance.VcsRootID)
+	}
+}
+
+func TestRunBuildRejectsUnknownVcsRoot(T *testing.T) {
+	T.Parallel()
+
+	var captured TriggerBuildRequest
+	client := revisionTestClient(T, []string{"Repo1", "Repo2"}, nil, &captured)
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{
+		Revisions: []RevisionSpec{{VcsRootID: "Nope", Version: "abc123"}},
+	})
+	require.Error(T, err)
+	assert.Contains(T, err.Error(), `"Nope"`)
+	var verr *ValidationError
+	require.ErrorAs(T, err, &verr)
+	assert.Contains(T, verr.Tip, "Repo1, Repo2")
+	assert.Empty(T, captured.BuildType.ID, "must not trigger on validation failure")
+}
+
+func TestRunBuildResolvesBranchHeadFromRepositoryState(T *testing.T) {
+	T.Parallel()
+
+	var captured TriggerBuildRequest
+	client := revisionTestClient(T, []string{"Repo1"},
+		map[string]string{"refs/heads/feature/x": "deadbeef1234"}, &captured)
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{
+		Revisions: []RevisionSpec{{VcsRootID: "Repo1", Branch: "feature/x"}},
+	})
+	require.NoError(T, err)
+
+	require.NotNil(T, captured.Revisions)
+	require.Len(T, captured.Revisions.Revision, 1)
+	assert.Equal(T, "deadbeef1234", captured.Revisions.Revision[0].Version)
+	assert.Equal(T, "refs/heads/feature/x", captured.Revisions.Revision[0].VcsBranchName)
+}
+
+func TestRunBuildBranchHeadNotFound(T *testing.T) {
+	T.Parallel()
+
+	var captured TriggerBuildRequest
+	client := revisionTestClient(T, []string{"Repo1"},
+		map[string]string{"refs/heads/main": "aaa111"}, &captured)
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{
+		Revisions: []RevisionSpec{{VcsRootID: "Repo1", Branch: "ghost"}},
+	})
+	require.Error(T, err)
+	assert.Contains(T, err.Error(), "not found in VCS root")
+	assert.Empty(T, captured.BuildType.ID, "must not trigger when resolution fails")
 }

--- a/api/builds_test.go
+++ b/api/builds_test.go
@@ -276,6 +276,29 @@ func TestRunBuildBareRevisionAppliesToAllRoots(T *testing.T) {
 	}
 }
 
+func TestRunBuildDeprecatedRevisionField(T *testing.T) {
+	T.Parallel()
+
+	var captured TriggerBuildRequest
+	client := revisionTestClient(T, []string{"Repo1", "Repo2"}, nil, &captured)
+
+	_, err := client.RunBuild("MyBuild", RunBuildOptions{
+		Branch:   "main",
+		Revision: "abc123", //nolint:staticcheck // the deprecated field must keep working
+	})
+	require.NoError(T, err)
+
+	require.NotNil(T, captured.Revisions)
+	require.Len(T, captured.Revisions.Revision, 2)
+	for i, rootID := range []string{"Repo1", "Repo2"} {
+		rev := captured.Revisions.Revision[i]
+		assert.Equal(T, "abc123", rev.Version)
+		assert.Equal(T, "refs/heads/main", rev.VcsBranchName)
+		require.NotNil(T, rev.VcsRootInstance)
+		assert.Equal(T, rootID, rev.VcsRootInstance.VcsRootID)
+	}
+}
+
 func TestRunBuildRejectsUnknownVcsRoot(T *testing.T) {
 	T.Parallel()
 

--- a/api/locator.go
+++ b/api/locator.go
@@ -38,6 +38,17 @@ func nameValueLocator(value string) string {
 	return "name:(value:($base64:" + base64.RawURLEncoding.EncodeToString([]byte(value)) + "))"
 }
 
+// AddBranchName adds a branch dimension by name, routing metacharacter names through the value condition because the server re-parses branch values as locators (verified live against TeamCity 2026.1).
+func (l *Locator) AddBranchName(name string) *Locator {
+	if name == "" {
+		return l
+	}
+	if strings.ContainsAny(name, ":,()$") {
+		return l.AddRaw("branch", "("+nameValueLocator(name)+")")
+	}
+	return l.Add("branch", name)
+}
+
 // AddRaw adds a key:value pair without escaping the value.
 // Use for values that are already valid locator syntax (e.g. sub-locators).
 func (l *Locator) AddRaw(key, value string) *Locator {

--- a/api/types.go
+++ b/api/types.go
@@ -239,6 +239,26 @@ type VcsRootEntry struct {
 	VcsRoot *VcsRoot `json:"vcs-root,omitempty"`
 }
 
+type VcsRootInstanceList struct {
+	VcsRootInstance []VcsRootInstance `json:"vcs-root-instance"`
+}
+
+// VcsRootInstance is a VCS root resolved for a build configuration, including the branch heads it fetched.
+type VcsRootInstance struct {
+	ID              string           `json:"id,omitempty"`
+	VcsRootID       string           `json:"vcs-root-id,omitempty"`
+	RepositoryState *RepositoryState `json:"repositoryState,omitempty"`
+}
+
+type RepositoryState struct {
+	Branch []RepositoryBranch `json:"branch"`
+}
+
+type RepositoryBranch struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
 // LastChanges represents the changes to include in a build
 type LastChanges struct {
 	Change []PersonalChange `json:"change"`

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -335,6 +335,26 @@ teamcity run start MyProject_Build --branch main --revision abc123def
 teamcity run start MyProject_Build --branch @this --revision @head
 ```
 
+For jobs with multiple VCS roots, pin roots individually with `--revision ROOT=SHA[@BRANCH]`
+(repeatable). Use `ROOT=@BRANCH` to build the latest revision TeamCity has fetched for
+that branch:
+
+```Shell
+# Pin one VCS root to a commit, leave the others as usual
+teamcity run start MyProject_Build --revision GameRepo=abc123def
+
+# Pin a root to a commit on a specific branch
+teamcity run start MyProject_Build --revision GameRepo=abc123def@feature/x
+
+# Build one root from another branch (resolved to its latest known revision)
+teamcity run start MyProject_Build --revision GameRepo=@feature/x
+
+# Pin several roots at once
+teamcity run start MyProject_Build \
+  --revision GameRepo=abc123def@feature/x \
+  --revision ToolsRepo=def456abc
+```
+
 ### Build parameters
 
 Pass custom parameters, system properties, and environment variables:

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -223,6 +223,48 @@ func TestRunStartReuseDepsSendsIDs(T *testing.T) {
 	assert.Equal(T, 6917, captured.SnapshotDependencies.Build[1].ID)
 }
 
+func TestRunStartPerRootRevisionsSendsPayload(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	ts.Handle("GET /app/rest/buildTypes/id:"+testJob+"/vcs-root-entries", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.VcsRootEntries{Count: 2, VcsRootEntry: []api.VcsRootEntry{
+			{VcsRoot: &api.VcsRoot{ID: "Repo1"}},
+			{VcsRoot: &api.VcsRoot{ID: "Repo2"}},
+		}})
+	})
+	var captured api.TriggerBuildRequest
+	ts.Handle("POST /app/rest/buildQueue", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(T, json.Unmarshal(body, &captured))
+		cmdtest.JSON(w, api.Build{ID: 999, BuildTypeID: testJob, WebURL: "https://example/build/999"})
+	})
+
+	cmdtest.RunCmdWithFactory(T, ts.Factory, "run", "start", testJob,
+		"--revision", "Repo1=abc123@feature/x")
+
+	require.NotNil(T, captured.Revisions)
+	require.Len(T, captured.Revisions.Revision, 1)
+	rev := captured.Revisions.Revision[0]
+	assert.Equal(T, "abc123", rev.Version)
+	assert.Equal(T, "refs/heads/feature/x", rev.VcsBranchName)
+	require.NotNil(T, rev.VcsRootInstance)
+	assert.Equal(T, "Repo1", rev.VcsRootInstance.VcsRootID)
+}
+
+func TestRunStartPerRootRevisionsDryRun(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	got := cmdtest.CaptureOutput(T, ts.Factory, "run", "start", testJob, "--dry-run",
+		"--revision", "Repo1=abc123@feature/x", "--revision", "Repo2=@main")
+	assert.Contains(T, got, "Repo1=abc123@feature/x")
+	assert.Contains(T, got, "Repo2=@main")
+}
+
+func TestRunStartRevisionMixedFormsRejected(T *testing.T) {
+	ts := cmdtest.SetupMockClient(T)
+	err := cmdtest.CaptureErr(T, ts.Factory, "run", "start", testJob, "--dry-run",
+		"--revision", "abc123def4567890abc123def4567890abc12345", "--revision", "Repo1=def456")
+	assert.Contains(T, err.Error(), "cannot mix")
+}
+
 func TestRunStartDryRunNonExistentJob(T *testing.T) {
 	ts := cmdtest.SetupMockClient(T)
 	err := cmdtest.CaptureErr(T, ts.Factory, "run", "start", "NonExistentJob123456", "--dry-run")

--- a/internal/cmd/run/revision.go
+++ b/internal/cmd/run/revision.go
@@ -1,0 +1,76 @@
+package run
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/JetBrains/teamcity-cli/api"
+)
+
+// parseRevisionFlags turns --revision values into revision specs: a bare "SHA" (or @head) applies to every VCS root, "ROOT=SHA[@BRANCH]" or "ROOT=@BRANCH" pins one root.
+func parseRevisionFlags(values []string) ([]api.RevisionSpec, error) {
+	specs := make([]api.RevisionSpec, 0, len(values))
+	seen := make(map[string]bool)
+	var bare, keyed bool
+	for _, raw := range values {
+		spec, err := parseRevisionFlag(raw)
+		if err != nil {
+			return nil, err
+		}
+		if spec.VcsRootID == "" {
+			if bare {
+				return nil, api.Validation(
+					"only one bare --revision value is allowed",
+					"Use ROOT=SHA[@BRANCH] to pin individual VCS roots",
+				)
+			}
+			bare = true
+		} else {
+			if seen[spec.VcsRootID] {
+				return nil, api.Validation(
+					fmt.Sprintf("duplicate --revision for VCS root %q", spec.VcsRootID),
+					"Pass each VCS root at most once",
+				)
+			}
+			seen[spec.VcsRootID] = true
+			keyed = true
+		}
+		specs = append(specs, spec)
+	}
+	if bare && keyed {
+		return nil, api.Validation(
+			"cannot mix a bare --revision with ROOT= forms",
+			"Pin roots individually with ROOT=SHA[@BRANCH], or use a single bare SHA for all roots",
+		)
+	}
+	return specs, nil
+}
+
+// parseRevisionFlag parses one --revision value; bare values resolve @head and short SHAs via the local git repository, keyed values pass verbatim.
+func parseRevisionFlag(raw string) (api.RevisionSpec, error) {
+	root, value, found := strings.Cut(raw, "=")
+	if !found {
+		version, err := resolveRevisionFlag(raw)
+		if err != nil {
+			return api.RevisionSpec{}, err
+		}
+		return api.RevisionSpec{Version: version}, nil
+	}
+	version, branch, hasBranch := strings.Cut(value, "@")
+	if root == "" || (version == "" && branch == "") || (hasBranch && branch == "") {
+		return api.RevisionSpec{}, api.Validation(
+			fmt.Sprintf("invalid --revision value %q", raw),
+			"Use ROOT=SHA, ROOT=SHA@BRANCH, or ROOT=@BRANCH",
+		)
+	}
+	return api.RevisionSpec{VcsRootID: root, Version: version, Branch: branch}, nil
+}
+
+// formatRevisionSpec renders a keyed spec back in ROOT=SHA[@BRANCH] flag form.
+func formatRevisionSpec(s api.RevisionSpec) string {
+	v := s.Version
+	if s.Branch != "" {
+		v += "@" + s.Branch
+	}
+	return s.VcsRootID + "=" + v
+}

--- a/internal/cmd/run/revision_test.go
+++ b/internal/cmd/run/revision_test.go
@@ -1,0 +1,77 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/JetBrains/teamcity-cli/api"
+)
+
+func stubNoGit(t *testing.T) {
+	t.Helper()
+	old := isGitRepoFn
+	isGitRepoFn = func() bool { return false }
+	t.Cleanup(func() { isGitRepoFn = old })
+}
+
+func TestParseRevisionFlags(t *testing.T) {
+	stubNoGit(t)
+
+	tests := []struct {
+		name string
+		in   []string
+		want []api.RevisionSpec
+	}{
+		{"empty", nil, []api.RevisionSpec{}},
+		{"bare sha", []string{"abc123def"}, []api.RevisionSpec{{Version: "abc123def"}}},
+		{
+			"keyed sha and branch",
+			[]string{"Repo1=abc123@feature/x", "Repo2=def456"},
+			[]api.RevisionSpec{
+				{VcsRootID: "Repo1", Version: "abc123", Branch: "feature/x"},
+				{VcsRootID: "Repo2", Version: "def456"},
+			},
+		},
+		{"branch only", []string{"Repo1=@feature/x"}, []api.RevisionSpec{{VcsRootID: "Repo1", Branch: "feature/x"}}},
+		{"branch with @ inside", []string{"Repo1=@release@2024"}, []api.RevisionSpec{{VcsRootID: "Repo1", Branch: "release@2024"}}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseRevisionFlags(tc.in)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParseRevisionFlagsErrors(t *testing.T) {
+	stubNoGit(t)
+
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"mixed bare and keyed", []string{"abc123", "Repo1=def456"}, "cannot mix"},
+		{"two bare", []string{"abc123", "def456"}, "only one bare"},
+		{"duplicate root", []string{"Repo1=abc", "Repo1=def"}, "duplicate"},
+		{"empty value", []string{"Repo1="}, "invalid --revision"},
+		{"empty root", []string{"=abc123"}, "invalid --revision"},
+		{"empty branch", []string{"Repo1=abc@"}, "invalid --revision"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseRevisionFlags(tc.in)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.want)
+		})
+	}
+}
+
+func TestFormatRevisionSpec(t *testing.T) {
+	assert.Equal(t, "Repo1=abc123@feature/x", formatRevisionSpec(api.RevisionSpec{VcsRootID: "Repo1", Version: "abc123", Branch: "feature/x"}))
+	assert.Equal(t, "Repo1=abc123", formatRevisionSpec(api.RevisionSpec{VcsRootID: "Repo1", Version: "abc123"}))
+	assert.Equal(t, "Repo1=@feature/x", formatRevisionSpec(api.RevisionSpec{VcsRootID: "Repo1", Branch: "feature/x"}))
+}

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -157,7 +157,7 @@ func settingsLabel(settings string) string {
 
 type runStartOptions struct {
 	branch            string
-	revision          string
+	revisions         []string
 	params            map[string]string
 	systemProps       map[string]string
 	envVars           map[string]string
@@ -203,6 +203,8 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run start Falcon_Build --local-changes changes.patch  # from file
   teamcity run start Falcon_Build --revision abc123def --branch main
   teamcity run start Falcon_Build --revision @head --branch @this
+  teamcity run start Falcon_Build --revision GameRepo=abc123@feature/x --revision Tools=def456
+  teamcity run start Falcon_Build --revision GameRepo=@feature/x  # pin one root to its branch head
   teamcity run start Falcon_Build --settings vcs    # load versioned settings from VCS
   teamcity run start Falcon_Build --dry-run`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -215,7 +217,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch to build (or '@this' for current git branch)")
-	cmd.Flags().StringVar(&opts.revision, "revision", "", "Pin to a specific Git commit SHA (or '@head' for current HEAD)")
+	cmd.Flags().StringArrayVar(&opts.revisions, "revision", nil, "Pin revision: SHA or '@head' for all VCS roots; ROOT=SHA[@BRANCH] or ROOT=@BRANCH for one root (repeatable)")
 	cmd.Flags().StringToStringVarP(&opts.params, "param", "P", nil, "Parameters (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.systemProps, "system", "S", nil, "System properties (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.envVars, "env", "E", nil, "Environment variables (key=value)")
@@ -257,11 +259,17 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		return err
 	}
 	opts.branch = branch
-	revision, err := resolveRevisionFlag(opts.revision)
+	revSpecs, err := parseRevisionFlags(opts.revisions)
 	if err != nil {
 		return err
 	}
-	opts.revision = revision
+	var bareRevision string
+	var rootRevisions []api.RevisionSpec
+	if len(revSpecs) > 0 && revSpecs[0].VcsRootID == "" {
+		bareRevision = revSpecs[0].Version
+	} else {
+		rootRevisions = revSpecs
+	}
 	freezeSettings, err := resolveSettingsFlag(opts.settings)
 	if err != nil {
 		return err
@@ -281,7 +289,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 			"is_personal":       opts.personal,
 			"has_local_changes": opts.localChanges != "",
 			"has_branch":        opts.branch != "",
-			"has_revision":      opts.revision != "",
+			"has_revision":      len(opts.revisions) > 0,
 			"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
 			"is_watched":        false,
 			"is_dry_run":        true,
@@ -289,29 +297,31 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 
 		if opts.json {
 			return p.PrintJSON(struct {
-				DryRun            bool              `json:"dry_run"`
-				Job               string            `json:"job"`
-				Branch            string            `json:"branch,omitempty"`
-				Revision          string            `json:"revision,omitempty"`
-				Personal          bool              `json:"personal"`
-				LocalChanges      string            `json:"local_changes,omitempty"`
-				Params            map[string]string `json:"params,omitempty"`
-				SystemProps       map[string]string `json:"system_properties,omitempty"`
-				EnvVars           map[string]string `json:"environment_variables,omitempty"`
-				Comment           string            `json:"comment,omitempty"`
-				Tags              []string          `json:"tags,omitempty"`
-				CleanSources      bool              `json:"clean_sources,omitempty"`
-				RebuildDeps       bool              `json:"rebuild_deps,omitempty"`
-				RebuildFailedDeps bool              `json:"rebuild_failed_deps,omitempty"`
-				QueueAtTop        bool              `json:"queue_at_top,omitempty"`
-				Agent             int               `json:"agent_id,omitempty"`
-				ReuseDeps         []int             `json:"reuse_deps,omitempty"`
-				Settings          string            `json:"settings,omitempty"`
+				DryRun            bool               `json:"dry_run"`
+				Job               string             `json:"job"`
+				Branch            string             `json:"branch,omitempty"`
+				Revision          string             `json:"revision,omitempty"`
+				Revisions         []api.RevisionSpec `json:"revisions,omitempty"`
+				Personal          bool               `json:"personal"`
+				LocalChanges      string             `json:"local_changes,omitempty"`
+				Params            map[string]string  `json:"params,omitempty"`
+				SystemProps       map[string]string  `json:"system_properties,omitempty"`
+				EnvVars           map[string]string  `json:"environment_variables,omitempty"`
+				Comment           string             `json:"comment,omitempty"`
+				Tags              []string           `json:"tags,omitempty"`
+				CleanSources      bool               `json:"clean_sources,omitempty"`
+				RebuildDeps       bool               `json:"rebuild_deps,omitempty"`
+				RebuildFailedDeps bool               `json:"rebuild_failed_deps,omitempty"`
+				QueueAtTop        bool               `json:"queue_at_top,omitempty"`
+				Agent             int                `json:"agent_id,omitempty"`
+				ReuseDeps         []int              `json:"reuse_deps,omitempty"`
+				Settings          string             `json:"settings,omitempty"`
 			}{
 				DryRun:            true,
 				Job:               jobID,
 				Branch:            opts.branch,
-				Revision:          opts.revision,
+				Revision:          bareRevision,
+				Revisions:         rootRevisions,
 				Personal:          opts.personal || opts.localChanges != "",
 				LocalChanges:      opts.localChanges,
 				Params:            opts.params,
@@ -333,8 +343,11 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		if opts.branch != "" {
 			_, _ = fmt.Fprintf(p.Out, "  Branch: %s\n", opts.branch)
 		}
-		if opts.revision != "" {
-			_, _ = fmt.Fprintf(p.Out, "  Revision: %s\n", opts.revision)
+		if bareRevision != "" {
+			_, _ = fmt.Fprintf(p.Out, "  Revision: %s\n", bareRevision)
+		}
+		for _, s := range rootRevisions {
+			_, _ = fmt.Fprintf(p.Out, "  Revision: %s\n", formatRevisionSpec(s))
 		}
 		if len(opts.params) > 0 {
 			_, _ = fmt.Fprintln(p.Out, "  Parameters:")
@@ -466,7 +479,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		AgentID:                   opts.agent,
 		Tags:                      opts.tags,
 		PersonalChangeID:          personalChangeID,
-		Revision:                  opts.revision,
+		Revisions:                 revSpecs,
 		SnapshotDependencies:      opts.reuseDeps,
 		FreezeSettings:            freezeSettings,
 	})
@@ -478,7 +491,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		"is_personal":       opts.personal,
 		"has_local_changes": opts.localChanges != "",
 		"has_branch":        opts.branch != "",
-		"has_revision":      opts.revision != "",
+		"has_revision":      len(opts.revisions) > 0,
 		"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
 		"is_watched":        opts.watch,
 		"is_dry_run":        false,
@@ -504,6 +517,9 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 
 	if opts.branch != "" {
 		p.Info("  Branch: %s", opts.branch)
+	}
+	for _, s := range rootRevisions {
+		p.Info("  Revision: %s", formatRevisionSpec(s))
 	}
 	if opts.comment != "" {
 		p.Info("  Comment: %s", opts.comment)

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -76,7 +76,8 @@ Shows all branches and all build states (including canceled, personal, composite
 ### Flags for `teamcity run start`
 
 - `-b, --branch <name>` - Branch to build
-- `--revision <sha>` - Pin build to a specific Git commit SHA
+- `--revision <sha>` - Pin build to a specific Git commit SHA (all VCS roots)
+- `--revision <root>=<sha>[@<branch>]` - Pin one VCS root (repeatable); `<root>=@<branch>` builds the branch head TeamCity has fetched
 - `-P, --param <k=v>` - Build parameter (repeatable)
 - `-S, --system <k=v>` - System property (repeatable)
 - `-E, --env <k=v>` - Environment variable (repeatable)


### PR DESCRIPTION
## Summary

Jobs with several VCS roots could not start a run with a different branch or revision in just one of them — `--revision` stamped the same SHA on every root. This PR makes `--revision` repeatable with a per-root form (`ROOT=SHA[@BRANCH]`, or `ROOT=@BRANCH` to build a branch's current head), keeping the bare `--revision SHA` behavior unchanged. Verified live against a production TeamCity server with a 4-root job.

Implements the feature requested in [TW-100857](https://youtrack.jetbrains.com/issue/TW-100857).

## Changes

- `run start --revision` is now repeatable: bare `SHA|@head` keeps today's all-roots behavior; `ROOT=SHA[@BRANCH]` pins one VCS root; `ROOT=@BRANCH` resolves the branch head TeamCity has fetched
- `api`: `RunBuildOptions.Revision string` → `Revisions []RevisionSpec`; root IDs validated against the job's `vcs-root-entries` (typo lists available roots); branch-only specs resolved via the VCS root instance `repositoryState`
- `api/locator.go`: new `AddBranchName` helper, reused by the builds locator (deduplicates the branch-metacharacter handling)
- dry-run and queued output show per-root pins; dry-run JSON gains an additive `revisions` field
- docs (`teamcity-cli-managing-runs.md`) and skill reference (`commands.md`) updated

## Design Decisions

- **Roots are keyed by VCS root ID**, not numeric `vcs-root-instance` id — human-readable, matches the `vcs-root-id` reference the payload already sends.
- **Branch-only resolution uses `repositoryState`** of the job's VCS root instance. The changes endpoint was tried first but only covers branches with changes attributed inside the job (branch-spec-monitored); `repositoryState` covers every fetched branch — verified live where the changes route came back empty and `repositoryState` had the ref. No fallback source: reading it needs the same settings-view permission as the `vcs-root-entries` read every `--revision` use already requires.
- **Bare and keyed forms cannot mix**, and duplicate roots are an error — kept strict until a real need appears.
- **Exported API change**: `RunBuildOptions.Revision` (string) is replaced by `Revisions []RevisionSpec`. Per CONTRIBUTING this needs maintainer sign-off — happy to keep a deprecated `Revision` alias instead if preferred.

## Example

```bash
teamcity run start MyProject_Build \
  -b tech/feature/unity-6-update \
  --revision GraphicResources_Features=@migrated/feature/vip-palace --dry-run

[dry-run] Would trigger run for MyProject_Build
  Branch: tech/feature/unity-6-update
  Revision: GraphicResources_Features=@migrated/feature/vip-palace
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`) — 89 passed, 25 skipped (token-gated)
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A for the happy path (needs a token, sandbox VCS roots, and a real trigger, like the excluded `run start --personal` family); can add error-path coverage (mixed forms) if wanted
- [x] If adding a data-producing command: includes `--json` support
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` (README lists commands, not flags — no change needed)
- [x] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — scope requested in YouTrack [TW-100857](https://youtrack.jetbrains.com/issue/TW-100857) (filed by the author, State: Submitted); happy to mirror it as a GitHub issue if the `status:finalized` label is required here

🤖 Generated with [Claude Code](https://claude.com/claude-code)
