### PR TITLE
feat(run): pin revisions per VCS root

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ teamcity run list --user @me --branch @this --limit 1
 # start a build and stay attached to it
 teamcity run start MyProject_Build --branch main --watch
 
+# pin different revisions in a job with multiple VCS roots
+teamcity run start MyProject_Build --revision AppRepo=abc123 --revision AssetsRepo=@main
+
 # logs from the latest build of a job
 teamcity run log --job MyProject_Build
 

--- a/acceptance/testdata/run/run-revisions.txtar
+++ b/acceptance/testdata/run/run-revisions.txtar
@@ -1,0 +1,28 @@
+# Per-root revision validation runs before any server request.
+! exec teamcity run start Unused --revision abc --revision Root=def --json --no-input
+stderr '"code": "validation_error"'
+stderr 'cannot mix'
+
+! exec teamcity run start Unused --revision Root=abc --revision Root=def --no-input
+stderr 'duplicate --revision'
+
+! exec teamcity run start Unused --revision Root=abc@ --no-input
+stderr 'invalid --revision'
+
+# Dry-run preserves legacy JSON and displays independent root pins.
+exec teamcity job list --limit 1 --json --no-input
+extract '"id":\s*"([^"]+)"' JOB_ID
+
+exec teamcity run start $JOB_ID --revision 0123456789012345678901234567890123456789 --dry-run --json --no-input
+stdout '"revision": "0123456789012345678901234567890123456789"'
+! stdout '"revisions"'
+
+exec teamcity run start $JOB_ID --revision A=abc@feature --revision B=@master --dry-run --json --no-input
+stdout '"vcs_root": "A"'
+stdout '"version": "abc"'
+stdout '"branch": "master"'
+! stdout '"revision":'
+
+exec teamcity run start $JOB_ID --revision A=abc@feature --revision B=@master --dry-run --no-input
+stdout 'Revision: A=abc@feature'
+stdout 'Revision: B=@master'

--- a/api/builds.go
+++ b/api/builds.go
@@ -273,6 +273,7 @@ type RunBuildOptions struct {
 	Tags                      []string
 	PersonalChangeID          string
 	Revision                  string
+	Revisions                 []RevisionSpec // Per-root pins; cannot be combined with Revision.
 	SnapshotDependencies      []int
 	FreezeSettings            *bool // nil = build configuration default; true = settings from VCS; false = current server settings
 }
@@ -345,39 +346,12 @@ func (c *Client) RunBuild(buildTypeID string, opts RunBuildOptions) (*Build, err
 		req.SnapshotDependencies = &SnapshotDepBuilds{Build: refs}
 	}
 
-	if opts.Revision != "" {
-		entries, err := c.GetVcsRootEntries(buildTypeID)
+	if opts.Revision != "" || len(opts.Revisions) > 0 {
+		revisions, err := c.resolveBuildRevisions(buildTypeID, opts)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get VCS root entries: %w", err)
+			return nil, err
 		}
-		if entries.Count == 0 {
-			return nil, fmt.Errorf("build configuration %s has no VCS roots; cannot pin revision", buildTypeID)
-		}
-
-		branch := opts.Branch
-		if branch != "" && !strings.HasPrefix(branch, "refs/") {
-			branch = "refs/heads/" + branch
-		}
-
-		var revisions []Revision
-		for _, entry := range entries.VcsRootEntry {
-			vcsRootID := ""
-			if entry.VcsRoot != nil {
-				vcsRootID = entry.VcsRoot.ID
-			}
-			if vcsRootID == "" {
-				continue
-			}
-			rev := Revision{
-				Version:         opts.Revision,
-				VcsBranchName:   branch,
-				VcsRootInstance: &VcsRootInstanceRef{VcsRootID: vcsRootID},
-			}
-			revisions = append(revisions, rev)
-		}
-		if len(revisions) > 0 {
-			req.Revisions = &Revisions{Revision: revisions}
-		}
+		req.Revisions = &Revisions{Revision: revisions}
 	}
 
 	body, err := json.Marshal(req)

