### PR TITLE
fix(api): remove trailing slash from UploadSSHKey path

### DIFF
--- a/api/ssh_keys.go
+++ b/api/ssh_keys.go
@@ -19,7 +19,7 @@ func (c *Client) GetSSHKeys(projectID string) (*SSHKeyList, error) {
 
 // UploadSSHKey uploads a private SSH key to a project
 func (c *Client) UploadSSHKey(projectID, name string, privateKey []byte) error {
-	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys/?fileName=%s", url.PathEscape(projectID), url.QueryEscape(name))
+	path := fmt.Sprintf("/app/rest/projects/id:%s/sshKeys?fileName=%s", url.PathEscape(projectID), url.QueryEscape(name))
 	return c.doNoContent(c.ctx(), "POST", path, bytes.NewReader(privateKey), "text/plain")
 }
 

--- a/api/ssh_keys_test.go
+++ b/api/ssh_keys_test.go
@@ -48,3 +48,17 @@ func TestGenerateSSHKey(t *testing.T) {
 	assert.Equal(t, "my-key", key.Name)
 	assert.Equal(t, "ssh-ed25519 GENERATED", key.PublicKey)
 }
+
+func TestUploadSSHKey(t *testing.T) {
+	t.Parallel()
+	client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/app/rest/projects/id:MyProject/sshKeys?fileName=my-key", r.URL.String())
+		assert.Equal(t, "text/plain", r.Header.Get("Content-Type"))
+		w.WriteHeader(http.StatusOK)
+	})
+
+	err := client.UploadSSHKey("MyProject", "my-key", []byte("dummy-key-content"))
+	require.NoError(t, err)
+}
+

--- a/internal/cmdtest/mock_handlers.go
+++ b/internal/cmdtest/mock_handlers.go
@@ -775,7 +775,7 @@ func SetupMockClient(t *testing.T) *TestServer {
 		})
 	})
 
-	ts.Handle("POST /app/rest/projects/id:TestProject/sshKeys/", func(w http.ResponseWriter, r *http.Request) {
+	ts.Handle("POST /app/rest/projects/id:TestProject/sshKeys", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 


### PR DESCRIPTION
## Summary

Fixes SSH key upload failure caused by an erroneous trailing slash in the REST API request path (`/app/rest/projects/id:{projectID}/sshKeys/?fileName={name}` -> `/app/rest/projects/id:{projectID}/sshKeys?fileName={name}`).

Fixes #397

## Changes

- Remove trailing slash before `?fileName=` in `api/ssh_keys.go` `UploadSSHKey`.
- Update mock handler path in `internal/cmdtest/mock_handlers.go`.
- Add unit test `TestUploadSSHKey` in `api/ssh_keys_test.go`.

## Design Decisions

Straightforward.

## Example

```bash
teamcity project ssh upload ~/.ssh/id_ed25519 --project <PROJECT_ID> --name test-key
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A — SSH key upload requires write permissions / auth setup not available in guest acceptance runner
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — bug fix for existing command
- [ ] If adding a data-producing command: includes `--json` support — N/A — existing command
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A — no JSON output modified
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — bug fix, syntax/flags unchanged
- [x] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — Fixes #397
