### PR TITLE
fix(http): protect credentials across redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ See the [getting started guide](https://www.jetbrains.com/help/teamcity/teamcity
 
 ## Usage
 
+For security, redirects never downgrade HTTPS or forward request headers to another origin. Cross-origin artifact downloads remain supported without credentials.
+
 Log in once and the CLI remembers the server:
 
 ```bash
@@ -109,8 +111,6 @@ teamcity agent term Agent-Linux-01
 ```
 
 One naming note: TeamCity says *build* and *build configuration*; the CLI says `run` and `job`. The [glossary](https://www.jetbrains.com/help/teamcity/teamcity-cli-glossary.html) has the full mapping.
-
-Redirects never downgrade HTTPS or forward request headers to another origin; cross-origin artifact downloads remain supported without credentials.
 
 Every command takes `--json` or `--plain` for [scripting](https://www.jetbrains.com/help/teamcity/teamcity-cli-scripting.html), and `--web` opens the matching page in the TeamCity UI. When no command covers what you need, `teamcity api` calls the REST API directly with your stored credentials. You can also log in to several servers and switch between them — see [configuration](https://www.jetbrains.com/help/teamcity/teamcity-cli-configuration.html).
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ teamcity agent term Agent-Linux-01
 
 One naming note: TeamCity says *build* and *build configuration*; the CLI says `run` and `job`. The [glossary](https://www.jetbrains.com/help/teamcity/teamcity-cli-glossary.html) has the full mapping.
 
+Redirects never downgrade HTTPS or forward request headers to another origin; cross-origin artifact downloads remain supported without credentials.
+
 Every command takes `--json` or `--plain` for [scripting](https://www.jetbrains.com/help/teamcity/teamcity-cli-scripting.html), and `--web` opens the matching page in the TeamCity UI. When no command covers what you need, `teamcity api` calls the REST API directly with your stored credentials. You can also log in to several servers and switch between them — see [configuration](https://www.jetbrains.com/help/teamcity/teamcity-cli-configuration.html).
 
 ## Commands

--- a/api/client.go
+++ b/api/client.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/JetBrains/teamcity-cli/internal/httpclient"
 )
 
 // Minimum supported TeamCity version
@@ -190,7 +192,8 @@ func newClientBase(baseURL string) *Client {
 		BaseURL: strings.TrimSuffix(baseURL, "/"),
 		HTTPClient: &http.Client{
 			// No request timeout (gh-style): ctx cancellation bounds requests; opt in via WithTimeout.
-			Transport: defaultTransport(),
+			Transport:     defaultTransport(),
+			CheckRedirect: httpclient.RedirectPolicy(true),
 		},
 		serverInfo:   &serverInfoCache{},
 		extraHeaders: EnvHeaders(),

--- a/api/redirect_test.go
+++ b/api/redirect_test.go
@@ -1,0 +1,86 @@
+package api
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedirectCredentials(t *testing.T) {
+	t.Parallel()
+	for _, auth := range []string{"bearer", "basic"} {
+		t.Run(auth, func(t *testing.T) {
+			t.Parallel()
+			destination := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				for _, header := range []string{"Authorization", "Cookie", "X-Api-Key", "X-Raw-Secret", "Referer"} {
+					assert.Empty(t, request.Header.Get(header), header)
+				}
+				if request.URL.Path != "/final" {
+					http.Redirect(writer, request, "/final", http.StatusFound)
+					return
+				}
+				_, _ = io.WriteString(writer, "artifact")
+			}))
+			defer destination.Close()
+			origin := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				assert.NotEmpty(t, request.Header.Get("Authorization"))
+				assert.Equal(t, "proxy-secret", request.Header.Get("X-Api-Key"))
+				if !strings.HasPrefix(request.URL.Path, "/redirected/") {
+					http.Redirect(writer, request, "/redirected/"+strings.TrimPrefix(request.URL.Path, "/"), http.StatusFound)
+					return
+				}
+				http.Redirect(writer, request, destination.URL, http.StatusFound)
+			}))
+			defer origin.Close()
+			opts := WithExtraHeaders(map[string]string{"X-Api-Key": "proxy-secret", "Cookie": "session=secret"})
+			client := NewClient(origin.URL, "fake-token", opts)
+			if auth == "basic" {
+				client = NewClientWithBasicAuth(origin.URL, "fake-user", "fake-password", opts)
+			}
+			response, err := client.RawRequest(t.Context(), http.MethodGet, "/app/rest/server", nil, map[string]string{"X-Raw-Secret": "raw-secret"})
+			require.NoError(t, err)
+			assert.Equal(t, "artifact", string(response.Body))
+			var output bytes.Buffer
+			_, err = client.DownloadArtifactTo(t.Context(), "1", "artifact", &output)
+			require.NoError(t, err)
+			assert.Equal(t, "artifact", output.String())
+		})
+	}
+}
+
+func TestRedirectRejectsHTTPSDowngrade(t *testing.T) {
+	t.Parallel()
+	destination := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		t.Error("downgrade destination must not receive a request")
+	}))
+	defer destination.Close()
+	origin := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, destination.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+	client := NewClient(origin.URL, "fake-token")
+	client.HTTPClient.Transport = origin.Client().Transport
+	_, err := client.RawRequest(t.Context(), http.MethodGet, "/app/rest/server", nil, nil)
+	require.ErrorContains(t, err, "refusing HTTPS downgrade redirect")
+}
+
+func TestRedirectRejectsCrossOriginBody(t *testing.T) {
+	t.Parallel()
+	destination := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		t.Error("cross-origin destination must not receive a credential-bearing body")
+	}))
+	defer destination.Close()
+	origin := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.Redirect(writer, request, destination.URL, http.StatusTemporaryRedirect)
+	}))
+	defer origin.Close()
+	client := NewClient(origin.URL, "fake-token")
+	_, err := client.RawRequest(t.Context(), http.MethodPost, "/app/rest/server", strings.NewReader("secret"), nil)
+	require.ErrorContains(t, err, "refusing cross-origin redirect")
+}