--- a/api/revisions.go
+++ b/api/revisions.go
@@ -1,0 +1,113 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"slices"
+	"strings"
+)
+
+// RevisionSpec pins one VCS root to a commit or to the fetched head of Branch.
+type RevisionSpec struct {
+	VcsRootID string `json:"vcs_root"`
+	Version   string `json:"version,omitempty"`
+	Branch    string `json:"branch,omitempty"`
+}
+
+func (c *Client) resolveBuildRevisions(job string, opts RunBuildOptions) ([]Revision, error) {
+	if opts.Revision != "" && len(opts.Revisions) > 0 {
+		return nil, Validation("cannot mix a bare revision with per-root revisions", "Use either Revision or Revisions")
+	}
+	entries, err := c.GetVcsRootEntries(job)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get VCS root entries: %w", err)
+	}
+	roots := []string{}
+	for _, entry := range entries.VcsRootEntry {
+		if entry.VcsRoot != nil && entry.VcsRoot.ID != "" {
+			roots = append(roots, entry.VcsRoot.ID)
+		}
+	}
+	if len(roots) == 0 {
+		return nil, fmt.Errorf("build configuration %s has no VCS roots; cannot pin revision", job)
+	}
+	specs := slices.Clone(opts.Revisions)
+	if opts.Revision != "" {
+		for _, root := range roots {
+			specs = append(specs, RevisionSpec{VcsRootID: root, Version: opts.Revision, Branch: opts.Branch})
+		}
+	}
+	seen := map[string]bool{}
+	for _, spec := range specs {
+		switch {
+		case !slices.Contains(roots, spec.VcsRootID):
+			return nil, Validation(fmt.Sprintf("VCS root %q is not attached to %s", spec.VcsRootID, job), "Available VCS roots: "+strings.Join(roots, ", "))
+		case seen[spec.VcsRootID]:
+			return nil, Validation("duplicate revision for VCS root "+spec.VcsRootID, "Pass each VCS root at most once")
+		case spec.Version == "" && spec.Branch == "":
+			return nil, Validation("revision or branch required for VCS root "+spec.VcsRootID, "Use ROOT=SHA, ROOT=SHA@BRANCH, or ROOT=@BRANCH")
+		}
+		seen[spec.VcsRootID] = true
+	}
+	if slices.ContainsFunc(specs, func(s RevisionSpec) bool { return s.Version == "" }) {
+		if err := c.resolveBranchHeads(job, specs); err != nil {
+			return nil, err
+		}
+	}
+	revisions := make([]Revision, 0, len(specs))
+	for _, spec := range specs {
+		revisions = append(revisions, Revision{
+			Version: spec.Version, VcsBranchName: revisionBranch(spec.Branch),
+			VcsRootInstance: &VcsRootInstanceRef{VcsRootID: spec.VcsRootID},
+		})
+	}
+	return revisions, nil
+}
+
+// resolveBranchHeads resolves all branch-only pins in one request without fetching remote Git repositories.
+func (c *Client) resolveBranchHeads(job string, specs []RevisionSpec) error {
+	type branchHead struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	var state struct {
+		Instances []struct {
+			Root            string `json:"vcs-root-id"`
+			RepositoryState struct {
+				Branches []branchHead `json:"branch"`
+			} `json:"repositoryState"`
+		} `json:"vcs-root-instance"`
+	}
+	path := "/app/rest/buildTypes/id:" + url.PathEscape(job) + "/vcs-root-instances?fields=vcs-root-instance(vcs-root-id,repositoryState(branch(name,version)))"
+	if err := c.get(c.ctx(), path, &state); err != nil {
+		return fmt.Errorf("failed to get VCS branch heads: %w", err)
+	}
+	for i, spec := range specs {
+		if spec.Version != "" {
+			continue
+		}
+		for _, inst := range state.Instances {
+			if inst.Root != spec.VcsRootID {
+				continue
+			}
+			branches := inst.RepositoryState.Branches
+			if j := slices.IndexFunc(branches, func(branch branchHead) bool {
+				return branch.Name == revisionBranch(spec.Branch) || branch.Name == spec.Branch
+			}); j >= 0 {
+				specs[i].Version = branches[j].Version
+			}
+		}
+		if specs[i].Version == "" {
+			return Validation(fmt.Sprintf("no fetched revision for branch %q in VCS root %s", spec.Branch, spec.VcsRootID), "Check the root's branch specification, or pass ROOT=SHA@BRANCH")
+		}
+	}
+	return nil
+}
+
+// revisionBranch preserves full refs and qualifies short Git branch names.
+func revisionBranch(branch string) string {
+	if branch == "" || strings.HasPrefix(branch, "refs/") {
+		return branch
+	}
+	return "refs/heads/" + branch
+}

