### PR TITLE
refactor(go): apply remaining modern Go idioms

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1194,7 +1194,7 @@ func TestRebootAgentCancelledContext(T *testing.T) {
 	skipIfGuest(T)
 	T.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(T.Context())
 	cancel() // Cancel immediately
 
 	// Bogus ID: the request must never be sent, and must never reboot the real agent.

--- a/api/builds_artifacts.go
+++ b/api/builds_artifacts.go
@@ -20,7 +20,7 @@ func encodeArtifactPath(p string) string {
 // Artifact represents a build artifact
 type Artifact struct {
 	Name     string     `json:"name"`
-	Size     int64      `json:"size,omitempty"`
+	Size     int64      `json:"size,omitzero"`
 	ModTime  string     `json:"modificationTime,omitempty"`
 	Href     string     `json:"href,omitempty"`
 	Children *Artifacts `json:"children,omitempty"`

--- a/api/headers.go
+++ b/api/headers.go
@@ -15,10 +15,10 @@ func EnvHeaders() map[string]string {
 	var headers map[string]string
 	for _, e := range os.Environ() {
 		key, value, ok := strings.Cut(e, "=")
-		if !ok || !strings.HasPrefix(key, EnvHeaderPrefix) {
+		suffix, hasPrefix := strings.CutPrefix(key, EnvHeaderPrefix)
+		if !ok || !hasPrefix {
 			continue
 		}
-		suffix := key[len(EnvHeaderPrefix):]
 		if suffix == "" || value == "" || strings.ContainsAny(value, "\r\n\x00") {
 			continue
 		}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -119,7 +119,7 @@ type BuildStep struct {
 	ID         string       `json:"id,omitempty"`
 	Name       string       `json:"name"`
 	Type       string       `json:"type"`
-	Disabled   bool         `json:"disabled,omitempty"`
+	Disabled   bool         `json:"disabled,omitzero"`
 	Properties PropertyList `json:"properties"`
 }
 

--- a/api/messages.go
+++ b/api/messages.go
@@ -15,11 +15,11 @@ type BuildMessage struct {
 	Status           int    `json:"status"`
 	Timestamp        string `json:"timestamp,omitempty"`
 	ServerTimestamp  string `json:"serverTimestamp,omitempty"`
-	FlowID           int    `json:"flowId,omitempty"`
-	ParentID         int    `json:"parentId,omitempty"`
+	FlowID           int    `json:"flowId,omitzero"`
+	ParentID         int    `json:"parentId,omitzero"`
 	BlockType        string `json:"blockType,omitempty"`
-	ContainsMessages bool   `json:"containsMessages,omitempty"`
-	Verbose          bool   `json:"verbose,omitempty"`
+	ContainsMessages bool   `json:"containsMessages,omitzero"`
+	Verbose          bool   `json:"verbose,omitzero"`
 }
 
 // BuildMessagesResponse is the response from the /app/messages endpoint.

--- a/api/types.go
+++ b/api/types.go
@@ -8,7 +8,7 @@ import (
 
 // User represents a TeamCity user
 type User struct {
-	ID       int    `json:"id,omitempty"`
+	ID       int    `json:"id,omitzero"`
 	Username string `json:"username,omitempty"`
 	Name     string `json:"name,omitempty"`
 	Email    string `json:"email,omitempty"`
@@ -40,7 +40,7 @@ type BuildType struct {
 	ProjectID      string          `json:"projectId,omitempty"`
 	Href           string          `json:"href,omitempty"`
 	WebURL         string          `json:"webUrl,omitempty"`
-	Paused         bool            `json:"paused,omitempty"`
+	Paused         bool            `json:"paused,omitzero"`
 	Project        *Project        `json:"project,omitempty"`
 	VcsRootEntries *VcsRootEntries `json:"vcs-root-entries,omitempty"`
 }
@@ -59,9 +59,9 @@ type Build struct {
 	Number             string      `json:"number,omitempty"`
 	Status             string      `json:"status,omitempty"`
 	State              string      `json:"state,omitempty"`
-	Personal           bool        `json:"personal,omitempty"`
+	Personal           bool        `json:"personal,omitzero"`
 	BranchName         string      `json:"branchName,omitempty"`
-	DefaultBranch      bool        `json:"defaultBranch,omitempty"`
+	DefaultBranch      bool        `json:"defaultBranch,omitzero"`
 	Href               string      `json:"href,omitempty"`
 	WebURL             string      `json:"webUrl,omitempty"`
 	StatusText         string      `json:"statusText,omitempty"`
@@ -71,12 +71,12 @@ type Build struct {
 	BuildType          *BuildType  `json:"buildType,omitempty"`
 	Triggered          *Triggered  `json:"triggered,omitempty"`
 	Agent              *Agent      `json:"agent,omitempty"`
-	PercentageComplete int         `json:"percentageComplete,omitempty"`
-	Pinned             bool        `json:"pinned,omitempty"`
+	PercentageComplete int         `json:"percentageComplete,omitzero"`
+	Pinned             bool        `json:"pinned,omitzero"`
 	Tags               *TagList    `json:"tags,omitempty"`
 	LastChanges        *ChangeList `json:"lastChanges,omitempty"`
 	WaitReason         string      `json:"waitReason,omitempty"`
-	UsedByOtherBuilds  bool        `json:"usedByOtherBuilds,omitempty"`
+	UsedByOtherBuilds  bool        `json:"usedByOtherBuilds,omitzero"`
 }
 
 // BuildList represents a list of builds
@@ -96,12 +96,12 @@ type Triggered struct {
 
 // Agent represents a build agent
 type Agent struct {
-	ID         int    `json:"id,omitempty"`
+	ID         int    `json:"id,omitzero"`
 	Name       string `json:"name,omitempty"`
-	TypeID     int    `json:"typeId,omitempty"`
-	Connected  bool   `json:"connected,omitempty"`
-	Enabled    bool   `json:"enabled,omitempty"`
-	Authorized bool   `json:"authorized,omitempty"`
+	TypeID     int    `json:"typeId,omitzero"`
+	Connected  bool   `json:"connected,omitzero"`
+	Enabled    bool   `json:"enabled,omitzero"`
+	Authorized bool   `json:"authorized,omitzero"`
 	Href       string `json:"href,omitempty"`
 	WebURL     string `json:"webUrl,omitempty"`
 	Pool       *Pool  `json:"pool,omitempty"`
@@ -118,10 +118,10 @@ type AgentList struct {
 
 // Pool represents an agent pool
 type Pool struct {
-	ID        int          `json:"id,omitempty"`
+	ID        int          `json:"id,omitzero"`
 	Name      string       `json:"name,omitempty"`
 	Href      string       `json:"href,omitempty"`
-	MaxAgents int          `json:"maxAgents,omitempty"`
+	MaxAgents int          `json:"maxAgents,omitzero"`
 	Projects  *ProjectList `json:"projects,omitempty"`
 	Agents    *AgentList   `json:"agents,omitempty"`
 }
@@ -202,7 +202,7 @@ type TriggerBuildRequest struct {
 	BranchName           string             `json:"branchName,omitempty"`
 	Properties           *PropertyList      `json:"properties,omitempty"`
 	Comment              *BuildComment      `json:"comment,omitempty"`
-	Personal             bool               `json:"personal,omitempty"`
+	Personal             bool               `json:"personal,omitzero"`
 	TriggeringOptions    *TriggeringOptions `json:"triggeringOptions,omitempty"`
 	Agent                *AgentRef          `json:"agent,omitempty"`
 	Tags                 *TagList           `json:"tags,omitempty"`
@@ -247,7 +247,7 @@ type LastChanges struct {
 // PersonalChange represents a personal change (uploaded diff) reference
 type PersonalChange struct {
 	ID       string `json:"id"`
-	Personal bool   `json:"personal,omitempty"`
+	Personal bool   `json:"personal,omitzero"`
 }
 
 // BuildComment represents a comment on a build
@@ -257,17 +257,17 @@ type BuildComment struct {
 
 // TriggeringOptions represents options for triggering a build
 type TriggeringOptions struct {
-	CleanSources              bool `json:"cleanSources,omitempty"`
-	RebuildAllDependencies    bool `json:"rebuildAllDependencies,omitempty"`
-	QueueAtTop                bool `json:"queueAtTop,omitempty"`
-	RebuildFailedOrIncomplete bool `json:"rebuildFailedOrIncompleteDependencies,omitempty"`
+	CleanSources              bool `json:"cleanSources,omitzero"`
+	RebuildAllDependencies    bool `json:"rebuildAllDependencies,omitzero"`
+	QueueAtTop                bool `json:"queueAtTop,omitzero"`
+	RebuildFailedOrIncomplete bool `json:"rebuildFailedOrIncompleteDependencies,omitzero"`
 	// FreezeSettings overrides the versioned-settings source: true loads settings from VCS, false uses current server settings, nil keeps the build configuration default.
 	FreezeSettings *bool `json:"freezeSettings,omitempty"`
 }
 
 // AgentRef is a reference to an agent
 type AgentRef struct {
-	ID   int    `json:"id,omitempty"`
+	ID   int    `json:"id,omitzero"`
 	Name string `json:"name,omitempty"`
 }
 
@@ -315,7 +315,7 @@ type Server struct {
 }
 
 type Change struct {
-	ID       int    `json:"id,omitempty"`
+	ID       int    `json:"id,omitzero"`
 	Version  string `json:"version,omitempty"` // commit SHA
 	Username string `json:"username,omitempty"`
 	Date     string `json:"date,omitempty"`
@@ -342,11 +342,11 @@ type TestOccurrence struct {
 	ID         string `json:"id"`
 	Name       string `json:"name"`
 	Status     string `json:"status"` // SUCCESS, FAILURE, IGNORED
-	Duration   int    `json:"duration,omitempty"`
+	Duration   int    `json:"duration,omitzero"`
 	Details    string `json:"details,omitempty"`
-	NewFailure bool   `json:"newFailure,omitempty"`
-	Ignored    bool   `json:"ignored,omitempty"`
-	Muted      bool   `json:"muted,omitempty"`
+	NewFailure bool   `json:"newFailure,omitzero"`
+	Ignored    bool   `json:"ignored,omitzero"`
+	Muted      bool   `json:"muted,omitzero"`
 	Href       string `json:"href,omitempty"`
 
 	FirstFailed *TestOccurrence `json:"firstFailed,omitempty"`
@@ -355,10 +355,10 @@ type TestOccurrence struct {
 
 type TestOccurrences struct {
 	Count          int              `json:"count"`
-	Passed         int              `json:"passed,omitempty"`
-	Failed         int              `json:"failed,omitempty"`
-	Ignored        int              `json:"ignored,omitempty"`
-	Muted          int              `json:"muted,omitempty"`
+	Passed         int              `json:"passed,omitzero"`
+	Failed         int              `json:"failed,omitzero"`
+	Ignored        int              `json:"ignored,omitzero"`
+	Muted          int              `json:"muted,omitzero"`
 	NextHref       string           `json:"nextHref,omitempty"`
 	TestOccurrence []TestOccurrence `json:"testOccurrence"`
 }
@@ -384,10 +384,10 @@ func ParseTeamCityTime(s string) (time.Time, error) {
 type VersionedSettingsStatus struct {
 	MissingContextParameters []string                 `json:"missingContextParameters,omitempty"`
 	VersionedSettingsError   []VersionedSettingsError `json:"versionedSettingsError,omitempty"`
-	Type                     string                   `json:"type,omitempty"`        // info, warning, error
-	Message                  string                   `json:"message,omitempty"`     // Human-readable status message
-	Timestamp                string                   `json:"timestamp,omitempty"`   // When the status was recorded
-	DslOutdated              bool                     `json:"dslOutdated,omitempty"` // DSL scripts need regeneration
+	Type                     string                   `json:"type,omitempty"`       // info, warning, error
+	Message                  string                   `json:"message,omitempty"`    // Human-readable status message
+	Timestamp                string                   `json:"timestamp,omitempty"`  // When the status was recorded
+	DslOutdated              bool                     `json:"dslOutdated,omitzero"` // DSL scripts need regeneration
 }
 
 // VersionedSettingsError describes a failure processing versioned settings.
@@ -405,8 +405,8 @@ type VersionedSettingsConfig struct {
 	BuildSettingsMode   string `json:"buildSettingsMode,omitempty"`   // useFromVCS, useCurrentByDefault
 	VcsRootID           string `json:"vcsRootId,omitempty"`
 	SettingsPath        string `json:"settingsPath,omitempty"`
-	AllowUIEditing      bool   `json:"allowUIEditing,omitempty"`
-	ShowSettingsChanges bool   `json:"showSettingsChanges,omitempty"`
+	AllowUIEditing      bool   `json:"allowUIEditing,omitzero"`
+	ShowSettingsChanges bool   `json:"showSettingsChanges,omitzero"`
 }
 
 // SnapshotDependency represents a snapshot dependency between build configurations
@@ -629,7 +629,7 @@ type PipelineRef struct {
 
 // PipelineRunJobs represents jobs within a pipeline run
 type PipelineRunJobs struct {
-	Count int              `json:"count,omitempty"`
+	Count int              `json:"count,omitzero"`
 	Job   []PipelineRunJob `json:"job,omitempty"`
 }
 
@@ -642,7 +642,7 @@ type PipelineRunJob struct {
 
 // BuildRef is a lightweight reference to a build
 type BuildRef struct {
-	ID int `json:"id,omitempty"`
+	ID int `json:"id,omitzero"`
 }
 
 // APIError represents an error from TeamCity's REST API

--- a/internal/cmd/auth/status.go
+++ b/internal/cmd/auth/status.go
@@ -30,7 +30,7 @@ type authStatus struct {
 	TokenExpiry string      `json:"token_expiry,omitempty"`
 	Status      string      `json:"status"`
 	Error       string      `json:"error,omitempty"`
-	IsDefault   bool        `json:"is_default,omitempty"`
+	IsDefault   bool        `json:"is_default,omitzero"`
 
 	versionCheckErr string
 	keyringErr      error

--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -335,7 +335,7 @@ type ProjectTreeNode struct {
 type pipelineRef struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
-	JobCount int    `json:"jobCount,omitempty"`
+	JobCount int    `json:"jobCount,omitzero"`
 }
 
 type jobRef struct {

--- a/internal/cmd/run/start.go
+++ b/internal/cmd/run/start.go
@@ -300,11 +300,11 @@ func runRunStart(f *cmdutil.Factory, jobID string, opts *runStartOptions) error 
 				EnvVars           map[string]string `json:"environment_variables,omitempty"`
 				Comment           string            `json:"comment,omitempty"`
 				Tags              []string          `json:"tags,omitempty"`
-				CleanSources      bool              `json:"clean_sources,omitempty"`
-				RebuildDeps       bool              `json:"rebuild_deps,omitempty"`
-				RebuildFailedDeps bool              `json:"rebuild_failed_deps,omitempty"`
-				QueueAtTop        bool              `json:"queue_at_top,omitempty"`
-				Agent             int               `json:"agent_id,omitempty"`
+				CleanSources      bool              `json:"clean_sources,omitzero"`
+				RebuildDeps       bool              `json:"rebuild_deps,omitzero"`
+				RebuildFailedDeps bool              `json:"rebuild_failed_deps,omitzero"`
+				QueueAtTop        bool              `json:"queue_at_top,omitzero"`
+				Agent             int               `json:"agent_id,omitzero"`
 				ReuseDeps         []int             `json:"reuse_deps,omitempty"`
 				Settings          string            `json:"settings,omitempty"`
 			}{


### PR DESCRIPTION
## Summary

Apply the remaining applicable Modern Go Guidelines CLI recommendations for Go 1.26. Changes preserve runtime behavior and JSON output.

## Changes

- Use `omitzero` for 48 boolean/integer JSON fields that omit zero values.
- Use `strings.CutPrefix` for environment-header names.
- Derive the canceled-request test context from `T.Context()`.

## Design Decisions

Keep `omitempty` for strings, slices, maps, and pointers. Retain the suggestion-only `errors.As` lookup because its target does not satisfy `errors.AsType`'s `error` constraint. Keep changing-bound loops, lifecycle contexts, and explicitly stopped tickers where their existing semantics are required.

## Example

N/A — behavior-preserving refactor; no new commands or output changes.

## Test Plan

- [x] Unit tests pass (`go test ./...`, including API tests)
- [x] Linter passes (`just lint`)
- [x] Acceptance tests pass (`go test -tags=acceptance ./acceptance/...`)
- [ ] If adding a new command/flag: added `.txtar` test — N/A, no new commands or flags
- [ ] If adding a data-producing command: includes `--json` support — N/A, no new commands
- [x] If modifying `--json` output: no field removals/renames — scalar zero-value omission is unchanged
- [ ] If changing docs-visible behavior: updated docs, skills, and README — N/A, behavior unchanged
- [ ] External contributors: links a `status:finalized` issue — N/A, maintainer-requested audit

Read the complete official guidelines list for this module and relevant `explain` entries. Existing tests cover these refactors; no duplicate test scaffolding added. `just build`, version output, and command-help smoke checks pass.