--- a/docs/topics/teamcity-cli-configuration.md
+++ b/docs/topics/teamcity-cli-configuration.md
@@ -417,6 +417,8 @@ Setting `TERM=dumb` also disables colored output. Color is automatically disable
 
 ### Extra HTTP headers (corporate proxies)
 
+HTTPS redirects never downgrade to HTTP. Cross-origin API and artifact redirects are followed only for body-free GET/HEAD requests, without the original request headers (including tokens, cookies, and proxy credentials). Agent terminal redirects must stay on the same origin.
+
 If your TeamCity server sits behind an authenticating proxy such as **Cloudflare Access** or **Google IAP**, the proxy needs its own credentials on every request. `TEAMCITY_HEADER_*` lets you supply them via env vars without editing the config file. The CLI applies them to every API call, the auth login probe, the PKCE exchange, and the agent terminal WebSocket — anywhere a request might pass through the proxy.
 
 Header names follow these rules:

--- a/internal/httpclient/redirect.go
+++ b/internal/httpclient/redirect.go
@@ -1,0 +1,29 @@
+// Package httpclient shares HTTP security policies between API and terminal clients.
+package httpclient
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// RedirectPolicy rejects downgrades and optionally allows credential-free cross-origin downloads.
+func RedirectPolicy(allowCrossOrigin bool) func(*http.Request, []*http.Request) error {
+	return func(request *http.Request, via []*http.Request) error {
+		if len(via) >= 10 {
+			return errors.New("stopped after 10 redirects")
+		}
+		if via[len(via)-1].URL.Scheme == "https" && request.URL.Scheme != "https" {
+			return errors.New("refusing HTTPS downgrade redirect")
+		}
+		original := via[0].URL
+		if request.URL.Scheme == original.Scheme && strings.EqualFold(request.URL.Host, original.Host) {
+			return nil
+		}
+		if !allowCrossOrigin || (request.Method != http.MethodGet && request.Method != http.MethodHead) || request.Body != nil {
+			return errors.New("refusing cross-origin redirect")
+		}
+		request.Header = make(http.Header)
+		return nil
+	}
+}