--- a/api/revisions_test.go
+++ b/api/revisions_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunBuildRevisions(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		opts    RunBuildOptions
+		want    []Revision
+		wantErr string
+		heads   bool
+	}{
+		{name: "legacy pins every root", opts: RunBuildOptions{Revision: "abc", Branch: "feature"}, want: []Revision{
+			{Version: "abc", VcsBranchName: "refs/heads/feature", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "A"}},
+			{Version: "abc", VcsBranchName: "refs/heads/feature", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "B"}},
+		}},
+		{name: "pin only one root without inheriting logical branch", opts: RunBuildOptions{Branch: "unrelated", Revisions: []RevisionSpec{{VcsRootID: "A", Version: "abc"}}}, want: []Revision{
+			{Version: "abc", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "A"}},
+		}},
+		{name: "explicit branch and tag", opts: RunBuildOptions{Revisions: []RevisionSpec{{VcsRootID: "A", Version: "abc", Branch: "feature"}, {VcsRootID: "B", Version: "def", Branch: "refs/tags/v1"}}}, want: []Revision{
+			{Version: "abc", VcsBranchName: "refs/heads/feature", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "A"}},
+			{Version: "def", VcsBranchName: "refs/tags/v1", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "B"}},
+		}},
+		{name: "two branch heads in one request", opts: RunBuildOptions{Revisions: []RevisionSpec{{VcsRootID: "A", Branch: "main"}, {VcsRootID: "B", Branch: "refs/tags/v1"}}}, heads: true, want: []Revision{
+			{Version: "aaa", VcsBranchName: "refs/heads/main", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "A"}},
+			{Version: "bbb", VcsBranchName: "refs/tags/v1", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "B"}},
+		}},
+		{name: "mixed explicit and head", opts: RunBuildOptions{Revisions: []RevisionSpec{{VcsRootID: "A", Version: "older"}, {VcsRootID: "B", Branch: "refs/pull/12/merge"}}}, heads: true, want: []Revision{
+			{Version: "older", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "A"}},
+			{Version: "pr", VcsBranchName: "refs/pull/12/merge", VcsRootInstance: &VcsRootInstanceRef{VcsRootID: "B"}},
+		}},
+		{name: "unknown root", opts: RunBuildOptions{Revisions: []RevisionSpec{{VcsRootID: "typo", Version: "abc"}}}, wantErr: "is not attached to Job"},
+		{name: "duplicate root", opts: RunBuildOptions{Revisions: []RevisionSpec{{VcsRootID: "A", Version: "abc"}, {VcsRootID: "A", Version: "def"}}}, wantErr: "duplicate"},
+		{name: "missing version and branch", opts: RunBuildOptions{Revisions: []RevisionSpec{{VcsRootID: "A"}}}, wantErr: "revision or branch required"},
+		{name: "mixed legacy and keyed", opts: RunBuildOptions{Revision: "abc", Revisions: []RevisionSpec{{VcsRootID: "A", Version: "def"}}}, wantErr: "cannot mix"},
+		{name: "unfetched branch", opts: RunBuildOptions{Revisions: []RevisionSpec{{VcsRootID: "A", Branch: "absent"}}}, heads: true, wantErr: "no fetched revision"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var captured TriggerBuildRequest
+			posts, headRequests := 0, 0
+			client := setupTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/app/rest/buildTypes/id:Job/vcs-root-entries":
+					json.NewEncoder(w).Encode(VcsRootEntries{Count: 2, VcsRootEntry: []VcsRootEntry{{VcsRoot: &VcsRoot{ID: "A"}}, {VcsRoot: &VcsRoot{ID: "B"}}}})
+				case "/app/rest/buildTypes/id:Job/vcs-root-instances":
+					headRequests++
+					assert.Equal(t, "vcs-root-instance(vcs-root-id,repositoryState(branch(name,version)))", r.URL.Query().Get("fields"))
+					w.Write([]byte(`{"vcs-root-instance":[{"vcs-root-id":"A","repositoryState":{"branch":[{"name":"refs/heads/main","version":"aaa"}]}},{"vcs-root-id":"B","repositoryState":{"branch":[{"name":"refs/tags/v1","version":"bbb"},{"name":"refs/pull/12/merge","version":"pr"}]}}]}`))
+				case "/app/rest/buildQueue":
+					require.Equal(t, "POST", r.Method)
+					posts++
+					require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+					w.Write([]byte(`{"id":123}`))
+				default:
+					t.Errorf("unexpected request: %s", r.URL)
+					http.NotFound(w, r)
+				}
+			})
+			original, err := json.Marshal(tt.opts)
+			require.NoError(t, err)
+			_, err = client.RunBuild("Job", tt.opts)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				assert.Zero(t, posts)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, captured.Revisions)
+				assert.Equal(t, tt.want, captured.Revisions.Revision)
+				assert.Equal(t, 1, posts)
+			}
+			expectedHeads := 0
+			if tt.heads {
+				expectedHeads = 1
+			}
+			assert.Equal(t, expectedHeads, headRequests)
+			after, err := json.Marshal(tt.opts)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(original), string(after), "resolution must not mutate caller options")
+		})
+	}
+}

