### PR TITLE
fix(project): report actual versioned settings runtime status

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,5 @@ See [AI agent integration](https://www.jetbrains.com/help/teamcity/teamcity-cli-
 ## Contributing
 
 TeamCity CLI is open source under the Apache-2.0 license. Bug reports and pull requests are welcome — [CONTRIBUTING.md](CONTRIBUTING.md) covers how the project is built and tested.
+
+`project settings status` reports the server’s runtime message and missing DSL context parameters. Its “Recorded” timestamp is when the status was recorded, not the last successful sync.

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1408,3 +1408,11 @@ func TestRequestHeadersServerSide(T *testing.T) {
 	assert.Contains(T, logs, "user-agent")
 	assert.Contains(T, logs, "client: teamcity-cli/42.0.0-test")
 }
+
+func TestVersionedSettingsRuntimeStatus(t *testing.T) {
+	skipIfGuest(t)
+	t.Parallel()
+	status, err := client.GetVersionedSettingsStatus(testProject)
+	require.NoError(t, err)
+	assert.NotEmpty(t, status.Message)
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1413,6 +1413,9 @@ func TestVersionedSettingsRuntimeStatus(t *testing.T) {
 	skipIfGuest(t)
 	t.Parallel()
 	status, err := client.GetVersionedSettingsStatus(testProject)
-	require.NoError(t, err)
+	if err != nil {
+		require.ErrorContains(t, err, "never been enabled")
+		return
+	}
 	assert.NotEmpty(t, status.Message)
 }

--- a/api/types.go
+++ b/api/types.go
@@ -382,10 +382,20 @@ func ParseTeamCityTime(s string) (time.Time, error) {
 
 // VersionedSettingsStatus represents the sync status of versioned settings
 type VersionedSettingsStatus struct {
-	Type        string `json:"type,omitempty"`        // info, warning, error
-	Message     string `json:"message,omitempty"`     // Human-readable status message
-	Timestamp   string `json:"timestamp,omitempty"`   // When the status was recorded
-	DslOutdated bool   `json:"dslOutdated,omitempty"` // DSL scripts need regeneration
+	MissingContextParameters []string                 `json:"missingContextParameters,omitempty"`
+	VersionedSettingsError   []VersionedSettingsError `json:"versionedSettingsError,omitempty"`
+	Type                     string                   `json:"type,omitempty"`        // info, warning, error
+	Message                  string                   `json:"message,omitempty"`     // Human-readable status message
+	Timestamp                string                   `json:"timestamp,omitempty"`   // When the status was recorded
+	DslOutdated              bool                     `json:"dslOutdated,omitempty"` // DSL scripts need regeneration
+}
+
+// VersionedSettingsError describes a failure processing versioned settings.
+type VersionedSettingsError struct {
+	Message         string   `json:"message,omitempty"`
+	Type            string   `json:"type,omitempty"`
+	File            string   `json:"file,omitempty"`
+	StackTraceLines []string `json:"stackTraceLines,omitempty"`
 }
 
 // VersionedSettingsConfig represents the configuration of versioned settings

--- a/docs/topics/teamcity-cli-managing-projects.md
+++ b/docs/topics/teamcity-cli-managing-projects.md
@@ -637,7 +637,7 @@ teamcity project settings status MyProject
 teamcity project settings status MyProject --json
 ```
 
-This displays whether versioned settings are enabled, the current sync state, last successful sync timestamp, VCS root and format information, and any errors from the last sync attempt.
+This displays the server’s runtime status message, configuration, processing errors, and missing DSL context parameters. “Recorded” is the status timestamp, not a successful synchronization time. An informational status can mean synchronization is disabled or has never been enabled.
 
 ### Validating Kotlin DSL
 

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -58,7 +58,7 @@ func newProjectSettingsStatusCmd(f *cmdutil.Factory) *cobra.Command {
 Displays:
 - Whether versioned settings are enabled
 - Current sync state (up-to-date, pending changes, errors)
-- Last successful sync timestamp
+- Timestamp when the server recorded the status
 - VCS root and format information
 - Any warnings or errors from the last sync attempt`,
 		Example: `  teamcity project settings status MyProject
@@ -122,24 +122,20 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 		return nil
 	}
 
-	statusIcon := output.Green(output.Sym().Check)
-	statusLabel := "synchronized"
+	statusIcon := output.Faint("i")
+	statusLabel := "unknown"
 	if statusErr != nil {
 		statusIcon = output.Red(output.Sym().Cross)
 		statusLabel = "unavailable"
 	} else {
-		if syncingStatus := getSyncingStatus(status.Message); syncingStatus != "" {
-			statusIcon = output.Cyan(output.Sym().Recycle)
-			statusLabel = syncingStatus
-		} else {
-			switch status.Type {
-			case "warning":
-				statusIcon = output.Yellow("!")
-				statusLabel = "warning"
-			case "error":
-				statusIcon = output.Red(output.Sym().Cross)
-				statusLabel = "error"
-			}
+		if status.Message != "" {
+			statusLabel = status.Message
+		}
+		switch {
+		case status.Type == "error" || len(status.VersionedSettingsError) > 0:
+			statusIcon = output.Red(output.Sym().Cross)
+		case status.Type == "warn" || status.Type == "warning" || len(status.MissingContextParameters) > 0:
+			statusIcon = output.Yellow("!")
 		}
 	}
 
@@ -171,11 +167,18 @@ func runProjectSettingsStatus(f *cmdutil.Factory, projectID string, opts *projec
 	}
 
 	if status.Timestamp != "" {
-		_, _ = fmt.Fprintf(p.Out, "\n%-12s %s\n", output.Faint("Last sync"), formatRelativeTime(status.Timestamp))
+		_, _ = fmt.Fprintf(p.Out, "\n%-12s %s\n", output.Faint("Recorded"), formatRelativeTime(status.Timestamp))
 	}
 
-	if status.Message != "" && status.Type != "info" {
-		_, _ = fmt.Fprintf(p.Out, "%-12s %s\n", output.Faint("Message"), output.Faint(status.Message))
+	for _, detail := range status.VersionedSettingsError {
+		_, _ = fmt.Fprintf(p.Out, "Error        %s", detail.Message)
+		if detail.File != "" {
+			_, _ = fmt.Fprintf(p.Out, " (%s)", detail.File)
+		}
+		_, _ = fmt.Fprintln(p.Out)
+	}
+	if len(status.MissingContextParameters) > 0 {
+		_, _ = fmt.Fprintf(p.Out, "Missing context parameters: %s\n", strings.Join(status.MissingContextParameters, ", "))
 	}
 
 	_, _ = fmt.Fprintf(p.Out, "\n%-12s %s\n", output.Faint("View"), output.Faint(project.WebURL+"&tab=versionedSettings"))
@@ -285,34 +288,15 @@ func formatBuildMode(mode string) string {
 }
 
 func formatRelativeTime(ts string) string {
-	t, err := time.Parse("Mon Jan 2 15:04:05 MST 2006", ts)
+	t, err := api.ParseTeamCityTime(ts)
+	if err != nil {
+		t, err = time.Parse("Mon Jan 2 15:04:05 MST 2006", ts)
+	}
 	if err != nil {
 		return ts
 	}
 	local := t.Local()
 	return fmt.Sprintf("%s (%s)", output.RelativeTime(local), local.Format("Jan 2 15:04"))
-}
-
-func getSyncingStatus(message string) string {
-	lowerMsg := strings.ToLower(message)
-
-	if strings.Contains(lowerMsg, "running dsl") {
-		return "running DSL"
-	}
-	if strings.Contains(lowerMsg, "resolving maven dependencies") {
-		return "resolving dependencies"
-	}
-	if strings.Contains(lowerMsg, "loading project settings from vcs") {
-		return "loading from VCS"
-	}
-	if strings.Contains(lowerMsg, "generating settings") {
-		return "generating settings"
-	}
-	if strings.Contains(lowerMsg, "waiting for update") {
-		return "waiting for VCS"
-	}
-
-	return ""
 }
 
 type projectSettingsValidateOptions struct {

--- a/internal/cmd/project/settings_status_test.go
+++ b/internal/cmd/project/settings_status_test.go
@@ -1,0 +1,43 @@
+package project_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettingsStatusRuntimeMessage(t *testing.T) {
+	for _, message := range []string{"Synchronization is disabled", "Versioned Settings have never been enabled in this project", "Settings are up to date."} {
+		t.Run(message, func(t *testing.T) {
+			ts := cmdtest.SetupMockClient(t)
+			ts.Handle("GET /app/rest/projects/TestProject/versionedSettings/config", func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `{"synchronizationMode":"enabled","format":"kotlin"}`)
+			})
+			ts.Handle("GET /app/rest/projects/TestProject/versionedSettings/status", func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprintf(w, `{"type":"info","message":%q,"timestamp":"20260828T180800+0000"}`, message)
+			})
+			out := cmdtest.CaptureOutput(t, ts.Factory, "project", "settings", "status", "TestProject")
+			assert.Contains(t, out, message)
+			assert.NotContains(t, out, "synchronized")
+			assert.NotContains(t, out, "Last sync")
+			assert.Contains(t, out, "Recorded")
+		})
+	}
+}
+
+func TestSettingsStatusDetails(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/projects/TestProject/versionedSettings/config", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, `{}`) })
+	ts.Handle("GET /app/rest/projects/TestProject/versionedSettings/status", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"type":"warn","message":"Cannot load settings","missingContextParameters":["service"],"versionedSettingsError":[{"message":"DSL compilation error","type":"COMPILATION_ERROR","file":"settings.kts","stackTraceLines":["detail"]}]}`)
+	})
+	out := cmdtest.CaptureOutput(t, ts.Factory, "project", "settings", "status", "TestProject")
+	assert.Contains(t, out, "Missing context parameters: service")
+	assert.Contains(t, out, "DSL compilation error (settings.kts)")
+	out = cmdtest.CaptureOutput(t, ts.Factory, "project", "settings", "status", "TestProject", "--json")
+	assert.Contains(t, out, `"missingContextParameters"`)
+	assert.Contains(t, out, `"stackTraceLines"`)
+}

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -62,3 +62,5 @@ See [Workflows](references/workflows.md) for full details on each.
 - [Command reference](references/commands.md) — all commands and flags
 - [Workflows](references/workflows.md) — failure investigation, build chains, connections, pipelines
 - [Output formats](references/output.md) — JSON, plain text, scripting
