### PR TITLE
fix(analytics): migrate FUS declarations to SDK v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/JetBrains/teamcity-cli
 go 1.26
 
 require (
-	github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260529130422-2c411082a674
+	github.com/JetBrains/fus-reporting-api-go v0.2.0
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/buildkite/shellwords v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
-github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260529130422-2c411082a674 h1:0+gxkXi3gvEUPNJ4TDhcdf/M/y/Eq0dX0kNcRNDIgZY=
-github.com/JetBrains/fus-reporting-api-go v0.1.1-0.20260529130422-2c411082a674/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
+github.com/JetBrains/fus-reporting-api-go v0.2.0 h1:XqVo9c+bwDo4dwvnsoNnLP8YpZfaOFvV7D0vefSIVgQ=
+github.com/JetBrains/fus-reporting-api-go v0.2.0/go.mod h1:jSymVxc/0N4r8EeR3kUU5QqpX/Exw+XbHkAgixkWta4=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=

--- a/internal/analytics/scheme.go
+++ b/internal/analytics/scheme.go
@@ -25,22 +25,6 @@ const (
 	GroupMigrate   = "teamcity.cli.migrate"
 )
 
-// groupVersion maps each FUS group to its schema version.
-// Bump the version for a group whenever its schema changes (new fields, new enum values)
-// so AP can distinguish events from old vs new client versions.
-var groupVersion = map[string]int{
-	GroupSession:   1,
-	GroupCommand:   3, // "migrate" and "job.settings.*" commands added
-	GroupAPI:       1,
-	GroupAuth:      1,
-	GroupBuild:     2, // "muted" filter value added (FUS-7820)
-	GroupAgent:     1,
-	GroupPipeline:  1,
-	GroupSkill:     1,
-	GroupWorkspace: 1, // new group, initial version
-	GroupMigrate:   1, // new group, initial version
-}
-
 const (
 	regexpUUID          = "uuid"
 	regexpSemver        = "semver"
@@ -62,8 +46,8 @@ const (
 	enumSkillAgent      = "skill_agent"
 )
 
-// Scheme is the canonical FUS scheme; consumed at runtime and serialized to schema.json for AP registration.
-var Scheme = &fus.Scheme{
+// Definition is the source for event registration and fallback validation metadata.
+var Definition = &fus.Definition{
 	Version: SchemeVersion,
 	Rules: &fus.SchemeRules{
 		Enums: map[string][]string{
@@ -89,7 +73,7 @@ var Scheme = &fus.Scheme{
 			regexpInteger:       `\d+`,
 		},
 	},
-	Groups: []fus.GroupSchema{
+	Groups: []fus.GroupDefinition{
 		sessionGroup(),
 		commandGroup(),
 		apiGroup(),
@@ -103,204 +87,214 @@ var Scheme = &fus.Scheme{
 	},
 }
 
-func sessionGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupSession,
-		Type: fus.GroupTypeState,
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventInvoked)},
-			EventData: map[string][]string{
-				"session_id":         {fus.RegexpRefExpr(regexpUUID)},
-				"cli_version":        {fus.RegexpRefExpr(regexpSemver)},
-				"server_version":     {fus.RegexpRefExpr(regexpServerVersion)},
-				"os":                 {fus.EnumRefExpr(enumOS)},
-				"arch":               {fus.EnumRefExpr(enumArch)},
-				"server_type":        {fus.EnumRefExpr(enumServerType)},
-				"ci_system":          {fus.EnumRefExpr(enumCISystem)},
-				"auth_source":        {fus.EnumRefExpr(enumAuthSource)},
-				"ai_agent":           {fus.EnumRefExpr(enumAIAgent)},
-				"has_linked_project": {fus.EnumRefExpr(enumBoolean)},
-			},
-		},
-		AnonymizedFields: []fus.AnonymizedField{
-			{Event: EventInvoked, Fields: []string{"session_id"}},
+var Scheme = buildScheme()
+
+var groupVersion = func() map[string]int {
+	versions := make(map[string]int, len(Definition.Groups))
+	for _, group := range Definition.Groups {
+		versions[group.ID] = group.Version
+	}
+	return versions
+}()
+
+func buildScheme() *fus.Scheme {
+	scheme, err := Definition.BuildValidationScheme()
+	if err != nil {
+		panic(err)
+	}
+	return scheme
+}
+
+func sessionGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupSession, Version: 1, Type: fus.GroupTypeState, Description: "Session telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventInvoked, Description: "CLI session", Fields: []fus.FieldDefinition{
+				{Path: "session_id", Rules: []string{fus.RegexpRefExpr(regexpUUID)}, Anonymized: true},
+				{Path: "cli_version", Rules: []string{fus.RegexpRefExpr(regexpSemver)}},
+				{Path: "server_version", Rules: []string{fus.RegexpRefExpr(regexpServerVersion)}},
+				{Path: "os", Rules: []string{fus.EnumRefExpr(enumOS)}},
+				{Path: "arch", Rules: []string{fus.EnumRefExpr(enumArch)}},
+				{Path: "server_type", Rules: []string{fus.EnumRefExpr(enumServerType)}},
+				{Path: "ci_system", Rules: []string{fus.EnumRefExpr(enumCISystem)}},
+				{Path: "auth_source", Rules: []string{fus.EnumRefExpr(enumAuthSource)}},
+				{Path: "ai_agent", Rules: []string{fus.EnumRefExpr(enumAIAgent)}},
+				{Path: "has_linked_project", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
 		},
 	}
 }
 
-func commandGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:       GroupCommand,
-		Type:     fus.GroupTypeCounter,
-		Versions: []fus.SchemeRange{{From: "3"}}, // bumped for "migrate" and "job.settings.*" commands
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventExecuted)},
-			EventData: map[string][]string{
-				"session_id":       {fus.RegexpRefExpr(regexpUUID)},
-				"command":          {fus.EnumRefExpr(enumCommand)},
-				"source":           {fus.EnumRefExpr(enumSource)},
-				"has_json":         {fus.EnumRefExpr(enumBoolean)},
-				"has_git_context":  {fus.EnumRefExpr(enumBoolean)},
-				"has_link_context": {fus.EnumRefExpr(enumBoolean)},
-				"flag_count":       {fus.RegexpRefExpr(regexpInteger)},
-				"exit_code":        {fus.EnumRefExpr(enumExitCode)},
-				"duration_ms":      {fus.RegexpRefExpr(regexpInteger)},
-				"error_type":       {fus.EnumRefExpr(enumErrorType)},
-			},
-		},
-		AnonymizedFields: []fus.AnonymizedField{
-			{Event: EventExecuted, Fields: []string{"session_id"}},
+func commandGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupCommand, Version: 3, Type: fus.GroupTypeCounter, Description: "Command telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventExecuted, Description: "Command completed", Fields: []fus.FieldDefinition{
+				{Path: "session_id", Rules: []string{fus.RegexpRefExpr(regexpUUID)}, Anonymized: true},
+				{Path: "command", Rules: []string{fus.EnumRefExpr(enumCommand)}},
+				{Path: "source", Rules: []string{fus.EnumRefExpr(enumSource)}},
+				{Path: "has_json", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "has_git_context", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "has_link_context", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "flag_count", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "exit_code", Rules: []string{fus.EnumRefExpr(enumExitCode)}},
+				{Path: "duration_ms", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "error_type", Rules: []string{fus.EnumRefExpr(enumErrorType)}},
+			}},
 		},
 	}
 }
 
