### PR TITLE
feat(project): enable versioned settings by importing from VCS

### DIFF
--- a/acceptance/testdata/project/project-settings-enable.txtar
+++ b/acceptance/testdata/project/project-settings-enable.txtar
@@ -1,0 +1,8 @@
+# Settings enable validates input before accessing the server.
+exec teamcity project settings enable --help
+stdout 'Imports configuration'
+stdout '\-\-json'
+! exec teamcity project settings enable Project --vcs-root Root --format invalid --no-input
+stderr 'invalid settings format'
+! exec teamcity project settings enable Project --no-input
+stderr 'vcs-root'

--- a/api/projects.go
+++ b/api/projects.go
@@ -185,3 +185,29 @@ func (c *Client) ExportProjectSettings(projectID, format string, useRelativeIds 
 
 	return io.ReadAll(resp.Body)
 }
+
+// EnableVersionedSettings imports settings from VCS while preserving UI editing.
+func (c *Client) EnableVersionedSettings(projectID, vcsRootID, format, settingsPath string) (*VersionedSettingsConfig, error) {
+	body, err := json.Marshal(map[string]any{
+		"synchronizationMode": "enabled", "vcsRootId": vcsRootID, "format": format,
+		"settingsPath": settingsPath, "allowUIEditing": true, "importDecision": "importFromVCS",
+		"buildSettingsMode": "useFromVCS", "storeSecureValuesOutsideVcs": true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	path := fmt.Sprintf("/app/rest/projects/id:%s/versionedSettings/config", url.PathEscape(projectID))
+	resp, err := c.doRequest(c.ctx(), "PUT", path, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.handleErrorResponse(resp)
+	}
+	var result VersionedSettingsConfig
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/docs/topics/teamcity-cli-commands.md
+++ b/docs/topics/teamcity-cli-commands.md
@@ -707,6 +707,18 @@ Set a project parameter value
 <tr>
 <td>
 
+`teamcity project settings enable`
+
+</td>
+<td>
+
+Enable versioned settings by importing from VCS
+
+</td>
+</tr>
+<tr>
+<td>
+
 `teamcity project settings export`
 
 </td>

--- a/docs/topics/teamcity-cli-managing-projects.md
+++ b/docs/topics/teamcity-cli-managing-projects.md
@@ -631,6 +631,17 @@ Use relative IDs in the exported settings (enabled by default)
 </tr>
 </table>
 
+### Enabling versioned settings
+
+Import initial settings from an existing VCS root while keeping UI editing enabled:
+
+```Shell
+teamcity project settings enable MyProject --vcs-root MyProject_Settings
+teamcity project settings status MyProject
+```
+
+Use `--format xml` for XML settings, `--settings-path` for a custom repository directory, or `--json` for the configuration response. Existing configurations are refused rather than disabled automatically.
+
 ### Viewing versioned settings sync status
 
 Check the synchronization status of versioned settings for a project:

--- a/internal/analytics/enums.go
+++ b/internal/analytics/enums.go
@@ -26,7 +26,7 @@ func allCommands() []string {
 		"project.connection.list", "project.connection.view", "project.connection.authorize", "project.connection.delete",
 		"project.connection.create.docker", "project.connection.create.github-app",
 		"project.token.put", "project.token.get",
-		"project.settings.status", "project.settings.export", "project.settings.validate",
+		"project.settings.enable", "project.settings.status", "project.settings.export", "project.settings.validate",
 		"project.param.list", "project.param.get", "project.param.set", "project.param.delete",
 		"queue.list", "queue.remove", "queue.top", "queue.approve",
 		"agent.list", "agent.view", "agent.jobs", "agent.move", "agent.enable",

--- a/internal/cmd/project/settings.go
+++ b/internal/cmd/project/settings.go
@@ -36,6 +36,7 @@ See: https://www.jetbrains.com/help/teamcity/storing-project-settings-in-version
 	}
 
 	cmd.AddCommand(newProjectSettingsStatusCmd(f))
+	cmd.AddCommand(newProjectSettingsEnableCmd(f))
 	cmd.AddCommand(newProjectSettingsExportCmd(f))
 	cmd.AddCommand(newProjectSettingsValidateCmd(f))
 

--- a/internal/cmd/project/settings_enable.go
+++ b/internal/cmd/project/settings_enable.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/completion"
+	"github.com/spf13/cobra"
+)
+
+func newProjectSettingsEnableCmd(f *cmdutil.Factory) *cobra.Command {
+	var vcsRoot, format, settingsPath string
+	var asJSON bool
+	cmd := &cobra.Command{
+		Use: "enable <project-id>", Short: "Enable versioned settings by importing from VCS",
+		Long: `Enable versioned settings for a project that has no existing settings format.
+Imports configuration from the selected VCS root and keeps UI editing enabled.
+Does not overwrite the settings repository with the project's current configuration.
+Existing versioned settings are never disabled automatically; use the TeamCity UI
+for reconfiguration. Import completion and missing DSL context parameters can be
+checked with project settings status.`,
+		Example: "  teamcity project settings enable MyProject --vcs-root MyProject_Settings --format kotlin",
+		Args:    cobra.ExactArgs(1), ValidArgsFunction: completion.LinkedProjects(),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if format != "kotlin" && format != "xml" {
+				return api.Validation("invalid settings format", "Use --format kotlin or --format xml")
+			}
+			if vcsRoot == "" {
+				return api.RequiredFlag("vcs-root")
+			}
+			client, err := f.Client()
+			if err != nil {
+				return err
+			}
+			current, err := client.GetVersionedSettingsConfig(args[0])
+			if err != nil {
+				return fmt.Errorf("failed to get versioned settings configuration: %w", err)
+			}
+			if current.Format != "" || current.SynchronizationMode == "enabled" {
+				return api.Validation("project already has versioned settings configured", "Reconfigure versioned settings in the TeamCity UI; existing settings were not disabled")
+			}
+			enabler, ok := client.(interface {
+				EnableVersionedSettings(string, string, string, string) (*api.VersionedSettingsConfig, error)
+			})
+			if !ok {
+				return errors.New("client does not support enabling versioned settings")
+			}
+			result, err := enabler.EnableVersionedSettings(args[0], vcsRoot, format, settingsPath)
+			if err != nil {
+				return fmt.Errorf("failed to enable versioned settings: %w", err)
+			}
+			if asJSON {
+				return f.Printer.PrintJSON(result)
+			}
+			f.Printer.Success("Versioned settings import requested for %s", args[0])
+			f.Printer.Tip("Check progress with teamcity project settings status %s", args[0])
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&vcsRoot, "vcs-root", "", "VCS root containing the project settings (required)")
+	cmd.Flags().StringVar(&format, "format", "kotlin", "Settings format: kotlin or xml")
+	cmd.Flags().StringVar(&settingsPath, "settings-path", ".teamcity", "Settings directory in the repository")
+	cmd.Flags().BoolVar(&asJSON, "json", false, "Output as JSON")
+	return cmd
+}

--- a/internal/cmd/project/settings_enable_test.go
+++ b/internal/cmd/project/settings_enable_test.go
@@ -1,0 +1,35 @@
+package project_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSettingsEnable(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/projects/TestProject/versionedSettings/config", func(w http.ResponseWriter, r *http.Request) { fmt.Fprint(w, `{"synchronizationMode":"disabled"}`) })
+	ts.Handle("PUT /app/rest/projects/id:TestProject/versionedSettings/config", func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		assert.Equal(t, "importFromVCS", body["importDecision"])
+		assert.Equal(t, true, body["allowUIEditing"])
+		assert.Equal(t, true, body["storeSecureValuesOutsideVcs"])
+		assert.Equal(t, "Settings", body["vcsRootId"])
+		assert.Equal(t, "enabled", body["synchronizationMode"])
+		fmt.Fprint(w, `{"format":"kotlin","synchronizationMode":"enabled"}`)
+	})
+	out := cmdtest.CaptureOutput(t, ts.Factory, "project", "settings", "enable", "TestProject", "--vcs-root", "Settings", "--json")
+	assert.Contains(t, out, `"synchronizationMode": "enabled"`)
+	assert.NotContains(t, out, "import requested")
+}
+
+func TestSettingsEnablePreservesExistingConfiguration(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("PUT /app/rest/projects/id:TestProject/versionedSettings/config", func(w http.ResponseWriter, r *http.Request) { t.Error("must not modify existing settings") })
+	cmdtest.RunCmdWithFactoryExpectErr(t, ts.Factory, "already has versioned settings", "project", "settings", "enable", "TestProject", "--vcs-root", "Settings")
+}

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -39,7 +39,7 @@ Cross-origin downloads drop request headers; HTTPS downgrades and cross-origin t
 | Artifacts | `run artifacts`, `run download`                                                                   |
 | Metadata  | `run pin/unpin`, `run tag/untag`, `run comment`                                                   |
 | Jobs      | `job list`, `view`, `create`, `tree`, `pause/resume`, `step list/view/add/delete`, `param list/get/set/delete`, `settings list/get/set` |
-| Projects  | `project list`, `view`, `create`, `tree`, `param`, `token put/get`, `settings export/status`      |
+| Projects  | `project list`, `view`, `create`, `tree`, `param`, `token put/get`, `settings export/status/enable`      |
 | VCS/Conn  | `project vcs list/view/create/delete`, `project connection list/create/authorize/delete`          |
 | Queue     | `queue list`, `approve`, `remove`, `top`                                                          |
 | Agents    | `agent list`, `view`, `enable/disable`, `authorize/deauthorize`, `exec`, `term`, `reboot`, `move` |

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -269,6 +269,7 @@ The `<id>` (job) positional is optional when the repo is linked; `delete` accept
 | `teamcity project param delete <id> <name>`    | Delete parameter             |
 | `teamcity project token put <id>`              | Store secret, get token      |
 | `teamcity project token get <id> <token>`      | Retrieve secret              |
+| `teamcity project settings enable <id>`        | Import initial settings from VCS |
 | `teamcity project settings export <id>`        | Export settings as ZIP       |
 | `teamcity project settings status <id>`        | Show versioned settings sync |
 | `teamcity project settings validate [path]`    | Validate Kotlin DSL config   |
@@ -322,6 +323,13 @@ The `<id>` (job) positional is optional when the repo is linked; `delete` accept
 ### Flags for `teamcity project param set`
 
 - `--secure` - Mark as secure/password parameter
+
+### Flags for `teamcity project settings enable`
+
+- `--vcs-root <id>` - Settings VCS root (required)
+- `--format <kotlin|xml>` - Settings format (default: kotlin)
+- `--settings-path <path>` - Repository settings directory (default: .teamcity)
+- `--json` - Output the configuration as JSON
 
 ### Flags for `teamcity project settings export`
 

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -516,6 +516,12 @@ teamcity project vcs delete <vcs-root-id> --yes   # skip confirmation
 
 ## Project Settings (Export & Status)
 
+**Import initial settings from VCS (keeps UI editing enabled; refuses existing configurations):**
+```bash
+teamcity project settings enable <project-id> --vcs-root <root-id>
+teamcity project settings status <project-id>
+```
+
 **Check versioned settings sync status (requires server connection):**
 ```bash
 teamcity project settings status <project-id>


### PR DESCRIPTION
## Summary

Add `project settings enable` for initial versioned-settings setup from an existing VCS root. Import settings from VCS instead of overwriting the repository with generated project configuration.

## Changes

- Enable Kotlin or XML settings with VCS root, directory, and JSON options.
- Preserve UI editing and keep secure values outside VCS.
- Add request/regression tests, acceptance coverage, and command documentation.

## Design Decisions

Existing configurations are refused instead of automatically disabling them to bypass TeamCity's same-format update restriction. The command requests an import; completion and required DSL context parameters remain visible through `settings status` and the TeamCity UI/API. The public ClientInterface remains unchanged.

## Example

```console
$ teamcity project settings enable MyProject --vcs-root MyProject_Settings
✓ Versioned settings import requested for MyProject
```

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`go test -tags=acceptance ./acceptance/...`)
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [x] If adding a data-producing command: includes `--json` support
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A: new command
- [x] If changing docs-visible behavior: updated relevant `docs/` and `skills/`; `README.md` unchanged per requested scope
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A: maintainer-requested change

Built CLI verified against an HTTP fixture, including import direction and UI editing. Live verification created a temporary Sandbox child on cli.teamcity.com, but the configured token lacks “Enable / disable versioned settings”; the temporary project was deleted. A successful live import remains unverified.