--- a/docs/topics/teamcity-cli-managing-runs.md
+++ b/docs/topics/teamcity-cli-managing-runs.md
@@ -351,6 +351,24 @@ teamcity run start MyProject_Build --branch main --revision abc123def
 teamcity run start MyProject_Build --branch @this --revision @head
 ```
 
+For jobs with multiple VCS roots, repeat `--revision ROOT=SHA[@BRANCH]` to pin
+individual roots. Unspecified roots use TeamCity's normal revision selection.
+`ROOT=@BRANCH` uses the latest revision TeamCity has already fetched for that root;
+it does not fetch new commits. Use full refs for tags or pull requests.
+
+```Shell
+teamcity run start MyProject_Build --branch feature/game \
+  --revision GameRepo=abc123@feature/game --revision AssetsRepo=@main
+teamcity run start MyProject_Build --revision AssetsRepo=@refs/tags/v1.0
+```
+
+Root IDs are the VCS root IDs shown by `teamcity project vcs list`, not numeric
+VCS root instance IDs. A root can appear only once, and bare and per-root forms
+cannot be mixed. Bare `SHA`/`@head` still applies to every root and resolves locally;
+per-root SHAs are passed verbatim. `--branch` is the build's logical branch;
+use `@BRANCH` to specify a pinned root's own branch independently.
+`--dry-run` displays the requested pins without resolving branch heads.
+
 ### Build parameters
 
 Pass custom parameters, system properties, and environment variables:

--- a/internal/cmd/run/cmd_test.go
+++ b/internal/cmd/run/cmd_test.go
@@ -882,3 +882,21 @@ func TestRunList_invalid_limit(t *testing.T) {
 	err := cmdtest.CaptureErr(t, ts.Factory, "run", "list", "--limit", "-1")
 	assert.Equal(t, "--limit must not be negative, got -1", err.Error())
 }
+
+func TestRunStartPerRootRevisionsPayload(t *testing.T) {
+	ts := cmdtest.SetupMockClient(t)
+	ts.Handle("GET /app/rest/buildTypes/id:"+testJob+"/vcs-root-entries", func(w http.ResponseWriter, r *http.Request) {
+		cmdtest.JSON(w, api.VcsRootEntries{Count: 2, VcsRootEntry: []api.VcsRootEntry{{VcsRoot: &api.VcsRoot{ID: "A"}}, {VcsRoot: &api.VcsRoot{ID: "B"}}}})
+	})
+	var captured api.TriggerBuildRequest
+	ts.Handle("POST /app/rest/buildQueue", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+		cmdtest.JSON(w, api.Build{ID: 999, BuildTypeID: testJob})
+	})
+	cmdtest.RunCmdWithFactory(t, ts.Factory, "run", "start", testJob, "--branch", "logical", "--revision", "A=abc@feature", "--revision", "B=def")
+	require.NotNil(t, captured.Revisions)
+	require.Len(t, captured.Revisions.Revision, 2)
+	assert.Equal(t, "logical", captured.BranchName)
+	assert.Equal(t, api.Revision{Version: "abc", VcsBranchName: "refs/heads/feature", VcsRootInstance: &api.VcsRootInstanceRef{VcsRootID: "A"}}, captured.Revisions.Revision[0])
+	assert.Equal(t, api.Revision{Version: "def", VcsRootInstance: &api.VcsRootInstanceRef{VcsRootID: "B"}}, captured.Revisions.Revision[1])
+}

--- a/internal/cmd/run/revision.go
+++ b/internal/cmd/run/revision.go
@@ -1,0 +1,34 @@
+package run
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/JetBrains/teamcity-cli/api"
+)
+
+// parseRevisionFlags keeps bare revisions local and per-root revisions independent of the local checkout.
+func parseRevisionFlags(values []string) (string, []api.RevisionSpec, error) {
+	specs := []api.RevisionSpec{}
+	seen := map[string]bool{}
+	for _, raw := range values {
+		root, value, keyed := strings.Cut(raw, "=")
+		if !keyed {
+			if len(values) != 1 {
+				return "", nil, api.Validation("cannot mix a bare --revision with other revisions", "Use a single SHA or repeat ROOT=SHA[@BRANCH]")
+			}
+			revision, err := resolveRevisionFlag(raw)
+			return revision, specs, err
+		}
+		version, branch, hasBranch := strings.Cut(value, "@")
+		if root == "" || value == "" || (hasBranch && branch == "") {
+			return "", nil, api.Validation(fmt.Sprintf("invalid --revision value %q", raw), "Use ROOT=SHA, ROOT=SHA@BRANCH, or ROOT=@BRANCH")
+		}
+		if seen[root] {
+			return "", nil, api.Validation("duplicate --revision for VCS root "+root, "Pass each VCS root at most once")
+		}
+		seen[root] = true
+		specs = append(specs, api.RevisionSpec{VcsRootID: root, Version: version, Branch: branch})
+	}
+	return "", specs, nil
+}

--- a/internal/cmd/run/revision_test.go
+++ b/internal/cmd/run/revision_test.go
@@ -1,0 +1,64 @@
+package run
+
+import (
+	"testing"
+
+	"github.com/JetBrains/teamcity-cli/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRevisionFlags(t *testing.T) {
+	old := isGitRepoFn
+	isGitRepoFn = func() bool { return false }
+	t.Cleanup(func() { isGitRepoFn = old })
+	for _, tt := range []struct {
+		name   string
+		values []string
+		bare   string
+		specs  []api.RevisionSpec
+		err    string
+	}{
+		{name: "empty", specs: []api.RevisionSpec{}},
+		{name: "bare", values: []string{"abc123"}, bare: "abc123", specs: []api.RevisionSpec{}},
+		{name: "pins", values: []string{"A=abc@feature/x", "B=@release@2026"}, specs: []api.RevisionSpec{{VcsRootID: "A", Version: "abc", Branch: "feature/x"}, {VcsRootID: "B", Branch: "release@2026"}}},
+		{name: "head requires checkout", values: []string{"@head"}, err: "requires a git repository"},
+		{name: "bare first", values: []string{"abc", "A=def"}, err: "cannot mix"},
+		{name: "bare last", values: []string{"A=abc", "def"}, err: "cannot mix"},
+		{name: "two bare", values: []string{"abc", "def"}, err: "cannot mix"},
+		{name: "duplicate", values: []string{"A=abc", "A=def"}, err: "duplicate"},
+		{name: "missing root", values: []string{"=abc"}, err: "invalid"},
+		{name: "missing value", values: []string{"A="}, err: "invalid"},
+		{name: "empty branch", values: []string{"A=abc@"}, err: "invalid"},
+		{name: "empty branch only", values: []string{"A=@"}, err: "invalid"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			bare, specs, err := parseRevisionFlags(tt.values)
+			if tt.err != "" {
+				require.ErrorContains(t, err, tt.err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.bare, bare)
+			assert.Equal(t, tt.specs, specs)
+		})
+	}
+}
+
+func TestRevisionFlagsLocalGitResolution(t *testing.T) {
+	oldRepo, oldHead, oldResolve := isGitRepoFn, headRevisionFn, resolveRevisionFn
+	t.Cleanup(func() { isGitRepoFn, headRevisionFn, resolveRevisionFn = oldRepo, oldHead, oldResolve })
+	isGitRepoFn = func() bool { return true }
+	headRevisionFn = func() (string, error) { return "local-head", nil }
+	resolveRevisionFn = func(rev string) (string, error) { return "expanded-" + rev, nil }
+
+	bare, _, err := parseRevisionFlags([]string{"@head"})
+	require.NoError(t, err)
+	assert.Equal(t, "local-head", bare)
+	bare, _, err = parseRevisionFlags([]string{"abc"})
+	require.NoError(t, err)
+	assert.Equal(t, "expanded-abc", bare)
+	_, specs, err := parseRevisionFlags([]string{"OtherRepo=abc"})
+	require.NoError(t, err)
+	assert.Equal(t, "abc", specs[0].Version)
+}

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -158,6 +158,7 @@ func settingsLabel(settings string) string {
 type runStartOptions struct {
 	branch            string
 	revision          string
+	revisions         []string
 	params            map[string]string
 	systemProps       map[string]string
 	envVars           map[string]string
@@ -215,7 +216,7 @@ func newRunStartCmd(f *cmdutil.Factory) *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&opts.branch, "branch", "b", "", "Branch to build (or '@this' for current git branch)")
-	cmd.Flags().StringVar(&opts.revision, "revision", "", "Pin to a specific Git commit SHA (or '@head' for current HEAD)")
+	cmd.Flags().StringArrayVar(&opts.revisions, "revision", nil, "Pin SHA or @head for all roots; ROOT=SHA[@BRANCH] or ROOT=@BRANCH for one root (repeatable)")
 	cmd.Flags().StringToStringVarP(&opts.params, "param", "P", nil, "Parameters (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.systemProps, "system", "S", nil, "System properties (key=value)")
 	cmd.Flags().StringToStringVarP(&opts.envVars, "env", "E", nil, "Environment variables (key=value)")
@@ -257,7 +258,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		return err
 	}
 	opts.branch = branch
-	revision, err := resolveRevisionFlag(opts.revision)
+	revision, rootRevisions, err := parseRevisionFlags(opts.revisions)
 	if err != nil {
 		return err
 	}
@@ -281,7 +282,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 			"is_personal":       opts.personal,
 			"has_local_changes": opts.localChanges != "",
 			"has_branch":        opts.branch != "",
-			"has_revision":      opts.revision != "",
+			"has_revision":      opts.revision != "" || len(rootRevisions) > 0,
 			"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
 			"is_watched":        false,
 			"is_dry_run":        true,
@@ -289,29 +290,31 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 
 		if opts.json {
 			return p.PrintJSON(struct {
-				DryRun            bool              `json:"dry_run"`
-				Job               string            `json:"job"`
-				Branch            string            `json:"branch,omitempty"`
-				Revision          string            `json:"revision,omitempty"`
-				Personal          bool              `json:"personal"`
-				LocalChanges      string            `json:"local_changes,omitempty"`
-				Params            map[string]string `json:"params,omitempty"`
-				SystemProps       map[string]string `json:"system_properties,omitempty"`
-				EnvVars           map[string]string `json:"environment_variables,omitempty"`
-				Comment           string            `json:"comment,omitempty"`
-				Tags              []string          `json:"tags,omitempty"`
-				CleanSources      bool              `json:"clean_sources,omitempty"`
-				RebuildDeps       bool              `json:"rebuild_deps,omitempty"`
-				RebuildFailedDeps bool              `json:"rebuild_failed_deps,omitempty"`
-				QueueAtTop        bool              `json:"queue_at_top,omitempty"`
-				Agent             int               `json:"agent_id,omitempty"`
-				ReuseDeps         []int             `json:"reuse_deps,omitempty"`
-				Settings          string            `json:"settings,omitempty"`
+				DryRun            bool               `json:"dry_run"`
+				Job               string             `json:"job"`
+				Branch            string             `json:"branch,omitempty"`
+				Revision          string             `json:"revision,omitempty"`
+				Revisions         []api.RevisionSpec `json:"revisions,omitempty"`
+				Personal          bool               `json:"personal"`
+				LocalChanges      string             `json:"local_changes,omitempty"`
+				Params            map[string]string  `json:"params,omitempty"`
+				SystemProps       map[string]string  `json:"system_properties,omitempty"`
+				EnvVars           map[string]string  `json:"environment_variables,omitempty"`
+				Comment           string             `json:"comment,omitempty"`
+				Tags              []string           `json:"tags,omitempty"`
+				CleanSources      bool               `json:"clean_sources,omitzero"`
+				RebuildDeps       bool               `json:"rebuild_deps,omitzero"`
+				RebuildFailedDeps bool               `json:"rebuild_failed_deps,omitzero"`
+				QueueAtTop        bool               `json:"queue_at_top,omitzero"`
+				Agent             int                `json:"agent_id,omitzero"`
+				ReuseDeps         []int              `json:"reuse_deps,omitempty"`
+				Settings          string             `json:"settings,omitempty"`
 			}{
 				DryRun:            true,
 				Job:               jobID,
 				Branch:            opts.branch,
 				Revision:          opts.revision,
+				Revisions:         rootRevisions,
 				Personal:          opts.personal || opts.localChanges != "",
 				LocalChanges:      opts.localChanges,
 				Params:            opts.params,
@@ -335,6 +338,11 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		}
 		if opts.revision != "" {
 			_, _ = fmt.Fprintf(p.Out, "  Revision: %s\n", opts.revision)
+		}
+		for _, raw := range opts.revisions {
+			if strings.Contains(raw, "=") {
+				_, _ = fmt.Fprintf(p.Out, "  Revision: %s\n", raw)
+			}
 		}
 		if len(opts.params) > 0 {
 			_, _ = fmt.Fprintln(p.Out, "  Parameters:")
@@ -467,6 +475,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		Tags:                      opts.tags,
 		PersonalChangeID:          personalChangeID,
 		Revision:                  opts.revision,
+		Revisions:                 rootRevisions,
 		SnapshotDependencies:      opts.reuseDeps,
 		FreezeSettings:            freezeSettings,
 	})
@@ -478,7 +487,7 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 		"is_personal":       opts.personal,
 		"has_local_changes": opts.localChanges != "",
 		"has_branch":        opts.branch != "",
-		"has_revision":      opts.revision != "",
+		"has_revision":      opts.revision != "" || len(rootRevisions) > 0,
 		"param_count":       len(opts.params) + len(opts.systemProps) + len(opts.envVars),
 		"is_watched":        opts.watch,
 		"is_dry_run":        false,
@@ -505,6 +514,12 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 	if opts.branch != "" {
 		p.Info("  Branch: %s", opts.branch)
 	}
+	for _, raw := range opts.revisions {
+		if strings.Contains(raw, "=") {
+			p.Info("  Revision: %s", raw)
+		}
+	}
+
 	if opts.comment != "" {
 		p.Info("  Comment: %s", opts.comment)
 	}

--- a/skills/teamcity-cli/SKILL.md
+++ b/skills/teamcity-cli/SKILL.md
@@ -23,6 +23,7 @@ teamcity run log <id> --failed --raw    # Full failure diagnostics
 - **`--local-changes` excludes Kotlin DSL** — push `.teamcity/` changes before running.
 - **Select a server per command with `TEAMCITY_URL`** — `TEAMCITY_URL=https://cli.teamcity.com teamcity run list` uses stored credentials for that server; set `TEAMCITY_TOKEN` to override them.
 - **Read-only mode blocks remote shells** — `TEAMCITY_RO=1` or per-server `ro: true` rejects `agent exec` and `agent term` before connecting.