-func apiGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupAPI,
-		Type: fus.GroupTypeCounter,
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventInvoked)},
-			EventData: map[string][]string{
-				"method":       {fus.EnumRefExpr(enumHTTPMethod)},
-				"resource":     {fus.EnumRefExpr(enumAPIResource)},
-				"status_code":  {fus.RegexpRefExpr(regexpInteger)},
-				"is_paginated": {fus.EnumRefExpr(enumBoolean)},
-				"is_slurp":     {fus.EnumRefExpr(enumBoolean)},
-				"had_fields":   {fus.EnumRefExpr(enumBoolean)},
-				"had_input":    {fus.EnumRefExpr(enumBoolean)},
-			},
+func apiGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupAPI, Version: 1, Type: fus.GroupTypeCounter, Description: "API telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventInvoked, Description: "API request", Fields: []fus.FieldDefinition{
+				{Path: "method", Rules: []string{fus.EnumRefExpr(enumHTTPMethod)}},
+				{Path: "resource", Rules: []string{fus.EnumRefExpr(enumAPIResource)}},
+				{Path: "status_code", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "is_paginated", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "is_slurp", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "had_fields", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "had_input", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
 		},
 	}
 }
 
-func authGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupAuth,
-		Type: fus.GroupTypeCounter,
-		Rules: &fus.SchemeRules{
-			EventID: []string{
-				fus.EnumExpr(EventLoginCompleted, EventLoginAbandoned, EventTokenLoaded),
-			},
-			EventData: map[string][]string{
-				"method":      {fus.EnumExpr("token", "guest")},
-				"is_success":  {fus.EnumRefExpr(enumBoolean)},
-				"error_type":  {fus.EnumRefExpr(enumErrorType)},
-				"failed_step": {fus.EnumExpr("server", "token", "verify")},
-				"source":      {fus.EnumExpr("keyring", "env", "build_properties", "guest")},
-				"is_expired":  {fus.EnumRefExpr(enumBoolean)},
-			},
+func authGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupAuth, Version: 1, Type: fus.GroupTypeCounter, Description: "Auth telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventLoginCompleted, Description: "Login completed", Fields: []fus.FieldDefinition{
+				{Path: "method", Rules: []string{fus.EnumExpr("token", "guest")}},
+				{Path: "is_success", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "error_type", Rules: []string{fus.EnumRefExpr(enumErrorType)}},
+			}},
+			{ID: EventLoginAbandoned, Description: "Login abandoned", Fields: []fus.FieldDefinition{
+				{Path: "method", Rules: []string{fus.EnumExpr("token", "guest")}},
+				{Path: "failed_step", Rules: []string{fus.EnumExpr("server", "token", "verify")}},
+			}},
+			{ID: EventTokenLoaded, Description: "Token loaded", Fields: []fus.FieldDefinition{
+				{Path: "source", Rules: []string{fus.EnumExpr("keyring", "env", "build_properties", "guest")}},
+				{Path: "is_expired", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
 		},
 	}
 }
 