--- a/internal/httpclient/redirect_test.go
+++ b/internal/httpclient/redirect_test.go
@@ -1,0 +1,32 @@
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedirectPolicy(t *testing.T) {
+	t.Parallel()
+	original, err := http.NewRequest(http.MethodGet, "https://teamcity.example/api", nil)
+	require.NoError(t, err)
+	for _, target := range []string{"https://other.example/file", "https://sub.teamcity.example/file", "https://teamcity.example:8443/file"} {
+		t.Run(target, func(t *testing.T) {
+			t.Parallel()
+			request, err := http.NewRequest(http.MethodGet, target, nil)
+			require.NoError(t, err)
+			request.Header.Set("X-Custom-Secret", "secret")
+			require.NoError(t, RedirectPolicy(true)(request, []*http.Request{original}))
+			assert.Empty(t, request.Header)
+			require.ErrorContains(t, RedirectPolicy(false)(request, []*http.Request{original}), "cross-origin")
+		})
+	}
+	request, err := http.NewRequest(http.MethodGet, "https://TEAMCITY.example/file", nil)
+	require.NoError(t, err)
+	request.Header.Set("Authorization", "Bearer secret")
+	require.NoError(t, RedirectPolicy(true)(request, []*http.Request{original}))
+	assert.Equal(t, "Bearer secret", request.Header.Get("Authorization"))
+	require.ErrorContains(t, RedirectPolicy(true)(request, make([]*http.Request, 10)), "10 redirects")
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 
 	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/httpclient"
 	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/gorilla/websocket"
 	"golang.org/x/term"
@@ -61,8 +62,9 @@ func NewClient(baseURL, username, token string, debugf func(string, ...any)) *Cl
 		debugf:       debugf,
 		extraHeaders: api.EnvHeaders(),
 		httpClient: &http.Client{
-			Jar:     jar,
-			Timeout: 30 * time.Second,
+			Jar:           jar,
+			Timeout:       30 * time.Second,
+			CheckRedirect: httpclient.RedirectPolicy(false),
 		},
 	}
 }

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,10 +1,29 @@
 package terminal
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestOpenSessionRejectsCrossOriginRedirect(t *testing.T) {
+	t.Setenv("TEAMCITY_HEADER_X_API_KEY", "proxy-secret")
+	destination := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		t.Error("terminal credentials and cookies must not reach another origin")
+	}))
+	defer destination.Close()
+	origin := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		http.SetCookie(writer, &http.Cookie{Name: "session", Value: "secret"})
+		http.Redirect(writer, request, destination.URL, http.StatusFound)
+	}))
+	defer origin.Close()
+	client := NewClient(origin.URL, "user", "token", func(string, ...any) {})
+	_, err := client.OpenSession(1)
+	require.ErrorContains(t, err, "refusing cross-origin redirect")
+}
 
 func TestNewClient(t *testing.T) {
 	c := NewClient("https://tc.example.com/", "admin", "token123", func(string, ...any) {})

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -22,6 +22,7 @@ teamcity run log <id> --failed --raw    # Full failure diagnostics
 - **Build chains fail bottom-up** — deepest failed dependency is the root cause. Use `teamcity run tree <id>`.
 - **`--local-changes` excludes Kotlin DSL** — push `.teamcity/` changes before running.
 - **`TEAMCITY_URL` alone bypasses stored auth** — set both `TEAMCITY_URL` and `TEAMCITY_TOKEN`, or leave unset.
+- **Redirect credentials stay on-origin** — cross-origin downloads drop request headers; HTTPS downgrades and cross-origin terminal redirects are rejected.
 - **Logs**: use `--raw` and dump to a temp file. **Builds**: use `--watch` when starting them.
 - **VCS triggers aren't always wired up** — after pushing a fix you may need to start builds manually.
 - **`pipeline push` does not validate** — always `teamcity pipeline validate` first.

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -22,13 +22,14 @@ teamcity run log <id> --failed --raw    # Full failure diagnostics
 - **Build chains fail bottom-up** — deepest failed dependency is the root cause. Use `teamcity run tree <id>`.
 - **`--local-changes` excludes Kotlin DSL** — push `.teamcity/` changes before running.
 - **`TEAMCITY_URL` alone bypasses stored auth** — set both `TEAMCITY_URL` and `TEAMCITY_TOKEN`, or leave unset.
-- **Redirect credentials stay on-origin** — cross-origin downloads drop request headers; HTTPS downgrades and cross-origin terminal redirects are rejected.
 - **Logs**: use `--raw` and dump to a temp file. **Builds**: use `--watch` when starting them.
 - **VCS triggers aren't always wired up** — after pushing a fix you may need to start builds manually.
 - **`pipeline push` does not validate** — always `teamcity pipeline validate` first.
 - **GitHub VCS roots: use a GitHub App connection.** Never paste a PAT via `--auth password`. See [workflows](references/workflows.md).
 
 ## Core Commands
+
+Cross-origin downloads drop request headers; HTTPS downgrades and cross-origin terminal redirects are rejected.
 
 | Area      | Commands                                                                                          |
 |-----------|---------------------------------------------------------------------------------------------------|

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -33,6 +33,7 @@ Environment override note:
 - `TEAMCITY_URL` + `TEAMCITY_TOKEN` should be set together when overriding auth in scripts
 - `TEAMCITY_URL` alone bypasses stored `teamcity auth login` credentials
 - `TEAMCITY_HEADER_*` adds an HTTP header to every request: `TEAMCITY_HEADER_FOO_BAR=baz` sends `Foo-Bar: baz`. Use this for proxies that gate access (Cloudflare Access, Google IAP). Values are redacted in `--verbose` output.
+- Cross-origin redirects drop request headers and only permit body-free GET/HEAD requests. HTTPS downgrades and cross-origin terminal redirects are rejected.
 
 ## Builds/Runs (`teamcity run`)
 


### PR DESCRIPTION
## Summary

Prevent HTTP redirects from leaking TeamCity tokens, proxy credentials, or request bodies. Keep cross-origin artifact downloads working without credentials and constrain cookie-bearing terminal sessions to their original origin.

## Changes

- Share a redirect policy that blocks HTTPS downgrades, limits redirect chains, and removes all original headers on body-free cross-origin GET/HEAD requests.
- Reject cross-origin writes and terminal redirects.
- Add local HTTP/TLS regressions for bearer/basic auth, custom headers, streaming, repeated redirects, and terminal cookies; document the policy.

## Design Decisions

Clearing all cross-origin headers protects arbitrary proxy and per-request secrets, not just Authorization. Terminal sessions disallow origin changes because the cookie jar can reattach cookies after redirect validation. Existing same-origin behavior and signed artifact downloads remain available.

## Example

```text
teamcity run download 123 -o ./artifacts
```

Cross-origin downloads proceed without original credentials. An HTTPS-to-HTTP redirect fails with `refusing HTTPS downgrade redirect`.

## Test Plan

- [x] Unit tests pass (`just unit`); full `go test ./...` and focused `go test ./api ./internal/httpclient ./internal/terminal -count=1` pass.
- [x] Linter passes (`just lint`).
- [ ] Acceptance tests pass (`just acceptance`) — N/A — full live suite not run; local HTTP/TLS integration tests exercise redirect behavior.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag.
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A — unchanged.
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`.
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A — repository maintainer.

`just build` passes. A local two-server probe exercises the built binary with fake bearer/proxy/raw-header credentials and verifies none reach the redirect target.
