### PR TITLE
feat(project): support JSON output when creating VCS roots

### DIFF
--- a/acceptance/testdata/project/project-vcs-create-json.txtar
+++ b/acceptance/testdata/project/project-vcs-create-json.txtar
@@ -1,0 +1,11 @@
+# VCS creation supports the machine-readable output contract.
+exec teamcity project vcs create --help
+stdout '\-\-json'
+
+[!has_token] skip 'requires authentication token'
+exec teamcity project vcs create --project Sandbox --url https://github.com/JetBrains/teamcity-cli --name cli-json-$RANDOM_STRING --auth anonymous --no-test --json --no-input
+stdout '"id"'
+! stdout 'Created VCS root'
+extract '"id":\s*"([^"]+)"' ROOT_ID
+exec teamcity project vcs delete $ROOT_ID --yes --no-input
+stdout 'Deleted VCS root'

--- a/docs/topics/teamcity-cli-managing-projects.md
+++ b/docs/topics/teamcity-cli-managing-projects.md
@@ -344,6 +344,7 @@ teamcity project vcs create --url https://github.com/org/repo.git --auth anonymo
 <tr><td><code>--branch</code></td><td>Default branch (default: <code>refs/heads/main</code>)</td></tr>
 <tr><td><code>--branch-spec</code></td><td>Branch specification</td></tr>
 <tr><td><code>--no-test</code></td><td>Skip connection test before creating</td></tr>
+<tr><td><code>--json</code></td><td>Output the created VCS root as JSON</td></tr>
 </table>
 
 To reference an existing stored VCS token, use `project vcs create --auth token --token-id <full-token-id>` (instead of `--connection-id`). The token must already be permitted in the target project. Use `--username` if the provider requires a value other than `oauth2`; test the resulting root in the TeamCity UI.

