### PR TITLE
fix(agent): enforce read-only mode for terminal access

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ teamcity agent term Agent-Linux-01
 
 One naming note: TeamCity says *build* and *build configuration*; the CLI says `run` and `job`. The [glossary](https://www.jetbrains.com/help/teamcity/teamcity-cli-glossary.html) has the full mapping.
 
+Set `TEAMCITY_RO=1` to block writes and remote shells (`agent exec` and `agent term`). Use server-side permissions for a security boundary.
+
 Every command takes `--json` or `--plain` for [scripting](https://www.jetbrains.com/help/teamcity/teamcity-cli-scripting.html), and `--web` opens the matching page in the TeamCity UI. When no command covers what you need, `teamcity api` calls the REST API directly with your stored credentials. You can also log in to several servers and switch between them — see [configuration](https://www.jetbrains.com/help/teamcity/teamcity-cli-configuration.html).
 
 ## Commands

--- a/acceptance/testdata/agent/agent-read-only.txtar
+++ b/acceptance/testdata/agent/agent-read-only.txtar
@@ -1,0 +1,12 @@
+# Terminal commands must fail locally, even without a reachable server or credentials.
+env TEAMCITY_URL=http://127.0.0.1:1
+env TEAMCITY_TOKEN=
+env TEAMCITY_RO=1
+
+! exec teamcity agent exec 1 whoami --no-input
+stderr 'read-only mode: writes are blocked'
+! stderr 'connection refused'
+
+! exec teamcity agent term 1 --no-input
+stderr 'read-only mode: writes are blocked'
+! stderr 'connection refused'

--- a/docs/topics/teamcity-cli-scripting.md
+++ b/docs/topics/teamcity-cli-scripting.md
@@ -272,6 +272,8 @@ teamcity run start MyBuild     # blocked — would trigger a build
 
 This is useful for monitoring dashboards, reporting scripts, and shared environments where accidental modifications must be prevented. The flag also blocks write operations through `teamcity api` with non-GET methods.
 
+`agent exec` and `agent term` are also blocked before connecting, because a remote shell can modify the agent. This applies to both `TEAMCITY_RO=1` and per-server `ro: true`. Read-only mode is an accidental-write guard, not a security sandbox; use server-side permissions to restrict credentials.
+
 See [Configuration](teamcity-cli-configuration.md#Environment+variables) for accepted values.
 
 ### Quiet mode

--- a/internal/cmd/agent/terminal.go
+++ b/internal/cmd/agent/terminal.go
@@ -106,6 +106,10 @@ agent-side commands from teamcity flags.`,
 }
 
 func connectToAgent(f *cmdutil.Factory, ctx context.Context, nameOrID string, showProgress bool) (*terminal.Conn, error) {
+	if config.IsReadOnly() {
+		return nil, fmt.Errorf("%w: agent terminal access", api.ErrReadOnly)
+	}
+
 	serverURL := config.GetServerURL()
 	token, _, keyringErr := config.GetTokenWithSource()
 	if serverURL == "" || token == "" {

--- a/internal/cmd/agent/terminal_test.go
+++ b/internal/cmd/agent/terminal_test.go
@@ -1,0 +1,34 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/JetBrains/teamcity-cli/internal/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentTerminalReadOnly(t *testing.T) {
+	for _, source := range []string{"env", "server"} {
+		t.Run(source, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			ts := cmdtest.NewTestServer(t)
+			t.Setenv("TEAMCITY_RO", "")
+			if source == "env" {
+				t.Setenv("TEAMCITY_RO", "1")
+			} else {
+				config.Get().Servers[ts.URL] = config.ServerConfig{RO: true}
+				t.Cleanup(func() { delete(config.Get().Servers, ts.URL) })
+			}
+			ts.Factory.ClientFunc = func() (api.ClientInterface, error) {
+				t.Fatal("read-only terminal access must fail before creating a client")
+				return nil, nil
+			}
+			for _, args := range [][]string{{"agent", "exec", "1", "whoami"}, {"agent", "term", "1"}} {
+				err := cmdtest.CaptureErr(t, ts.Factory, args...)
+				require.ErrorIs(t, err, api.ErrReadOnly)
+			}
+		})
+	}
+}

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -22,6 +22,7 @@ teamcity run log <id> --failed --raw    # Full failure diagnostics
 - **Build chains fail bottom-up** — deepest failed dependency is the root cause. Use `teamcity run tree <id>`.
 - **`--local-changes` excludes Kotlin DSL** — push `.teamcity/` changes before running.
 - **`TEAMCITY_URL` alone bypasses stored auth** — set both `TEAMCITY_URL` and `TEAMCITY_TOKEN`, or leave unset.
+- **Read-only mode blocks remote shells** — `TEAMCITY_RO=1` or per-server `ro: true` rejects `agent exec` and `agent term` before connecting.
 - **Logs**: use `--raw` and dump to a temp file. **Builds**: use `--watch` when starting them.
 - **VCS triggers aren't always wired up** — after pushing a fix you may need to start builds manually.
 - **`pipeline push` does not validate** — always `teamcity pipeline validate` first.

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -371,6 +371,8 @@ The `<id>` (job) positional is optional when the repo is linked; `delete` accept
 | `teamcity agent term <id>`        | Open interactive shell on agent   |
 | `teamcity agent reboot <id>`      | Reboot a build agent              |
 
+`agent exec` and `agent term` are blocked by `TEAMCITY_RO=1` or per-server `ro: true`.
+
 ### Flags for `teamcity agent list`
 
 - `-p, --pool <name>` - Filter by agent pool

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -607,6 +607,8 @@ teamcity agent reboot <agent-id> --graceful
 
 ## Remote Agent Access
 
+`TEAMCITY_RO=1` or per-server `ro: true` blocks both commands below before connecting. Use server-side permissions, rather than this local guard alone, to restrict credential access.
+
 **Open interactive shell on an agent:**
 ```bash
 teamcity agent term <agent-id>


### PR DESCRIPTION
## Summary

Block agent terminal access in read-only mode. The separate terminal client previously bypassed the REST client's write guard.

## Changes

- Reject `agent exec` and `agent term` before credential lookup or network access.
- Test environment and per-server settings, add an offline acceptance test, and document the boundary.

## Design Decisions

Guard the shared connection entry point so both commands return the existing read-only error. This remains an accidental-write guard, not a replacement for server-side permissions.

## Example

```text
$ TEAMCITY_RO=1 teamcity agent exec 1 whoami
Error: read-only mode: writes are blocked: agent terminal access
```

## Test Plan

- [x] Unit tests pass (`just unit`); full `go test ./...` and focused `go test ./internal/cmd/agent -count=1` pass.
- [x] Linter passes (`just lint`).
- [ ] Acceptance tests pass (`just acceptance`) — full suite not run; isolated `agent-read-only` script passes with `-run '^TestAcceptance$/^agent$'`.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag; regression script added.
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A — unchanged.
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`.
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A — repository maintainer.

`just build` passes; the built binary rejects both commands with an unreachable server and no token. An initial acceptance invocation hit the harness's empty-directory error; the correctly scoped rerun passes.