+
+`project settings status` reports the server’s runtime message and missing DSL context parameters. Its “Recorded” timestamp is when the status was recorded, not the last successful sync.

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -559,3 +559,5 @@ Available on all list commands (`run list`, `agent list`, `job list`, `pool list
 
 - `--plain` - Tab-separated plain text output for scripting (mutually exclusive with `--json`)
 - `--no-header` - Omit header row (use with `--plain`)
+
+`project settings status` reports the server’s runtime message and missing DSL context parameters. Its “Recorded” timestamp is when the status was recorded, not the last successful sync.

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -951,3 +951,5 @@ teamcity pipeline delete <pipeline-id> --yes   # skip confirmation
 | `Not authenticated`          | `TEAMCITY_URL` set without matching token, or no auth configured | Unset `TEAMCITY_URL` to use stored auth from `teamcity auth login`, or set both `TEAMCITY_URL` and `TEAMCITY_TOKEN` |
 | `No server configured`       | Missing auth config       | Run `teamcity auth login -s <url>` or set `TEAMCITY_URL` and `TEAMCITY_TOKEN` env vars  |
 | `Network access blocked by sandbox` | Sandbox proxy blocking outbound requests | Add the server domain to the sandbox `allowedDomains`, or exclude `teamcity` from sandboxing |
+
+`project settings status` reports the server’s runtime message and missing DSL context parameters. Its “Recorded” timestamp is when the status was recorded, not the last successful sync.


### PR DESCRIPTION
## Summary

Report TeamCity's runtime versioned-settings message instead of treating every informational status as synchronized. Disabled and never-enabled projects now retain the server's explanation.

## Changes

- Display runtime messages, processing errors, and missing DSL context parameters.
- Label status timestamps as Recorded and parse REST timestamps.
- Preserve existing JSON fields and add structured diagnostic fields; update documentation.

## Design Decisions

The status endpoint already existed. Its severity is not a synchronization state, and its timestamp is when the status was recorded, not evidence of a successful sync.

## Example

```console
$ teamcity project settings status Probe
! Probe | Synchronization is disabled
```

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests pass (`just acceptance`) — N/A: no acceptance scripts changed; guest integration lacks VIEW_BUILD_CONFIGURATION_SETTINGS. Authenticated built CLI checked live Sandbox: server reports that versioned settings have never been enabled; also exercised disabled-state diagnostics against a local HTTP fixture.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A: no new command/flag
- [ ] If adding a data-producing command: includes `--json` support — N/A: existing command
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A: maintainer-requested fix