--- a/internal/cmd/project/vcs.go
+++ b/internal/cmd/project/vcs.go
@@ -269,6 +269,7 @@ type vcsCreateOptions struct {
 	connectionID string
 	tokenID      string
 	noTest       bool
+	json         bool
 }
 
 func newVcsCreateCmd(f *cmdutil.Factory) *cobra.Command {
@@ -317,6 +318,7 @@ Stored --token-id credentials must be tested in the TeamCity UI.`,
 	cmd.Flags().StringVar(&opts.connectionID, "connection-id", "", "OAuth connection ID")
 	cmd.Flags().StringVar(&opts.tokenID, "token-id", "", "Stored token ID (requires --auth token; excludes --connection-id)")
 	cmd.MarkFlagsMutuallyExclusive("connection-id", "token-id")
+	cmd.Flags().BoolVar(&opts.json, "json", false, "Output the created VCS root as JSON")
 	cmd.Flags().BoolVar(&opts.noTest, "no-test", false, "Skip connection test before creating")
 
 	_ = cmd.RegisterFlagCompletionFunc("auth", completion.VCSAuthMethods())
@@ -331,7 +333,7 @@ func runVcsCreate(f *cmdutil.Factory, opts *vcsCreateOptions) error {
 		return err
 	}
 
-	interactive := f.IsInteractive()
+	interactive := !opts.json && f.IsInteractive()
 
 	if interactive {
 		if err := runInteractiveForm(f, &opts.project, api.PermissionEditProject, formField{title: "Repository URL", value: &opts.repoURL}); err != nil {
@@ -397,11 +399,11 @@ func runVcsCreate(f *cmdutil.Factory, opts *vcsCreateOptions) error {
 	testReq.URL = repoURL
 	testReq.VcsName = "jetbrains.git"
 
-	if opts.tokenID != "" && !opts.noTest && !f.JSONOutput {
+	if opts.tokenID != "" && !opts.noTest && !f.JSONOutput && !opts.json {
 		f.Printer.Tip("Test the stored token connection in the TeamCity UI after creating the VCS root")
 	}
 	if opts.tokenID == "" && !opts.noTest && client.SupportsFeature("vcs_test_connection") {
-		if err := runConnectionTest(f, client, testReq, projectID); err != nil {
+		if err := runConnectionTest(f, client, testReq, projectID, opts.json); err != nil {
 			return err
 		}
 	}
@@ -421,6 +423,9 @@ func runVcsCreate(f *cmdutil.Factory, opts *vcsCreateOptions) error {
 		return fmt.Errorf("failed to create VCS root: %w", err)
 	}
 
+	if opts.json {
+		return f.Printer.PrintJSON(created)
+	}
 	f.Printer.Success("Created VCS root %q (%s) in project %s", created.Name, created.ID, projectID)
 	return nil
 }
@@ -653,33 +658,41 @@ func runVcsTest(f *cmdutil.Factory, id, overrideConnID string) error {
 			"Pass --connection-id <id> to test, or test from the TeamCity UI",
 		)
 	}
-	if err := runConnectionTest(f, client, req, projectID); err != nil {
+	if err := runConnectionTest(f, client, req, projectID, false); err != nil {
 		return err
 	}
 	f.Printer.Success("Connection to %q is working", root.Name)
 	return nil
 }
 
-func runConnectionTest(f *cmdutil.Factory, client api.ClientInterface, req api.TestConnectionRequest, projectID string) error {
-	_, _ = fmt.Fprint(f.Printer.ErrOut, "Testing connection... ")
+func runConnectionTest(f *cmdutil.Factory, client api.ClientInterface, req api.TestConnectionRequest, projectID string, jsonOutput bool) error {
+	if !jsonOutput {
+		_, _ = fmt.Fprint(f.Printer.ErrOut, "Testing connection... ")
+	}
 	result, err := client.TestVcsConnection(req, projectID)
 	if err != nil {
-		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Sym().Cross))
+		if !jsonOutput {
+			_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Sym().Cross))
+		}
 		return fmt.Errorf("connection test failed: %w", err)
 	}
 	if result.Status != "OK" {
-		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Sym().Cross))
+		if !jsonOutput {
+			_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Red(output.Sym().Cross))
+		}
 		msg := "connection test failed"
 		if len(result.Errors) > 0 {
 			msg = result.Errors[0].Message
 		}
-		if req.ConnectionID != "" && strings.Contains(msg, "Malformed request") {
+		if !jsonOutput && req.ConnectionID != "" && strings.Contains(msg, "Malformed request") {
 			f.Printer.Tip("First-time use of this connection requires authorization. Run: %s",
 				output.Cyan(fmt.Sprintf("teamcity project connection authorize %s -p %s", req.ConnectionID, projectID)))
 		}
 		return fmt.Errorf("%s", msg)
 	}
-	_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Green(output.Sym().Check))
+	if !jsonOutput {
+		_, _ = fmt.Fprintln(f.Printer.ErrOut, output.Green(output.Sym().Check))
+	}
 	return nil
 }
 

--- a/internal/cmd/project/vcs_test.go
+++ b/internal/cmd/project/vcs_test.go
@@ -1,6 +1,9 @@
 package project_test
 
 import (
+	"encoding/json"
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/JetBrains/teamcity-cli/internal/cmdtest"
@@ -146,4 +149,22 @@ func TestVcsStoredTokenSkipsPreflightHintForJSON(t *testing.T) {
 	assert.NotContains(t, out, "Test the stored token")
 	assert.NotContains(t, out, "Testing connection")
 	assert.Contains(t, out, "Created VCS root")
+}
+
+func TestVcsCreateJSON(t *testing.T) {
+	for _, auth := range []string{"anonymous", "token"} {
+		t.Run(auth, func(t *testing.T) {
+			ts := cmdtest.SetupMockClient(t)
+			args := []string{"project", "vcs", "create", "--project", "TestProject", "--url", "https://github.com/org/repo.git", "--auth", auth, "--json"}
+			if auth == "token" {
+				args = append(args, "--token-id", "tc_token_id:CID_test:-1:uuid")
+			}
+			out := cmdtest.CaptureOutput(t, ts.Factory, args...)
+			var root api.VcsRoot
+			require.NoError(t, json.Unmarshal([]byte(out), &root))
+			assert.Equal(t, "TestProject_NewRoot", root.ID)
+			assert.NotContains(t, out, "Created VCS root")
+			assert.NotContains(t, out, "Test the stored token")
+		})
+	}
 }

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -256,7 +256,7 @@ The `<id>` (job) positional is optional when the repo is linked; `delete` accept
 | `teamcity project tree [id]`                   | Show project hierarchy tree  |
 | `teamcity project vcs list --project <id>`     | List VCS roots               |
 | `teamcity project vcs view <id>`              | View VCS root details        |
-| `teamcity project vcs create --project <id>`  | Create VCS root (interactive or flag-driven) |
+| `teamcity project vcs create --project <id>`  | Create a VCS root; `--json` returns the created object |
 | `teamcity project vcs delete <id>`            | Delete a VCS root            |
 | `teamcity project connection list -p <id>`    | List project connections     |
 | `teamcity project connection create github-app -p <id>` | Register GitHub App (manifest flow) |


### PR DESCRIPTION
## Summary

Add `project vcs create --json` so scripts can consume the created VCS root directly, matching sibling commands.

## Changes

- Emit the created resource as JSON and disable interactive forms for JSON requests.
- Suppress connection-test progress and tips in JSON mode.
- Add regression/acceptance coverage and update command documentation.

## Design Decisions

Straightforward.

## Example

```bash
teamcity project vcs create -p Sandbox --url https://github.com/JetBrains/teamcity-cli --auth anonymous --no-test --json
```

## Test Plan

- [x] Unit tests pass (`go test ./...`)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`go test -tags=acceptance ./acceptance/...`)
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/`
- [x] If adding a data-producing command: includes `--json` support
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated relevant `docs/` and `skills/`; `README.md` unchanged per requested scope
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A: maintainer-requested fix

Built CLI created a temporary VCS root in cli.teamcity.com's Sandbox; output decoded as one JSON resource with the expected project and root ID. The root was deleted afterwards.
