### PR TITLE
feat(evals): report token, turn and tool-call cost per arm

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -84,6 +84,30 @@ Also reported: per-task `pass^2` (probability both reps pass — reliability,
 not just average), judge means per arm, and `gate_summary.json` for trend
 tooling.
 
+## Efficiency (advisory)
+
+Alongside the judge, the report prints mean **total tokens**, **turns**, and
+**tool calls** per arm, with `CURRENT` as a percentage of `CONTROL`:
+
+```
+  Efficiency (advisory, per run):
+    Total tokens             CONTROL=46,150  CURRENT=31,150  (-33% vs CONTROL)
+```
+
+Like the judge, this **never gates** — a skill that documents more can
+legitimately cost more, and cheap-but-wrong is not the goal.
+
+It exists because pass rate is blind to a whole class of change. A skill edit
+that only alters *how much context an agent must load* — splitting one large
+reference into per-task docs, say — cannot move a pass rate that is already at
+the ceiling, so the deterministic checks report "no change" while real work was
+done. Tokens and turns make that visible. Read it as a trend across runs, not
+as a target: per-run token counts vary with how many times the agent retried a
+live call.
+
+Runs from before this was added have no `events` block; those metrics are simply
+omitted rather than counted as zero.
+
 ## Tasks
 
 | Task                       | What It Tests                                       |

--- a/evals/scripts/compare.py
+++ b/evals/scripts/compare.py
@@ -93,6 +93,7 @@ def load_runs(exp_dir: Path) -> list[dict]:
             "all_passed": passed == len(checks),
             "failed_checks": [r["check"] for r in checks if not r.get("passed")],
             "llm_grades": data.get("llm_grades") or [],
+            "events": data.get("events") or {},
         })
     return runs
 
@@ -153,6 +154,32 @@ def pass_k(all_passed: list[bool], k: int = PASS_K) -> float | None:
     if n < k:
         return None
     return math.comb(c, k) / math.comb(n, k)
+
+
+# What an agent spent to reach its answer. Advisory, like the judge — a skill
+# that documents more can legitimately cost more, so this never gates. It exists
+# because pass rate alone cannot see a change that only alters how much context
+# the agent must load (e.g. splitting one large reference into per-task docs).
+EFFICIENCY_METRICS = (
+    ("total_tokens", "Total tokens", 0),
+    ("num_turns", "Turns", 1),
+    ("tool_calls_count", "Tool calls", 1),
+)
+
+
+def efficiency_summary(runs: list[dict]) -> dict[str, dict[str, float]]:
+    """metric → arm → mean, over runs that recorded it (advisory)."""
+    vals: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for r in runs:
+        for key, _, _ in EFFICIENCY_METRICS:
+            v = r["events"].get(key)
+            if isinstance(v, (int, float)):
+                vals[key][r["treatment"]].append(v)
+    return {
+        key: {arm: round(mean(v), nd) for arm, v in arms.items()}
+        for key, _, nd in EFFICIENCY_METRICS
+        if (arms := vals.get(key))
+    }
 
 
 def judge_summary(runs: list[dict]) -> dict[str, dict[str, float]]:
@@ -224,6 +251,22 @@ def analyze(exp_dir: Path) -> dict | None:
             arm_s = "  ".join(f"{a}={v}" for a, v in sorted(arms.items()))
             print(f"    {dim:<24s} {arm_s}")
         summary["judge"] = judges
+
+    efficiency = efficiency_summary(runs)
+    if efficiency:
+        print("\n  Efficiency (advisory, per run):")
+        labels = {key: label for key, label, _ in EFFICIENCY_METRICS}
+        for key, _, _ in EFFICIENCY_METRICS:
+            arms = efficiency.get(key)
+            if not arms:
+                continue
+            arm_s = "  ".join(f"{a}={v:,}" for a, v in sorted(arms.items()))
+            delta = ""
+            if {"CONTROL", "CURRENT"} <= arms.keys() and arms["CONTROL"]:
+                pct = arms["CURRENT"] / arms["CONTROL"] - 1
+                delta = f"  ({pct:+.0%} vs CONTROL)"
+            print(f"    {labels[key]:<24s} {arm_s}{delta}")
+        summary["efficiency"] = efficiency
 
     breaches = []
     floor = float(os.environ.get("GATE_LIFT_FLOOR", "-0.05"))

--- a/evals/tests/test_checks.py
+++ b/evals/tests/test_checks.py
@@ -185,6 +185,34 @@ def test_bootstrap_ci_widens_with_noise():
     assert low <= sum(lifts.values()) / len(lifts) <= high
 
 
+def test_efficiency_summary_averages_per_arm():
+    runs = [
+        {"treatment": "CONTROL", "events": {"total_tokens": 1000, "num_turns": 10,
+                                            "tool_calls_count": 20}},
+        {"treatment": "CONTROL", "events": {"total_tokens": 2000, "num_turns": 12,
+                                            "tool_calls_count": 22}},
+        {"treatment": "CURRENT", "events": {"total_tokens": 500, "num_turns": 6,
+                                            "tool_calls_count": 8}},
+    ]
+    eff = compare.efficiency_summary(runs)
+    assert eff["total_tokens"] == {"CONTROL": 1500, "CURRENT": 500}
+    assert eff["num_turns"] == {"CONTROL": 11.0, "CURRENT": 6.0}
+
+
+def test_efficiency_summary_tolerates_missing_and_malformed_events():
+    # Legacy artifacts have no "events"; a partial one must not invent zeros for
+    # metrics it never recorded, and non-numeric values must be ignored.
+    runs = [
+        {"treatment": "CONTROL", "events": {}},
+        {"treatment": "CURRENT", "events": {"num_turns": 4}},
+        {"treatment": "CURRENT", "events": {"num_turns": "n/a", "total_tokens": None}},
+    ]
+    eff = compare.efficiency_summary(runs)
+    assert "total_tokens" not in eff
+    assert eff["num_turns"] == {"CURRENT": 4.0}
+    assert compare.efficiency_summary([{"treatment": "CONTROL", "events": {}}]) == {}
+
+
 def test_load_runs_sanitizes_legacy_artifacts(tmp_path):
     legacy = {
         "task": "find-builds/CURRENT",


### PR DESCRIPTION
The deterministic pass rate is blind to a class of skill change: an edit that
only alters *how much context an agent must load* — splitting one large
reference into per-task docs, say — cannot move a pass rate already near the
ceiling. The report says "no change" while real work was done.

The data was already captured per run in `events{}` and thrown away by
`load_runs`. Now `compare.py` prints it:

```
  Efficiency (advisory, per run):
    Total tokens             CONTROL=46,150  CURRENT=31,150  (-33% vs CONTROL)
    Turns                    CONTROL=14.5  CURRENT=10.5  (-28% vs CONTROL)
    Tool calls               CONTROL=26  CURRENT=18  (-31% vs CONTROL)
```

Also recorded in `gate_summary.json` for trend tooling.

**Advisory only — it never feeds the gate**, exactly like the judge. A skill
that documents more can legitimately cost more, and cheap-but-wrong is not the
goal.

Notes for review:

- Artifacts predating this have no `events` block. Those metrics are **omitted
  rather than counted as zero**, so old result dirs still compare cleanly —
  counting zeros would show a fake 100% saving.
- Read it as a trend across runs, not a target: per-run token counts vary with
  how often the agent retried a live call.
- 20/20 harness unit tests pass (18 existing + 2 new, covering per-arm means and
  missing/malformed `events`).