### PR TITLE
feat(run): add --tag filter to run list

### DIFF
--- a/acceptance/testdata/run/run-list-filters.txtar
+++ b/acceptance/testdata/run/run-list-filters.txtar
@@ -15,6 +15,9 @@ exec teamcity run list --status success --branch main --limit 3 --no-input
 exec teamcity run list --since 2024-01-01 --until 2025-12-31 --limit 5 --no-input
 ! stderr 'Error'
 
+exec teamcity run list --tag nonexistent-tag-xyz --limit 3 --no-input
+! stderr 'Error'
+
 # --project (discover first)
 exec teamcity api '/app/rest/projects?locator=count:1&fields=project(id)' --raw --no-input
 extract '"id":"([^"]+)"' PROJECT_ID

--- a/api/builds.go
+++ b/api/builds.go
@@ -23,6 +23,7 @@ type BuildsOptions struct {
 	Project     string
 	Number      string
 	Revision    string
+	Tags        []string
 	Favorites   bool
 	Limit       int
 	SinceDate   string
@@ -67,6 +68,9 @@ func (opts BuildsOptions) Locator() *Locator {
 		Add("revision", opts.Revision).
 		Add("sinceDate", opts.SinceDate).
 		Add("untilDate", opts.UntilDate)
+	for _, tag := range opts.Tags {
+		locator.Add("tag", tag)
+	}
 	if opts.Favorites {
 		locator.AddLocator("tag", currentUserFavoriteBuildsTagLocator())
 	}

--- a/api/builds_test.go
+++ b/api/builds_test.go
@@ -72,6 +72,16 @@ func TestBuildsOptionsLocator(T *testing.T) {
 			},
 		},
 		{
+			name: "tag filter adds a tag dimension per tag",
+			opts: BuildsOptions{
+				Tags: []string{"release", "v1.0"},
+			},
+			want: []string{
+				"tag:release",
+				"tag:v1.0",
+			},
+		},
+		{
 			name: "deep lookup (exact number) skips the unscoped lookup-limit cap",
 			opts: BuildsOptions{Number: "123", DeepLookup: true},
 			want: []string{

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -62,6 +62,10 @@ teamcity run list --user @me
 
 # Combine filters
 teamcity run list --job MyProject_Build --status failure --branch main
+
+# Filter by tag (repeat --tag to require all of them)
+teamcity run list --tag release
+teamcity run list --tag release --tag v1.0
 ```
 
 > The `@me` shortcut substitutes the currently authenticated username.
@@ -222,6 +226,18 @@ Filter by the user who triggered the build. Use `@me` for the current user.
 <td>
 
 Filter by VCS revision (commit SHA). Use `@head` to resolve the current git HEAD.
+
+</td>
+</tr>
+<tr>
+<td>
+
+`-t`, `--tag`
+
+</td>
+<td>
+
+Filter by tag (can be repeated, matches runs with all given tags)
 
 </td>
 </tr>

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -666,6 +666,31 @@ func TestRunListFavoritesLocator(T *testing.T) {
 	assert.Contains(T, capturedQuery, "count%3A1")
 }
 
+func TestRunListTagFlagDoesNotSplitOnComma(T *testing.T) {
+	var capturedQuery string
+	ts := cmdtest.NewTestServer(T)
+	ts.Handle("GET /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.Server{VersionMajor: 2025, VersionMinor: 7, BuildNumber: "197398"})
+	})
+	ts.Handle("HEAD /app/rest/server", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	ts.Handle("GET /app/rest/builds", func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.RawQuery
+		cmdtest.JSON(w, api.BuildList{Count: 0, Builds: []api.Build{}})
+	})
+
+	rootCmd := cmd.NewCommand(ts.Factory)
+	rootCmd.SetArgs([]string{"run", "list", "--tag", "release,prod", "--limit", "1"})
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	err := rootCmd.Execute()
+	require.NoError(T, err)
+
+	assert.Contains(T, capturedQuery, api.BuildsOptions{Tags: []string{"release,prod"}}.Locator().Encode())
+}
+
 func TestRunList_plain(t *testing.T) {
 	ts := cmdtest.SetupMockClient(t)
 	got := cmdtest.CaptureOutput(t, ts.Factory, "run", "list", "--plain")

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -25,6 +25,7 @@ type runListOptions struct {
 	status     string
 	user       string
 	revision   string
+	tags       []string
 	favorites  bool
 	project    string
 	limit      int
@@ -52,6 +53,7 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
   teamcity run list --branch @this
   teamcity run list --revision abc1234
   teamcity run list --revision @head --job Falcon_Build
+  teamcity run list --tag release
   teamcity run list --since 24h
   teamcity run list --json
   teamcity run list --json=id,status,webUrl
@@ -67,6 +69,7 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.status, "status", "", "Filter by status (success, failure, running, queued, error, unknown)")
 	cmd.Flags().StringVarP(&opts.user, "user", "u", "", "Filter by user who triggered")
 	cmd.Flags().StringVar(&opts.revision, "revision", "", "Filter by VCS revision/commit SHA (or '@head' for current HEAD)")
+	cmd.Flags().StringSliceVarP(&opts.tags, "tag", "t", nil, "Filter by tag (can be repeated, matches runs with all given tags)")
 	cmd.Flags().BoolVar(&opts.favorites, "favorites", false, "Show favorites for the current user")
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number of items (0 for all)")
@@ -264,6 +267,7 @@ func resolveRunListRequest(client api.ClientInterface, opts *runListOptions, fie
 			User:        user,
 			Project:     opts.project,
 			Revision:    revision,
+			Tags:        opts.tags,
 			Favorites:   opts.favorites,
 			Limit:       opts.limit,
 			SinceDate:   sinceDate,

--- a/internal/cmd/run/list.go
+++ b/internal/cmd/run/list.go
@@ -69,7 +69,7 @@ func newRunListCmd(f *cmdutil.Factory) *cobra.Command {
 	cmd.Flags().StringVar(&opts.status, "status", "", "Filter by status (success, failure, running, queued, error, unknown)")
 	cmd.Flags().StringVarP(&opts.user, "user", "u", "", "Filter by user who triggered")
 	cmd.Flags().StringVar(&opts.revision, "revision", "", "Filter by VCS revision/commit SHA (or '@head' for current HEAD)")
-	cmd.Flags().StringSliceVarP(&opts.tags, "tag", "t", nil, "Filter by tag (can be repeated, matches runs with all given tags)")
+	cmd.Flags().StringArrayVarP(&opts.tags, "tag", "t", nil, "Filter by tag (can be repeated, matches runs with all given tags)")
 	cmd.Flags().BoolVar(&opts.favorites, "favorites", false, "Show favorites for the current user")
 	cmd.Flags().StringVarP(&opts.project, "project", "p", "", "Filter by project ID")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "n", 30, "Maximum number of items (0 for all)")

--- a/internal/cmd/run/list_test.go
+++ b/internal/cmd/run/list_test.go
@@ -21,6 +21,16 @@ func TestResolveRunListRequestFavorites(T *testing.T) {
 	assert.Equal(T, 30, req.builds.Limit)
 }
 
+func TestResolveRunListRequestTags(T *testing.T) {
+	req, err := resolveRunListRequest(nil, &runListOptions{
+		tags:  []string{"release", "v1.0"},
+		limit: 30,
+	}, nil)
+	require.NoError(T, err)
+
+	assert.Equal(T, []string{"release", "v1.0"}, req.builds.Tags)
+}
+
 func TestResolveRunListRequestAtMeUsesConfigUser(T *testing.T) {
 	oldConfigUser := runListConfigCurrentUserFn
 	T.Cleanup(func() {

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -64,6 +64,7 @@ Shows all branches and all build states (including canceled, personal, composite
 - `-b, --branch <name>` - Filter by branch (`@this` = current git branch)
 - `--status <status>` - Filter: success, failure, running, queued, error, unknown
 - `-u, --user <name>` - Filter by user
+- `-t, --tag <tag>` - Filter by tag (repeatable, matches runs with all given tags)
 - `--favorites` - Show favorite builds for the current user
 - `-p, --project <id>` - Filter by project
 - `-n, --limit <n>` - Limit results (default: 30)


### PR DESCRIPTION
## Summary

`run list` has no `--tag` flag even though `run tag --help` documents `teamcity run list --tag <tag>` for finding runs by tag. Fixes #386 by implementing the filter (TeamCity's build locator supports a `tag` dimension) rather than removing the doc reference.

## Changes

- Add `Tags []string` to `api.BuildsOptions`; each tag adds a `tag:` locator dimension (repeated dimensions AND together on the server, verified live).
- Add repeatable `-t, --tag` flag to `run list`.
- Update `managing-runs.md` and the `teamcity-cli` skill's flag reference.
- Add unit tests (locator, flag wiring) and an acceptance case.

## Design Decisions

Made `--tag` repeatable (AND semantics) rather than single-value, matching `run start --tag`'s existing repeatable convention and because TeamCity's locator supports ANDing multiple `tag:` dimensions natively — confirmed against a live server rather than assumed from docs.

## Example

```bash
teamcity run list --tag release
teamcity run list --tag release --tag v1.0
```

## Test Plan

- [x] Unit tests pass (`just unit`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A, not run in this environment; added `.txtar` case for CI
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [ ] If adding a data-producing command: N/A — not a new data-producing command
- [ ] If modifying `--json` output: N/A — no `--json` changes
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A for README (no flag table there)
- [ ] External contributors: N/A — maintainer PR