-func buildGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:       GroupBuild,
-		Type:     fus.GroupTypeCounter,
-		Versions: []fus.SchemeRange{{From: "2"}}, // bumped per FUS-7820 (added "muted" filter value)
-		Rules: &fus.SchemeRules{
-			EventID: []string{
-				fus.EnumExpr(EventStarted, EventWatchFinished, EventLogViewed, EventTestsViewed, EventDiffViewed),
-			},
-			EventData: map[string][]string{
-				"is_personal":       {fus.EnumRefExpr(enumBoolean)},
-				"has_local_changes": {fus.EnumRefExpr(enumBoolean)},
-				"has_branch":        {fus.EnumRefExpr(enumBoolean)},
-				"has_revision":      {fus.EnumRefExpr(enumBoolean)},
-				"param_count":       {fus.RegexpRefExpr(regexpInteger)},
-				"is_watched":        {fus.EnumRefExpr(enumBoolean)},
-				"is_dry_run":        {fus.EnumRefExpr(enumBoolean)},
-				"duration_seconds":  {fus.RegexpRefExpr(regexpInteger)},
-				"final_status":      {fus.EnumExpr("success", "failure", "error", "canceled")},
-				"had_logs":          {fus.EnumRefExpr(enumBoolean)},
-				"is_timed_out":      {fus.EnumRefExpr(enumBoolean)},
-				"mode":              {fus.EnumExpr("full", "failed", "raw", "follow")},
-				"is_from_job":       {fus.EnumRefExpr(enumBoolean)},
-				"filter":            {fus.EnumExpr("all", "failed", "muted")},
-				"had_log_diff":      {fus.EnumRefExpr(enumBoolean)},
-			},
+func buildGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupBuild, Version: 2, Type: fus.GroupTypeCounter, Description: "Build telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventStarted, Description: "Build started", Fields: []fus.FieldDefinition{
+				{Path: "is_personal", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "has_local_changes", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "has_branch", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "has_revision", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "param_count", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "is_watched", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "is_dry_run", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
+			{ID: EventWatchFinished, Description: "Build watch finished", Fields: []fus.FieldDefinition{
+				{Path: "duration_seconds", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "final_status", Rules: []string{fus.EnumExpr("success", "failure", "error", "canceled")}},
+				{Path: "had_logs", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "is_timed_out", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
+			{ID: EventLogViewed, Description: "Build log viewed", Fields: []fus.FieldDefinition{
+				{Path: "mode", Rules: []string{fus.EnumExpr("full", "failed", "raw", "follow")}},
+				{Path: "is_from_job", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
+			{ID: EventTestsViewed, Description: "Build tests viewed", Fields: []fus.FieldDefinition{
+				{Path: "filter", Rules: []string{fus.EnumExpr("all", "failed", "muted")}},
+				{Path: "is_from_job", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
+			{ID: EventDiffViewed, Description: "Build diff viewed", Fields: []fus.FieldDefinition{
+				{Path: "had_log_diff", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
 		},
 	}
 }
 
-func agentGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupAgent,
-		Type: fus.GroupTypeCounter,
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventTerminalClosed, EventExecFinished, EventStateChanged)},
-			EventData: map[string][]string{
-				"duration_seconds": {fus.RegexpRefExpr(regexpInteger)},
-				"exit_reason":      {fus.EnumExpr("user", "timeout", "disconnected", "error")},
-				"exit_code":        {fus.RegexpRefExpr(regexpInteger)},
-				"had_timeout":      {fus.EnumRefExpr(enumBoolean)},
-				"action":           {fus.EnumExpr("enable", "disable", "authorize", "deauthorize", "move", "reboot")},
-			},
+func agentGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupAgent, Version: 1, Type: fus.GroupTypeCounter, Description: "Agent telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventTerminalClosed, Description: "Agent terminal closed", Fields: []fus.FieldDefinition{
+				{Path: "duration_seconds", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "exit_reason", Rules: []string{fus.EnumExpr("user", "timeout", "disconnected", "error")}},
+			}},
+			{ID: EventExecFinished, Description: "Agent command finished", Fields: []fus.FieldDefinition{
+				{Path: "duration_seconds", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "exit_code", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "had_timeout", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
+			{ID: EventStateChanged, Description: "Agent state changed", Fields: []fus.FieldDefinition{
+				{Path: "action", Rules: []string{fus.EnumExpr("enable", "disable", "authorize", "deauthorize", "move", "reboot")}},
+			}},
 		},
 	}
 }
 
-func pipelineGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupPipeline,
-		Type: fus.GroupTypeCounter,
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventValidated, EventCreated, EventSynced)},
-			EventData: map[string][]string{
-				"error_count":        {fus.RegexpRefExpr(regexpInteger)},
-				"warning_count":      {fus.RegexpRefExpr(regexpInteger)},
-				"is_from_file":       {fus.EnumRefExpr(enumBoolean)},
-				"used_cached_schema": {fus.EnumRefExpr(enumBoolean)},
-				"action":             {fus.EnumExpr("push", "pull")},
-			},
+func pipelineGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupPipeline, Version: 1, Type: fus.GroupTypeCounter, Description: "Pipeline telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventValidated, Description: "Pipeline validated", Fields: []fus.FieldDefinition{
+				{Path: "error_count", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "warning_count", Rules: []string{fus.RegexpRefExpr(regexpInteger)}},
+				{Path: "is_from_file", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "used_cached_schema", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
+			{ID: EventCreated, Description: "Pipeline created", Fields: []fus.FieldDefinition{
+				{Path: "is_from_file", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
+			{ID: EventSynced, Description: "Pipeline synced", Fields: []fus.FieldDefinition{
+				{Path: "action", Rules: []string{fus.EnumExpr("push", "pull")}},
+			}},
 		},
 	}
 }
 
-func skillGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupSkill,
-		Type: fus.GroupTypeCounter,
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventManaged)},
-			EventData: map[string][]string{
-				"action":           {fus.EnumExpr("install", "update", "remove")},
-				"agent":            {fus.EnumRefExpr(enumSkillAgent)},
-				"scope":            {fus.EnumExpr("global", "project")},
-				"is_auto_detected": {fus.EnumRefExpr(enumBoolean)},
-				"is_success":       {fus.EnumRefExpr(enumBoolean)},
-			},
+func skillGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupSkill, Version: 1, Type: fus.GroupTypeCounter, Description: "Skill telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventManaged, Description: "Skill managed", Fields: []fus.FieldDefinition{
+				{Path: "action", Rules: []string{fus.EnumExpr("install", "update", "remove")}},
+				{Path: "agent", Rules: []string{fus.EnumRefExpr(enumSkillAgent)}},
+				{Path: "scope", Rules: []string{fus.EnumExpr("global", "project")}},
+				{Path: "is_auto_detected", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "is_success", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
 		},
 	}
 }
 
-func migrateGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupMigrate,
-		Type: fus.GroupTypeCounter,
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventCompleted)},
-			EventData: map[string][]string{
-				"source":            {fus.EnumExpr(MigrateSourceGitHubActions, MigrateSourceBamboo, MigrateSourceMixed, MigrateSourceOther, MigrateSourceNone)},
-				"outcome":           {fus.EnumExpr(MigrateOutcomeClean, MigrateOutcomePartial, MigrateOutcomeFailed, MigrateOutcomeNothingFound)},
-				"validation_status": {fus.EnumExpr(MigrateValidationValid, MigrateValidationInvalid, MigrateValidationSkipped)},
-				"is_dry_run":        {fus.EnumRefExpr(enumBoolean)},
-			},
+func migrateGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupMigrate, Version: 1, Type: fus.GroupTypeCounter, Description: "Migrate telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventCompleted, Description: "Migration completed", Fields: []fus.FieldDefinition{
+				{Path: "source", Rules: []string{fus.EnumExpr(MigrateSourceGitHubActions, MigrateSourceBamboo, MigrateSourceMixed, MigrateSourceOther, MigrateSourceNone)}},
+				{Path: "outcome", Rules: []string{fus.EnumExpr(MigrateOutcomeClean, MigrateOutcomePartial, MigrateOutcomeFailed, MigrateOutcomeNothingFound)}},
+				{Path: "validation_status", Rules: []string{fus.EnumExpr(MigrateValidationValid, MigrateValidationInvalid, MigrateValidationSkipped)}},
+				{Path: "is_dry_run", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
 		},
 	}
 }
 
