### PR TITLE
fix(run): confine artifact downloads to output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ teamcity agent term Agent-Linux-01
 
 One naming note: TeamCity says *build* and *build configuration*; the CLI says `run` and `job`. The [glossary](https://www.jetbrains.com/help/teamcity/teamcity-cli-glossary.html) has the full mapping.
 
+Artifact downloads stay within `--output` and preserve existing files if a transfer fails or is incomplete.
+
 Every command takes `--json` or `--plain` for [scripting](https://www.jetbrains.com/help/teamcity/teamcity-cli-scripting.html), and `--web` opens the matching page in the TeamCity UI. When no command covers what you need, `teamcity api` calls the REST API directly with your stored credentials. You can also log in to several servers and switch between them — see [configuration](https://www.jetbrains.com/help/teamcity/teamcity-cli-configuration.html).
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ teamcity agent term Agent-Linux-01
 
 One naming note: TeamCity says *build* and *build configuration*; the CLI says `run` and `job`. The [glossary](https://www.jetbrains.com/help/teamcity/teamcity-cli-glossary.html) has the full mapping.
 
-Artifact downloads stay within `--output` and preserve existing files if a transfer fails or is incomplete.
-
 Every command takes `--json` or `--plain` for [scripting](https://www.jetbrains.com/help/teamcity/teamcity-cli-scripting.html), and `--web` opens the matching page in the TeamCity UI. When no command covers what you need, `teamcity api` calls the REST API directly with your stored credentials. You can also log in to several servers and switch between them — see [configuration](https://www.jetbrains.com/help/teamcity/teamcity-cli-configuration.html).
 
 ## Commands
+
+Artifact downloads are confined to `--output`; failed or incomplete transfers preserve existing files.
 
 | Group        | Commands                                                                                                                                                                                                                                                                                                        |
 |--------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -1009,6 +1009,8 @@ teamcity run artifacts 12345 --json
 
 ### Downloading artifacts
 
+Downloads stay within the selected output directory, including when existing directories contain symlinks. Each file is staged before replacing its destination, so a failed or incomplete download preserves the previous file. A destination file symlink is replaced, not followed.
+
 Download artifacts from a completed run:
 
 ```Shell

--- a/internal/cmd/run/download.go
+++ b/internal/cmd/run/download.go
@@ -2,6 +2,7 @@ package run
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"os"
@@ -71,6 +72,11 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 	if err := os.MkdirAll(absOutput, 0755); err != nil {
 		return fmt.Errorf("failed to create directory: %w", err)
 	}
+	root, err := os.OpenRoot(absOutput)
+	if err != nil {
+		return fmt.Errorf("failed to open output directory: %w", err)
+	}
+	defer func() { _ = root.Close() }()
 
 	ctx, cancel := context.WithTimeout(f.Context(), opts.timeout)
 	defer cancel()
@@ -120,10 +126,9 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s path escapes output directory\n", nameWidth, artifact.Name, "", output.Red("   "+output.Sym().Cross))
 			continue
 		}
-		outputPath := filepath.Join(absOutput, rel)
 		size := humanize.IBytes(uint64(artifact.Size))
 
-		if err := downloadArtifact(ctx, client, runID, artifact, outputPath, nameWidth, p.Quiet, p.Out); err != nil {
+		if err := downloadArtifact(ctx, client, runID, artifact, root, rel, nameWidth, p.Quiet, p.Out); err != nil {
 			_, _ = fmt.Fprintf(p.Out, "%-*s  %10s  %s %v\n", nameWidth, artifact.Name, size, output.Red("   "+output.Sym().Cross), err)
 			continue
 		}
@@ -139,17 +144,19 @@ func runRunDownload(f *cmdutil.Factory, runID string, opts *runDownloadOptions) 
 	return nil
 }
 
-func downloadArtifact(ctx context.Context, client api.ClientInterface, runID string, artifact api.Artifact, outputPath string, nameWidth int, quiet bool, out io.Writer) error {
+func downloadArtifact(ctx context.Context, client api.ClientInterface, runID string, artifact api.Artifact, root *os.Root, outputPath string, nameWidth int, quiet bool, out io.Writer) error {
 	if dir := filepath.Dir(outputPath); dir != "." {
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := root.MkdirAll(dir, 0755); err != nil {
 			return err
 		}
 	}
 
-	f, err := os.Create(outputPath)
+	tempPath := filepath.Join(filepath.Dir(outputPath), ".teamcity-download-"+rand.Text())
+	f, err := root.OpenFile(tempPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}
+	defer func() { _ = root.Remove(tempPath) }()
 
 	var w io.Writer = f
 	if output.IsTerminal() && !quiet && artifact.Size > 0 {
@@ -161,15 +168,16 @@ func downloadArtifact(ctx context.Context, client api.ClientInterface, runID str
 	written, err := client.DownloadArtifactTo(ctx, runID, artifact.Name, w)
 	if err != nil {
 		_ = f.Close()
-		_ = os.Remove(outputPath)
 		return err
 	}
 
 	if artifact.Size > 0 && written != artifact.Size {
 		_ = f.Close()
-		_ = os.Remove(outputPath)
 		return fmt.Errorf("incomplete: got %d/%d bytes", written, artifact.Size)
 	}
 
-	return f.Close()
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return root.Rename(tempPath, outputPath)
 }

--- a/internal/cmd/run/download_test.go
+++ b/internal/cmd/run/download_test.go
@@ -1,0 +1,85 @@
+package run_test
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunDownloadConfinement(t *testing.T) {
+	for _, scenario := range []string{"nested", "directory symlink", "file symlink", "hard link", "traversal", "incomplete", "server error"} {
+		t.Run(scenario, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			ts := cmdtest.NewTestServer(t)
+			outputDir, outsideDir := t.TempDir(), t.TempDir()
+			outsidePath := filepath.Join(outsideDir, "target")
+			require.NoError(t, os.WriteFile(outsidePath, []byte("original"), 0600))
+			artifactName := "nested/target"
+			var expectedError string
+			switch scenario {
+			case "directory symlink":
+				if err := os.Symlink(outsideDir, filepath.Join(outputDir, "nested")); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+				expectedError = "downloaded 0 of 1 artifacts"
+			case "file symlink":
+				artifactName = "target"
+				if err := os.Symlink(outsidePath, filepath.Join(outputDir, artifactName)); err != nil {
+					t.Skipf("symlinks unavailable: %v", err)
+				}
+			case "hard link":
+				artifactName = "target"
+				require.NoError(t, os.Link(outsidePath, filepath.Join(outputDir, artifactName)))
+			case "traversal":
+				artifactName = "../target"
+				expectedError = "downloaded 0 of 1 artifacts"
+			case "incomplete", "server error":
+				artifactName = "target"
+				require.NoError(t, os.WriteFile(filepath.Join(outputDir, artifactName), []byte("original"), 0600))
+				expectedError = "downloaded 0 of 1 artifacts"
+			}
+			ts.Handle("GET /app/rest/builds/id:1/artifacts/children", func(writer http.ResponseWriter, request *http.Request) {
+				size := int64(len("replacement"))
+				if scenario == "incomplete" {
+					size++
+				}
+				cmdtest.JSON(writer, api.Artifacts{File: []api.Artifact{{Name: artifactName, Size: size, Content: &api.Content{}}}})
+			})
+			ts.Handle("GET /app/rest/builds/id:1/artifacts/content/", func(writer http.ResponseWriter, request *http.Request) {
+				if scenario == "server error" {
+					http.Error(writer, "not found", http.StatusNotFound)
+					return
+				}
+				cmdtest.Text(writer, "replacement")
+			})
+			args := []string{"run", "download", "1", "--output", outputDir}
+			if expectedError != "" {
+				cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, expectedError, args...)
+			} else {
+				cmdtest.RunCmdWithFactory(t, ts.Factory, args...)
+				contents, err := os.ReadFile(filepath.Join(outputDir, artifactName))
+				require.NoError(t, err)
+				assert.Equal(t, "replacement", string(contents))
+			}
+			contents, err := os.ReadFile(outsidePath)
+			require.NoError(t, err)
+			assert.Equal(t, "original", string(contents))
+			if scenario == "incomplete" || scenario == "server error" {
+				contents, err := os.ReadFile(filepath.Join(outputDir, artifactName))
+				require.NoError(t, err)
+				assert.Equal(t, "original", string(contents))
+			}
+			require.NoError(t, filepath.WalkDir(outputDir, func(path string, entry os.DirEntry, err error) error {
+				require.NoError(t, err)
+				assert.NotContains(t, entry.Name(), ".teamcity-download-")
+				return nil
+			}))
+		})
+	}
+}

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -22,6 +22,7 @@ teamcity run log <id> --failed --raw    # Full failure diagnostics
 - **Build chains fail bottom-up** — deepest failed dependency is the root cause. Use `teamcity run tree <id>`.
 - **`--local-changes` excludes Kotlin DSL** — push `.teamcity/` changes before running.
 - **`TEAMCITY_URL` alone bypasses stored auth** — set both `TEAMCITY_URL` and `TEAMCITY_TOKEN`, or leave unset.
+- **Artifact downloads stay within `--output`** — escaping directory symlinks are rejected; failed transfers preserve existing files.
 - **Logs**: use `--raw` and dump to a temp file. **Builds**: use `--watch` when starting them.
 - **VCS triggers aren't always wired up** — after pushing a fix you may need to start builds manually.
 - **`pipeline push` does not validate** — always `teamcity pipeline validate` first.

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -22,7 +22,6 @@ teamcity run log <id> --failed --raw    # Full failure diagnostics
 - **Build chains fail bottom-up** — deepest failed dependency is the root cause. Use `teamcity run tree <id>`.
 - **`--local-changes` excludes Kotlin DSL** — push `.teamcity/` changes before running.
 - **`TEAMCITY_URL` alone bypasses stored auth** — set both `TEAMCITY_URL` and `TEAMCITY_TOKEN`, or leave unset.
-- **Artifact downloads stay within `--output`** — escaping directory symlinks are rejected; failed transfers preserve existing files.
 - **Logs**: use `--raw` and dump to a temp file. **Builds**: use `--watch` when starting them.
 - **VCS triggers aren't always wired up** — after pushing a fix you may need to start builds manually.
 - **`pipeline push` does not validate** — always `teamcity pipeline validate` first.
@@ -48,6 +47,8 @@ teamcity run log <id> --failed --raw    # Full failure diagnostics
 | Link      | `teamcity link` — bind repo via `teamcity.toml`                                                   |
 
 ## Quick Workflows
+
+Artifact downloads stay within `--output`: escaping directory symlinks are rejected, and failed transfers preserve existing files.
 
 See [Workflows](references/workflows.md) for full details on each.
 

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -151,6 +151,8 @@ the name once as a header, one row per build, and a pass-rate footer.
 
 ### Flags for `teamcity run download`
 
+Downloads confine writes to `--output`, replace destination file symlinks rather than following them, and preserve existing files on failed transfers.
+
 - `-a, --artifact <pattern>` - Artifact name pattern to filter (matches full path and basename)
 - `-p, --path <subdir>` - Download artifacts under this subdirectory
 - `-o, --output <path>` - Local directory to save artifacts to


### PR DESCRIPTION
## Summary

Confine artifact downloads to the chosen output directory. Lexical path validation alone allowed existing symlinks to redirect writes outside it; failed downloads also destroyed existing destination files.

## Changes

- Use `os.Root` for directory creation, staging, cleanup, and final rename.
- Stage each artifact and only replace the destination after a successful complete transfer.
- Cover escaping directory symlinks, destination symlinks/hard links, traversal, nested files, and failed/incomplete downloads.

## Design Decisions

Root-relative operations enforce confinement during filesystem access rather than a race-prone preflight symlink check. Renaming staged files replaces a destination symlink/hard-link entry without modifying its external target.

## Example

```text
teamcity run download 123 --output ./artifacts
```

A directory symlink escaping `./artifacts` is rejected; incomplete transfers leave existing destination files intact.

## Test Plan

- [x] Unit tests pass (`just unit`); full `go test ./...` and focused `go test ./internal/cmd/run -count=1` pass.
- [x] Linter passes (`just lint`).
- [ ] Acceptance tests pass (`just acceptance`) — full live suite not run; local HTTP/filesystem command regressions pass.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag.
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A — unchanged.
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`.
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A — repository maintainer.

`just build` passes. A local built-binary probe confirms escaping symlinks are rejected without changing the outside file, while ordinary nested downloads succeed.
