### PR TITLE
fix(tests): enable permissions before assigning admin role

### DIFF
--- a/api/testenv_auth_test.go
+++ b/api/testenv_auth_test.go
@@ -1,0 +1,35 @@
+//go:build integration
+
+package api_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestContainerBootstrapAuthentication(t *testing.T) {
+	if testEnvRef == nil || !testEnvRef.ownsContainers {
+		t.Skip("only checks authentication on the disposable test server")
+	}
+	response, err := client.RawRequest(t.Context(), http.MethodGet, "/app/rest/server/authSettings", nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	var settings struct {
+		PerProjectPermissions bool `json:"perProjectPermissions"`
+		Modules               struct {
+			Module []struct {
+				Name string `json:"name"`
+			} `json:"module"`
+		} `json:"modules"`
+	}
+	require.NoError(t, json.Unmarshal(response.Body, &settings))
+	assert.True(t, settings.PerProjectPermissions)
+	require.NotEmpty(t, settings.Modules.Module, "bootstrap must preserve authentication modules")
+	user, err := client.GetCurrentUser()
+	require.NoError(t, err)
+	assert.Equal(t, "admin", user.Username)
+}

--- a/api/testenv_test.go
+++ b/api/testenv_test.go
@@ -3,6 +3,7 @@
 package api_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -239,7 +240,7 @@ func startContainers() (*testEnv, error) {
 		return nil, fmt.Errorf("accept license: %w", err)
 	}
 
-	env.Token, err = setupServer(env.URL, superToken, env.ProjectID, env.ConfigID)
+	env.Token, err = setupServer(ctx, env.URL, superToken, env.ProjectID, env.ConfigID)
 	if err != nil {
 		env.Cleanup()
 		return nil, fmt.Errorf("setup server: %w", err)
@@ -385,8 +386,8 @@ func acceptLicense(serverURL, superToken string) error {
 	return nil
 }
 
-func setupServer(serverURL, superToken, projectID, configID string) (string, error) {
-	client := api.NewClientWithBasicAuth(serverURL, "", superToken)
+func setupServer(ctx context.Context, serverURL, superToken, projectID, configID string) (string, error) {
+	client := api.NewClientWithBasicAuth(serverURL, "", superToken).WithContext(ctx)
 
 	deadline := time.Now().Add(2 * time.Minute)
 	for time.Now().Before(deadline) {
@@ -422,6 +423,31 @@ func setupServer(serverURL, superToken, projectID, configID string) (string, err
 		client.SetBuildTypeSetting(configID, "artifactRules", "result.txt\nreports => reports")
 	}
 
+	// Role assignments require per-project permissions; preserve the configured login modules.
+	authSettings, err := client.RawRequest(ctx, http.MethodGet, "/app/rest/server/authSettings", nil, nil)
+	if err != nil {
+		return "", fmt.Errorf("get authentication settings: %w", err)
+	}
+	if authSettings.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("get authentication settings: HTTP %d", authSettings.StatusCode)
+	}
+	var settings map[string]json.RawMessage
+	if err := json.Unmarshal(authSettings.Body, &settings); err != nil {
+		return "", fmt.Errorf("decode authentication settings: %w", err)
+	}
+	settings["perProjectPermissions"] = json.RawMessage("true")
+	body, err := json.Marshal(settings)
+	if err != nil {
+		return "", fmt.Errorf("encode authentication settings: %w", err)
+	}
+	updated, err := client.RawRequest(ctx, http.MethodPut, "/app/rest/server/authSettings", bytes.NewReader(body), nil)
+	if err != nil {
+		return "", fmt.Errorf("enable per-project permissions: %w", err)
+	}
+	if updated.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("enable per-project permissions: HTTP %d", updated.StatusCode)
+	}
+
 	if !client.UserExists("admin") {
 		if _, err := client.CreateUser(api.CreateUserRequest{
 			Username: "admin",
@@ -432,7 +458,7 @@ func setupServer(serverURL, superToken, projectID, configID string) (string, err
 		}
 	}
 
-	adminClient := api.NewClientWithBasicAuth(serverURL, "admin", "admin123")
+	adminClient := api.NewClientWithBasicAuth(serverURL, "admin", "admin123").WithContext(ctx)
 	_ = adminClient.DeleteAPIToken("tc-cli-test")
 	token, err := adminClient.CreateAPIToken("tc-cli-test")
 	if err != nil {


### PR DESCRIPTION
## Summary

Fix fresh TeamCity integration-server startup failing with `Role assignment operations are not supported when per-project permissions are disabled`. This affects main and feature branches before API tests run, including [main run 14372](https://cli.teamcity.com/viewLog.html?buildId=14372) and [ARM64 run 14342](https://cli.teamcity.com/viewLog.html?buildId=14342).

## Changes

- Enable per-project permissions before creating the test administrator, preserving the existing authentication settings and modules.
- Check REST response statuses and bind bootstrap clients to the setup context.
- Assert authentication mode, retained modules, and admin-token access on disposable test servers.

## Design Decisions

The server rejects role assignments in simple-permissions mode. Read-modify-write of `/app/rest/server/authSettings` preserves login modules; a partial PUT containing only the permissions flag is rejected by the server. This changes only the disposable test-server bootstrap.

## Example

N/A — test infrastructure only.

## Test Plan

- [x] Unit tests pass (`just unit`) — full `go test ./...`.
- [x] Linter passes (`just lint`).
- [ ] Acceptance tests pass (`just acceptance`) — N/A — no CLI behavior change; integration suite is the relevant verification.
- [ ] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — N/A — no new command/flag.
- [ ] If adding a data-producing command: includes `--json` support — N/A — no new command.
- [ ] If modifying `--json` output: no field removals/renames (additive only) — N/A — unchanged.
- [ ] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md` — N/A — test infrastructure only.
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A — maintainer-requested fix.

The exact failure reproduced locally with a freshly pulled `jetbrains/teamcity-server:latest` before this change. With the fix, the full API integration suite passes against freshly pulled containers: `TEAMCITY_VERSION=ci-repro go test -tags=integration ./api -count=1 -timeout 30m` (255 seconds), including the new bootstrap regression. `just build` passes. Independent source/code review found no blockers. The existing `server/rootUrl` 405 warning is separate from the fatal role-assignment failure. CI verification [14387](https://cli.teamcity.com/build/14387): Linux integration passed 1,928 tests (4 skipped), ARM64 integration passed 1,929 tests (4 skipped), both with race detection and coverage. Guest and acceptance stages also passed on both architectures.