-func workspaceGroup() fus.GroupSchema {
-	return fus.GroupSchema{
-		ID:   GroupWorkspace,
-		Type: fus.GroupTypeCounter,
-		Rules: &fus.SchemeRules{
-			EventID: []string{fus.EnumExpr(EventLinked)},
-			EventData: map[string][]string{
-				"source":       {fus.EnumExpr(WorkspaceSourceFlag, WorkspaceSourceAuto, WorkspaceSourceInteractive)},
-				"is_ambiguous": {fus.EnumRefExpr(enumBoolean)},
-				"is_subdir":    {fus.EnumRefExpr(enumBoolean)},
-			},
+func workspaceGroup() fus.GroupDefinition {
+	return fus.GroupDefinition{
+		ID: GroupWorkspace, Version: 1, Type: fus.GroupTypeCounter, Description: "Workspace telemetry",
+		Events: []fus.EventDefinition{
+			{ID: EventLinked, Description: "Workspace linked", Fields: []fus.FieldDefinition{
+				{Path: "source", Rules: []string{fus.EnumExpr(WorkspaceSourceFlag, WorkspaceSourceAuto, WorkspaceSourceInteractive)}},
+				{Path: "is_ambiguous", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+				{Path: "is_subdir", Rules: []string{fus.EnumRefExpr(enumBoolean)}},
+			}},
 		},
 	}
 }

--- a/internal/analytics/scheme_test.go
+++ b/internal/analytics/scheme_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	fus "github.com/JetBrains/fus-reporting-api-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestScheme_BuildsValidator ensures every group/event/field in the scheme is
@@ -36,24 +38,38 @@ func TestScheme_HasAllExpectedGroups(t *testing.T) {
 	}
 }
 
-// TestScheme_FlatGroupsRespectFieldCap covers groups where every declared field
-// is sent on every event (session, command, api). Multi-event groups (build,
-// auth, agent, etc.) declare a union of fields across events, so they are
-// excluded — Track() enforces the per-event 10-field cap at runtime.
-func TestScheme_FlatGroupsRespectFieldCap(t *testing.T) {
-	flat := map[string]bool{
-		GroupSession: true,
-		GroupCommand: true,
-		GroupAPI:     true,
-	}
-	for _, g := range Scheme.Groups {
-		if !flat[g.ID] || g.Rules == nil {
-			continue
+func TestDefinitionMatchesEvents(t *testing.T) {
+	t.Parallel()
+	es, err := Definition.BuildEventsScheme(fus.RecorderConfig{RecorderID: RecorderID, RecorderVersion: RecorderVersion}, "test")
+	require.NoError(t, err)
+	samples := map[string]map[string]bool{}
+	for _, event := range SampleEvents() {
+		key := event.Group.ID + "/" + event.Event.ID
+		if samples[key] == nil {
+			samples[key] = map[string]bool{}
 		}
-		if n := len(g.Rules.EventData); n > fus.MaxDataFields {
-			t.Errorf("flat group %q declares %d fields, exceeds FUS cap of %d", g.ID, n, fus.MaxDataFields)
+		for field := range event.Event.Data {
+			samples[key][field] = true
 		}
 	}
+	for _, group := range es.Scheme {
+		assert.Equal(t, groupVersion[group.ID], group.Version)
+		for _, event := range group.Schema {
+			key := group.ID + "/" + event.Event
+			assert.LessOrEqual(t, len(event.Fields), fus.MaxDataFields, key)
+			fields := map[string]bool{}
+			for _, field := range event.Fields {
+				fields[field.Path] = true
+				if field.ShouldBeAnonymized {
+					assert.Equal(t, "session_id", field.Path)
+					assert.Equal(t, []string{"{regexp#hash}"}, field.Value)
+				}
+			}
+			assert.Equal(t, samples[key], fields, key)
+			delete(samples, key)
+		}
+	}
+	assert.Empty(t, samples, "sample events missing from the declaration")
 }
 
 func TestNormalizeCommand(t *testing.T) {

--- a/internal/analytics/validate.go
+++ b/internal/analytics/validate.go
@@ -127,6 +127,10 @@ func SampleEvents() []fus.LogEvent {
 		mk(GroupWorkspace, EventLinked, false, map[string]any{
 			"source": WorkspaceSourceFlag, "is_ambiguous": false, "is_subdir": true,
 		}),
+		mk(GroupMigrate, EventCompleted, false, map[string]any{
+			"source": MigrateSourceGitHubActions, "outcome": MigrateOutcomeClean,
+			"validation_status": MigrateValidationValid, "is_dry_run": false,
+		}),
 	}
 }
 

--- a/scripts/generate-fus-schema.go
+++ b/scripts/generate-fus-schema.go
@@ -1,17 +1,6 @@
 //go:build ignore
 
-// Script to generate FUS schema files from the in-Go FUS scheme.
-//
-// Produces two files:
-//   - internal/analytics/schema.json: the AP metadata format (EventGroupRemoteDescriptors),
-//     used at runtime by fus.NewValidator as the embedded fallback scheme.
-//   - internal/analytics/events-scheme.json: the events scheme format (EventsScheme),
-//     used by the FUS metadata team to generate metadata entries. Attach this to
-//     YT issues in the FUS project when requesting metadata changes.
-//
-// Run with:
-//
-//	go run scripts/generate-fus-schema.go
+// Run go run scripts/generate-fus-schema.go to generate fallback and registration JSON.
 package main
 
 import (
@@ -36,7 +25,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	es, err := fus.BuildEventsScheme(analytics.Scheme, fus.RecorderConfig{
+	es, err := analytics.Definition.BuildEventsScheme(fus.RecorderConfig{
 		RecorderID:      analytics.RecorderID,
 		RecorderVersion: analytics.RecorderVersion,
 		ProductCode:     analytics.ProductCode,


### PR DESCRIPTION
## Summary

Migrate telemetry declarations to fus-reporting-api-go v0.2.0 so registration JSON contains each event's own fields. Uses https://github.com/JetBrains/fus-reporting-api-go/pull/4. No FUS metadata update is required by this migration: emitted event IDs, group versions, field rules and anonymization are preserved.

## Changes

- Replace flattened declarations with `fus.Definition`; derive fallback metadata and the group-version lookup from it.
- Switch the schema generator to `Definition.BuildEventsScheme`.
- Check all 20 event declarations against sample payloads and the per-event field cap.

## Design Decisions

Existing `Track` calls and CDN metadata selection stay unchanged. The generated fallback is scoped to the declared group versions; those are the same versions the CLI already sends. Both JSON files were regenerated locally and remain gitignored, as before.

## Example

`go run scripts/generate-fus-schema.go` now declares only `had_log_diff` for `build/diff.viewed`, instead of all build-group fields. CLI behavior is unchanged.

## Test Plan

- [x] Unit tests pass (`go test ./...`; `go test -race ./internal/analytics`)
- [x] Linter passes (`just lint`)
- [ ] Acceptance tests — N/A, no command behavior changes
- [ ] New command/flag `.txtar` test — N/A
- [ ] Data-producing command `--json` support — N/A
- [ ] JSON output compatibility — N/A, no CLI output changes
- [ ] Docs/skills/README — N/A, no docs-visible behavior changes
- [ ] Finalized issue — N/A, JetBrains member

Also ran `just build`, `bin/teamcity --version` and the schema generator. Compared old/new fallback rules: all 10 groups retain the same event IDs, field rules, shared rule definitions and anonymization.
