### PR TITLE
fix(connection): always print authorization URL

### DIFF
--- a/acceptance/testdata/project/project-connection.txtar
+++ b/acceptance/testdata/project/project-connection.txtar
@@ -29,6 +29,11 @@ stdout 'Created connection'
 extract '\(([A-Za-z0-9_-]+)\) in project' GHAPP_ID
 ! stderr 'Error'
 
+# Headless authorization prints a usable URL without launching a browser.
+exec teamcity project connection authorize $GHAPP_ID --project Sandbox --no-input
+stdout '/oauth/githubapp/repositories.html\?projectId=Sandbox&connectionId='
+! stdout 'Opening browser'
+
 exec teamcity project connection delete $GHAPP_ID --project Sandbox --force --no-input
 stdout 'Deleted connection'
 ! stderr 'Error'

--- a/docs/topics/teamcity-cli-managing-projects.md
+++ b/docs/topics/teamcity-cli-managing-projects.md
@@ -462,7 +462,7 @@ OAuth-style connections (GitHub App, Bitbucket, GitLab, …) need a per-user aut
 teamcity project connection authorize PROJECT_EXT_42 -p Backend
 ```
 
-The command opens a browser to complete the OAuth flow and stores the resulting token against the current user. Connection types without a user OAuth flow (Docker, AWS) return an error.
+The command prints the authorization URL and opens a browser to complete the OAuth flow, storing the resulting token against the current user. With `--no-input`, it prints the URL without opening a browser. Connection types without a user OAuth flow (Docker, AWS) return an error.
 
 ### Deleting a connection
 

--- a/internal/cmd/project/connection_authorize.go
+++ b/internal/cmd/project/connection_authorize.go
@@ -7,7 +7,6 @@ import (
 	"github.com/JetBrains/teamcity-cli/api"
 	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
 	"github.com/JetBrains/teamcity-cli/internal/completion"
-	"github.com/JetBrains/teamcity-cli/internal/output"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
 )
@@ -40,8 +39,10 @@ func newConnectionAuthorizeCmd(f *cmdutil.Factory) *cobra.Command {
 		Long: `Run the per-user OAuth flow against an existing OAuth-style connection.
 
 After this completes, the current user has a token stored in TeamCity for the connection.
-This is required before the VCS root test-connection endpoint can verify access using
-the connection (TeamCity calls upstream as the current user via the App's user OAuth).
+The repository preflight used by vcs create accesses the connection as the current user.
+
+The authorization URL is always printed so it can be opened from another machine.
+With --no-input, print the URL without opening a browser.
 
 Connection types that don't have a per-user OAuth flow (Docker, AWS) error out.`,
 		Example: `  teamcity project connection authorize PROJECT_EXT_42 -p Sandbox`,
@@ -89,10 +90,12 @@ func openConnectionAuthorize(f *cmdutil.Factory, client api.ClientInterface, pro
 	authorizeURL := fmt.Sprintf("%s/oauth/%s/repositories.html?projectId=%s&connectionId=%s&updateToken=true&showMode=popup",
 		client.ServerURL(), seg, url.QueryEscape(projectID), url.QueryEscape(id))
 
-	f.Printer.Info("Opening browser to authorize (connection %s)...", id)
-	if err := openBrowser(authorizeURL); err != nil {
-		f.Printer.Warn("Could not open browser automatically: %v", err)
-		_, _ = fmt.Fprintf(f.Printer.Out, "  Open this URL:\n  %s\n", output.Cyan(authorizeURL))
+	_, _ = fmt.Fprintln(f.Printer.Out, authorizeURL)
+	if !f.NoInput {
+		f.Printer.Info("Opening browser to authorize (connection %s)...", id)
+		if err := openBrowser(authorizeURL); err != nil {
+			f.Printer.Warn("Could not open browser automatically: %v", err)
+		}
 	}
 	f.Printer.Tip("Complete the flow in your browser. The tab closes on success; you can return here then.")
 	return nil

--- a/internal/cmd/project/connection_authorize_internal_test.go
+++ b/internal/cmd/project/connection_authorize_internal_test.go
@@ -1,0 +1,41 @@
+package project
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/JetBrains/teamcity-cli/internal/cmdutil"
+	"github.com/JetBrains/teamcity-cli/internal/output"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorizeURLFallback(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		noInput   bool
+		openError error
+	}{
+		{name: "success"}, {name: "browser failure", openError: errors.New("cannot launch")}, {name: "no input", noInput: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			previous := openBrowser
+			t.Cleanup(func() { openBrowser = previous })
+			calls := 0
+			openBrowser = func(rawURL string) error { calls++; return tt.openError }
+			var out, stderr bytes.Buffer
+			f := &cmdutil.Factory{NoInput: tt.noInput, Printer: &output.Printer{Out: &out, ErrOut: &stderr}}
+			err := openConnectionAuthorize(f, api.NewClient("https://tc.example/context", "unused"), "Project +", "PROJECT_EXT_42", "GitHubApp")
+			require.NoError(t, err)
+			assert.Contains(t, out.String(), "https://tc.example/context/oauth/githubapp/repositories.html?projectId=Project+%2B&connectionId=PROJECT_EXT_42")
+			if tt.noInput {
+				assert.Zero(t, calls)
+				assert.NotContains(t, out.String(), "Opening browser")
+			} else {
+				assert.Equal(t, 1, calls)
+			}
+		})
+	}
+}

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -408,7 +408,8 @@ The output prints `Next steps:` with follow-up commands and the install link. Ca
 
 ```bash
 teamcity project connection authorize PROJECT_EXT_NN -p <project-id>
-# browser opens TeamCity's OAuth page → click Authorize on GitHub → tab self-closes.
+# Prints the URL and opens the browser; add --no-input to print it without opening.
+# Complete authorization in the browser; the tab closes on success.
 ```
 
 **3. Install the App on a repo** (one-time, per repo, on github.com):


### PR DESCRIPTION
## Summary

`project connection authorize` could silently open no browser and leave the user without a URL. Always print the authorization URL, and honor `--no-input` by leaving browser launch to the user.

## Changes

- Print the URL before attempting browser launch, including successful launches.
- Skip browser launch under `--no-input`.
- Cover browser success, failure, and headless operation; document remote-shell usage.

## Design Decisions

The URL is primary output, so it remains available with `--quiet`. Authorization remains a per-user browser flow.

## Example

```console
$ teamcity project connection authorize PROJECT_EXT_84 -p Sandbox --no-input
https://cli.teamcity.com/oauth/githubapp/repositories.html?projectId=Sandbox&connectionId=PROJECT_EXT_84&updateToken=true&showMode=popup
Tip: Complete the flow in your browser. The tab closes on success; you can return here then.
```

## Test Plan

- [x] Unit tests pass (`go test ./...`; targeted tests rerun after review)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`go test -tags=acceptance ./acceptance/...`); authenticated write scripts skipped without acceptance token
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A, existing global flag; existing connection script extended
- [ ] If adding a data-producing command: includes `--json` support — N/A, existing browser authorization command
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A
- [x] If changing docs-visible behavior: updated relevant docs and skills; README intentionally unchanged per requested scope
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A, maintainer-requested fix

`just build` passed. The built binary printed the expected URL against the actual Sandbox connection with `--no-input`; no browser or OAuth flow was opened. Independent agent review found no blocking issues.