+- **Multi-root runs**: repeat `--revision ROOT=SHA[@BRANCH]`; `ROOT=@BRANCH` uses a fetched branch head. Bare SHA pins every root.
 - **Logs**: use `--raw` and dump to a temp file. **Builds**: use `--watch` when starting them.
 - **VCS triggers aren't always wired up** — after pushing a fix you may need to start builds manually.
 - **`pipeline push` does not validate** — always `teamcity pipeline validate` first.

--- a/skills/teamcity-cli/references/commands.md
+++ b/skills/teamcity-cli/references/commands.md
@@ -86,7 +86,8 @@ Shows all branches and all build states (including canceled, personal, composite
 ### Flags for `teamcity run start`
 
 - `-b, --branch <name>` - Branch to build
-- `--revision <sha>` - Pin build to a specific Git commit SHA
+- `--revision <sha>` - Pin every VCS root to one Git commit SHA (or local `@head`)
+- `--revision ROOT=SHA[@BRANCH]` - Pin individual roots (repeatable); `ROOT=@BRANCH` uses the latest fetched branch head; cannot mix with a bare SHA
 - `-P, --param <k=v>` - Build parameter (repeatable)
 - `-S, --system <k=v>` - System property (repeatable)
 - `-E, --env <k=v>` - Environment variable (repeatable)

--- a/skills/teamcity-cli/references/workflows.md
+++ b/skills/teamcity-cli/references/workflows.md
@@ -113,6 +113,17 @@ teamcity run start <job-id> --watch
 teamcity run start <job-id> --branch feature/my-branch --watch
 ```
 
+For jobs with unrelated VCS roots, pin each root independently (use VCS root IDs):
+
+```bash
+teamcity run start <job-id> --branch feature/game \
+  --revision GameRepo=<sha>@feature/game --revision AssetsRepo=@main
+```
+
+Unspecified roots keep normal TeamCity selection. Branch-only pins use the latest
+head TeamCity has fetched; explicit per-root SHAs are not resolved in local Git.
+
+
 **Start with parameters:**
 ```bash
 teamcity run start <job-id> -P "param1=value1" -P "param2=value2"


### PR DESCRIPTION
## Summary

Allow multi-repository jobs to pin each VCS root independently with repeatable `--revision ROOT=SHA[@BRANCH]` or `ROOT=@BRANCH`. Bare `SHA`/`@head` retains its existing all-roots behavior. Alternative implementation of #396, addressing [TW-100857](https://youtrack.jetbrains.com/issue/TW-100857).

## Changes

- Parse and validate per-root pins; resolve all requested branch heads in one REST read.
- Preserve `RunBuildOptions.Revision` and legacy dry-run JSON; add per-root output and documentation.
- Cover payloads, local Git compatibility, validation, and dry-run output with tests.

## Design Decisions

Use VCS root IDs and the job's fetched `repositoryState`; branch-only pins do not fetch Git. Explicit per-root pins do not inherit the build's logical branch, which may belong to another repository. Keep REST response structs local and reuse the existing revision payload. Production changes are +189/-53 lines, versus +281/-68 in #396.

## Example

```bash
teamcity run start MyProject_Build --branch feature/game \
  --revision GameRepo=abc123@feature/game --revision AssetsRepo=@main --dry-run

[dry-run] Would trigger run for MyProject_Build
  Branch: feature/game
  Revision: GameRepo=abc123@feature/game
  Revision: AssetsRepo=@main
```

## Test Plan

- [x] Unit tests pass (`just unit`); also `go test ./...`
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`just acceptance`)
- [x] If adding a new command/flag: added `.txtar` test in `acceptance/testdata/` — expanded `--revision` coverage
- [ ] If adding a data-producing command: includes `--json` support — N/A — existing command; JSON support preserved
- [x] If modifying `--json` output: no field removals/renames (additive only)
- [x] If changing docs-visible behavior: updated `docs/`, `skills/`, and `README.md`
- [ ] External contributors: links a `status:finalized` issue (or trivial/docs/deps change) — N/A — JetBrains member

Live verification on `cli.teamcity.com`: runs 14579 and 14580 completed successfully with two unrelated repositories, covering mixed SHA/branch pins and a full tag ref with the other root unspecified. Checked both revision metadata and the SHAs printed by the build step. Run 14590 confirmed an explicit SHA without a root branch in queued metadata, then was canceled while waiting for an agent. Invalid roots and unfetched branches returned validation errors. The temporary sandbox job was removed afterward.
